### PR TITLE
Location changes

### DIFF
--- a/src/build123d/direct_api.py
+++ b/src/build123d/direct_api.py
@@ -148,6 +148,7 @@ from OCP.gp import (
     gp_Dir2d,
     gp_Elips,
     gp_EulerSequence,
+    gp_Quaternion,
     gp_GTrsf,
     gp_Lin,
     gp_Pln,
@@ -1123,7 +1124,7 @@ class Location:
         rot = transformation.GetRotation()
 
         rv_trans = (trans.X(), trans.Y(), trans.Z())
-        rv_rot = rot.GetEulerAngles(gp_EulerSequence.gp_Extrinsic_XYZ)
+        rv_rot = rot.GetEulerAngles(gp_EulerSequence.gp_Intrinsic_XYZ)
 
         return rv_trans, rv_rot
 
@@ -1160,14 +1161,16 @@ class Rotation(Location):
         self.about_y = about_y
         self.about_z = about_z
 
-        # Compute rotation matrix.
-        rot_x = gp_Trsf()
-        rot_x.SetRotation(gp_Ax1(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0)), radians(about_x))
-        rot_y = gp_Trsf()
-        rot_y.SetRotation(gp_Ax1(gp_Pnt(0, 0, 0), gp_Dir(0, 1, 0)), radians(about_y))
-        rot_z = gp_Trsf()
-        rot_z.SetRotation(gp_Ax1(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), radians(about_z))
-        super().__init__(rot_x * rot_y * rot_z)
+        q = gp_Quaternion()
+        q.SetEulerAngles(
+            gp_EulerSequence.gp_Intrinsic_XYZ,
+            radians(about_x),
+            radians(about_y),
+            radians(about_z),
+        )
+        t = gp_Trsf()
+        t.SetRotationPart(q)
+        super().__init__(t)
 
 
 #:TypeVar("RotationLike"): Three tuple of angles about x, y, z or Rotation

--- a/src/build123d/direct_api.py
+++ b/src/build123d/direct_api.py
@@ -1069,11 +1069,9 @@ class Location:
     def __init__(
         self,
         translation: VectorLike,
-        axis: VectorLike = (0, 0, 1),
         angle: float = 0,
     ) -> None:  # pragma: no cover
-        """Location with translation and rotation around axis by angle
-        with respect to the original location."""
+        """Location (usually 2-dim) with an angle to rotate about z-axis"""
         ...
 
     @overload

--- a/src/build123d/direct_api.py
+++ b/src/build123d/direct_api.py
@@ -1097,6 +1097,17 @@ class Location:
             translation = args[0]
 
             if isinstance(translation, (Vector, tuple)):
+                if kwargs.get("rotation") is not None:
+                    rotation = [radians(a) for a in kwargs["rotation"]]
+                    q = gp_Quaternion()
+                    q.SetEulerAngles(gp_EulerSequence.gp_Intrinsic_XYZ, *rotation)
+                    transform.SetRotation(q)
+                elif kwargs.get("angle") is not None:
+                    angle = radians(kwargs["angle"])
+                    q = gp_Quaternion()
+                    q.SetEulerAngles(gp_EulerSequence.gp_Intrinsic_XYZ, 0, 0, angle)
+                    transform.SetRotation(q)
+                # set translation part after setting rotation (if exists)
                 transform.SetTranslationPart(Vector(translation).wrapped)
             elif isinstance(translation, Plane):
                 coordinate_system = gp_Ax3(
@@ -1116,19 +1127,6 @@ class Location:
                 transform = translation
             else:
                 raise TypeError("Unexpected parameters")
-
-            # translation part of transform is set. Now handle rotation part
-
-            if kwargs.get("rotation") is not None:
-                rotation = [radians(a) for a in kwargs["rotation"]]
-                q = gp_Quaternion()
-                q.SetEulerAngles(gp_EulerSequence.gp_Intrinsic_XYZ, *rotation)
-                transform.SetRotation(q)
-            elif kwargs.get("angle") is not None:
-                angle = radians(kwargs["angle"])
-                q = gp_Quaternion()
-                q.SetEulerAngles(gp_EulerSequence.gp_Intrinsic_XYZ, 0, 0, angle)
-                transform.SetRotation(q)
 
         elif len(args) == 2:
             translation, origin = args

--- a/src/build123d/direct_api.py
+++ b/src/build123d/direct_api.py
@@ -1177,7 +1177,7 @@ class Location:
             Location as String
         """
         position_str = ", ".join((f"{v:.2f}" for v in self.to_tuple()[0]))
-        orientation_str = ", ".join((f"{180*v/pi:.2f}" for v in self.to_tuple()[1]))
+        orientation_str = ", ".join((f"{v:.2f}" for v in self.to_tuple()[1]))
         return f"(p=({position_str}), o=({orientation_str}))"
 
     def __str__(self):
@@ -1189,7 +1189,7 @@ class Location:
             Location as String
         """
         position_str = ", ".join((f"{v:.2f}" for v in self.to_tuple()[0]))
-        orientation_str = ", ".join((f"{180*v/pi:.2f}" for v in self.to_tuple()[1]))
+        orientation_str = ", ".join((f"{v:.2f}" for v in self.to_tuple()[1]))
         return f"Location: (position=({position_str}), orientation=({orientation_str}))"
 
 

--- a/src/build123d/direct_api.py
+++ b/src/build123d/direct_api.py
@@ -1166,9 +1166,11 @@ class Location:
         rot = transformation.GetRotation()
 
         rv_trans = (trans.X(), trans.Y(), trans.Z())
-        rv_rot = rot.GetEulerAngles(gp_EulerSequence.gp_Intrinsic_XYZ)
+        rv_rot = [
+            degrees(a) for a in rot.GetEulerAngles(gp_EulerSequence.gp_Intrinsic_XYZ)
+        ]
 
-        return rv_trans, rv_rot
+        return rv_trans, tuple(rv_rot)
 
     def __repr__(self):
         """To String

--- a/tests/direct_api_tests.py
+++ b/tests/direct_api_tests.py
@@ -444,6 +444,19 @@ class TestCadObjects(unittest.TestCase):
         self.assertTupleAlmostEquals(loc1.to_tuple()[0], loc2.to_tuple()[0], 6)
         self.assertTupleAlmostEquals(loc1.to_tuple()[1], loc2.to_tuple()[1], 6)
 
+        loc1 = Location((1, 2), angle=34)
+        self.assertTupleAlmostEquals(loc1.to_tuple()[0], (1, 2, 0), 6)
+        self.assertTupleAlmostEquals(loc1.to_tuple()[1], (0, 0, 34), 6)
+
+        rot_angles = (-115.00, 35.00, -135.00)
+        loc2 = Location((1, 2, 3), rotation=rot_angles)
+        self.assertTupleAlmostEquals(loc2.to_tuple()[0], (1, 2, 3), 6)
+        self.assertTupleAlmostEquals(loc2.to_tuple()[1], rot_angles, 6)
+
+        loc3 = Location(loc2)
+        self.assertTupleAlmostEquals(loc3.to_tuple()[0], (1, 2, 3), 6)
+        self.assertTupleAlmostEquals(loc3.to_tuple()[1], rot_angles, 6)
+
     def test_location_repr_and_str(self):
         self.assertEqual(
             repr(Location()), "(p=(0.00, 0.00, 0.00), o=(-0.00, 0.00, -0.00))"

--- a/tests/direct_api_tests.py
+++ b/tests/direct_api_tests.py
@@ -465,6 +465,11 @@ class TestCadObjects(unittest.TestCase):
             str(Location()),
             "Location: (position=(0.00, 0.00, 0.00), orientation=(-0.00, 0.00, -0.00))",
         )
+        loc = Location((1, 2, 3), (33, 45, 67))
+        self.assertEqual(
+            str(loc),
+            "Location: (position=(1.00, 2.00, 3.00), orientation=(33.00, 45.00, 67.00))",
+        )
 
     def test_location_inverted(self):
         loc = Location(Plane.XZ)

--- a/tests/direct_api_tests.py
+++ b/tests/direct_api_tests.py
@@ -444,12 +444,12 @@ class TestCadObjects(unittest.TestCase):
         self.assertTupleAlmostEquals(loc1.to_tuple()[0], loc2.to_tuple()[0], 6)
         self.assertTupleAlmostEquals(loc1.to_tuple()[1], loc2.to_tuple()[1], 6)
 
-        loc1 = Location((1, 2), angle=34)
+        loc1 = Location((1, 2), 34)
         self.assertTupleAlmostEquals(loc1.to_tuple()[0], (1, 2, 0), 6)
         self.assertTupleAlmostEquals(loc1.to_tuple()[1], (0, 0, 34), 6)
 
         rot_angles = (-115.00, 35.00, -135.00)
-        loc2 = Location((1, 2, 3), rotation=rot_angles)
+        loc2 = Location((1, 2, 3), rot_angles)
         self.assertTupleAlmostEquals(loc2.to_tuple()[0], (1, 2, 3), 6)
         self.assertTupleAlmostEquals(loc2.to_tuple()[1], rot_angles, 6)
 

--- a/tests/direct_api_tests.py
+++ b/tests/direct_api_tests.py
@@ -469,7 +469,7 @@ class TestCadObjects(unittest.TestCase):
     def test_location_inverted(self):
         loc = Location(Plane.XZ)
         self.assertTupleAlmostEquals(
-            loc.inverse().orientation.to_tuple(), (-math.pi / 2, 0, 0), 6
+            loc.inverse().orientation.to_tuple(), (-90, 0, 0), 6
         )
 
     def test_edge_wrapper_radius(self):
@@ -1331,9 +1331,7 @@ class TestAxis(unittest.TestCase):
         x_location = Axis.X.to_location()
         self.assertTrue(isinstance(x_location, Location))
         self.assertTupleAlmostEquals(x_location.position.to_tuple(), (0, 0, 0), 5)
-        self.assertTupleAlmostEquals(
-            x_location.orientation.to_tuple(), (0, math.pi / 2, math.pi), 5
-        )
+        self.assertTupleAlmostEquals(x_location.orientation.to_tuple(), (0, 90, 180), 5)
 
     def test_axis_to_plane(self):
         x_plane = Axis.X.to_plane()


### PR DESCRIPTION
I've added a bunch of changes:

**Commit 1:**
Use intrinsic Euler angle for `to_tuple()` (see our discussion few days ago)
I had to adapt two tests `0.00` instead if `-0.00` since the algorithm has different floating errors
And I added a test to ensure that the old way (matrix multiplications) and intrinsic_XYZ Euler angles return the same result.

**Commit 2:** 
I changed all overload comments to doc strings. They are now visible in VS Code as type hints
 I added 
- `Location(loc: Location)`
- `Location(translation: VectorLike: rotation: RotationLike)`

I enhanced `Location(translation: VectorLike: axis:VektorLike, angle: float)` to
- `Location(translation: VectorLike: axis:VektorLike=(0,0,1), angle: float=None)`

**Commit 3 - 5:** fixes

**Commit 6 - 7:**
- keywords felt inconsistent. so changed to use positional arguments only

**Commit 8:** fixes