### PR TITLE
Create pegboard_j_hook.py example

### DIFF
--- a/examples/pegboard_j_hook.py
+++ b/examples/pegboard_j_hook.py
@@ -76,4 +76,4 @@ with BuildPart() as mainp:
     Split(bisect_by=Plane(origin=(0,0,-splitz)))
     Split(bisect_by=Plane(origin=(0,0,splitz)),keep=Keep.BOTTOM)
 
-show_object(mainp.part.wrapped,options=rand_color(alpha=.8))
+show_object(mainp.part.wrapped)

--- a/examples/pegboard_j_hook.py
+++ b/examples/pegboard_j_hook.py
@@ -1,0 +1,79 @@
+"""
+name: pegboard_j_hook.py
+by:   jdegenstein
+date: November 17th 2022
+desc:
+    This example creates a model of j-shaped pegboard hook commonly used 
+    for organization of tools in garages.
+    
+license:
+    Copyright 2022 jdegenstein
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+
+from build123d import *
+
+pegd = 6.35+0.1 #mm ~0.25inch
+c2c  = 25.4 #mm 1.0inch
+arcd = 7.2
+both = 10
+topx = 6
+midx = 8
+maind = 0.82*pegd
+midd  = 1.0*pegd
+hookd = 23
+hookx = 10
+splitz  = maind/2-.1
+topangs = 70
+
+with BuildPart() as mainp:
+    with BuildLine(mode=Mode.PRIVATE) as sprof:
+        l1 = Line((-both,0),(c2c-arcd/2-0.5,0))
+        l2 = JernArc(start=l1@1,
+                    tangent=l1%1,
+                    radius=arcd/2,
+                    arc_size=topangs
+                    )
+        l3 = TangentLine(start=l2@1,
+                         tangent=l2%1,
+                         length=topx
+                         )
+        l4 = JernArc(start=l3@1,
+                     tangent=l3%1,
+                     radius=arcd/2,
+                     arc_size=-topangs
+                     )
+        l5 = TangentLine(start=l4@1,
+                         tangent=l4%1,
+                         length=topx
+                         )
+        l6 = JernArc(start=l1@0,
+                     tangent=(l1%0).reverse(),
+                     radius=hookd/2,
+                     arc_size=170
+                     )
+        l7 = TangentLine(start=l6@1,
+                         tangent=l6%1,
+                         length=hookx
+                         )
+    with BuildSketch(Plane.YZ):
+        Circle(radius=maind/2)
+    Sweep(path=sprof.wires()[0])
+    with BuildLine(mode=Mode.PRIVATE) as stub:
+        l7 = Line((0,0),(0,midx+maind/2))
+    with BuildSketch(Plane.XZ):
+        Circle(radius=midd/2)
+    Sweep(path=stub.wires()[0])
+    #splits help keep the object 3d printable by reducing overhang
+    Split(bisect_by=Plane(origin=(0,0,-splitz)))
+    Split(bisect_by=Plane(origin=(0,0,splitz)),keep=Keep.BOTTOM)
+
+show_object(mainp.part.wrapped,options=rand_color(alpha=.8))


### PR DESCRIPTION
Initial proposal to add a new example to build123d. The design is for standard 1-inch center-to-center spaced pegboard with 0.25 inch holes. The lower peg "stub" is designed to be a tight fit (~0.25 inch) to keep the hook in place when removing tools.

![image](https://user-images.githubusercontent.com/16868537/202574497-495382eb-80e8-4c9f-9910-8d02829e7daa.png)

