### PR TITLE
New validate

### DIFF
--- a/src/build123d/abstract_operations.py
+++ b/src/build123d/abstract_operations.py
@@ -2,6 +2,9 @@ from build123d import Face, Mode, BuildSketch, Location, LocationList, Compound,
 
 
 class BaseSketchOperation(Compound):
+
+    _applies_to = [BuildSketch._tag()]
+
     def __init__(
         self,
         face: Face,

--- a/src/build123d/abstract_operations.py
+++ b/src/build123d/abstract_operations.py
@@ -12,7 +12,7 @@ class BaseSketchOperation(Compound):
         centered: tuple[bool, bool] = (True, True),
         mode: Mode = Mode.ADD,
     ):
-        context: BuildSketch = BuildSketch._get_context()
+        context: BuildSketch = BuildSketch._get_context(self)
 
         bounding_box = face.bounding_box()
         center_offset = Vector(

--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -171,14 +171,23 @@ class Builder(ABC):
         return NotImplementedError  # pragma: no cover
 
     @classmethod
-    def _get_context(cls):
+    def _get_context(cls, caller=None):
         """Return the instance of the current builder
 
         Note: each derived class can override this class to return the class
         type to keep IDEs happy. In Python 3.11 the return type should be set to Self
         here to avoid having to recreate this method.
         """
-        return cls._current.get(None)
+        result = cls._current.get(None)
+        if caller is not None and result is None:
+            if hasattr(caller, "_applies_to"):
+                raise RuntimeError(
+                    f"No valid context found, use one of {caller._applies_to}"
+                )
+            else:
+                raise RuntimeError(f"No valid context found")
+
+        return result
 
     def vertices(self, select: Select = Select.ALL) -> ShapeList[Vertex]:
         """Return Vertices

--- a/src/build123d/build_generic.py
+++ b/src/build123d/build_generic.py
@@ -92,8 +92,8 @@ class Add(Compound):
         rotation: Union[float, RotationLike] = None,
         mode: Mode = Mode.ADD,
     ):
-        context: Builder = Builder._get_context()
-        validate_inputs(self, context, objects)
+        context: Builder = Builder._get_context(self)
+        context.validate_inputs(self, objects)
 
         if isinstance(context, BuildPart):
             rotation_value = (0, 0, 0) if rotation is None else rotation
@@ -168,9 +168,8 @@ class BoundingBox(Compound):
         *objects: Shape,
         mode: Mode = Mode.ADD,
     ):
-        context: Builder = Builder._get_context()
-
-        validate_inputs(self, context, objects)
+        context: Builder = Builder._get_context(self)
+        context.validate_inputs(self, objects)
 
         if isinstance(context, BuildPart):
             new_objects = []
@@ -237,9 +236,8 @@ class Chamfer(Compound):
     def __init__(
         self, *objects: Union[Edge, Vertex], length: float, length2: float = None
     ):
-        context: Builder = Builder._get_context()
-
-        validate_inputs(self, context, objects)
+        context: Builder = Builder._get_context(self)
+        context.validate_inputs(self, objects)
 
         if isinstance(context, BuildPart):
             new_part = context.part.chamfer(length, length2, list(objects))
@@ -277,9 +275,8 @@ class Fillet(Compound):
     _applies_to = [BuildPart._tag(), BuildSketch._tag()]
 
     def __init__(self, *objects: Union[Edge, Vertex], radius: float):
-        context: Builder = Builder._get_context()
-
-        validate_inputs(self, context, objects)
+        context: Builder = Builder._get_context(self)
+        context.validate_inputs(self, objects)
 
         if isinstance(context, BuildPart):
             new_part = context.part.fillet(radius, list(objects))
@@ -323,9 +320,8 @@ class Mirror(Compound):
         about: Plane = Plane.XZ,
         mode: Mode = Mode.ADD,
     ):
-        context: Builder = Builder._get_context()
-
-        validate_inputs(self, context, objects)
+        context: Builder = Builder._get_context(self)
+        context.validate_inputs(self, objects)
 
         if not objects:
             objects = [context._obj]
@@ -382,9 +378,8 @@ class Offset(Compound):
         kind: Kind = Kind.ARC,
         mode: Mode = Mode.REPLACE,
     ):
-        context: Builder = Builder._get_context()
-
-        validate_inputs(self, context, objects)
+        context: Builder = Builder._get_context(self)
+        context.validate_inputs(self, objects)
 
         if not objects:
             objects = [context._obj]
@@ -462,9 +457,8 @@ class Scale(Compound):
         by: Union[float, tuple[float, float, float]],
         mode: Mode = Mode.REPLACE,
     ):
-        context: Builder = Builder._get_context()
-
-        validate_inputs(self, context, objects)
+        context: Builder = Builder._get_context(self)
+        context.validate_inputs(self, objects)
 
         if not objects:
             objects = [context._obj]
@@ -540,9 +534,8 @@ class Split(Compound):
                 )
             )
 
-        context: Builder = Builder._get_context()
-
-        validate_inputs(self, context, objects)
+        context: Builder = Builder._get_context(self)
+        context.validate_inputs(self, objects)
 
         if not objects:
             objects = [context._obj]

--- a/src/build123d/build_generic.py
+++ b/src/build123d/build_generic.py
@@ -53,7 +53,6 @@ from build123d import (
     BuildPart,
     Builder,
     LocationList,
-    validate_inputs,
 )
 
 logging.getLogger("build123d").addHandler(logging.NullHandler())
@@ -84,6 +83,8 @@ class Add(Compound):
             rotation about each axis for part. Defaults to None.
         mode (Mode, optional): combine mode. Defaults to Mode.ADD.
     """
+
+    _applies_to = [BuildPart._tag(), BuildSketch._tag(), BuildLine._tag()]
 
     def __init__(
         self,
@@ -160,6 +161,8 @@ class BoundingBox(Compound):
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
 
+    _applies_to = [BuildPart._tag(), BuildSketch._tag()]
+
     def __init__(
         self,
         *objects: Shape,
@@ -229,6 +232,8 @@ class Chamfer(Compound):
         length2 (float, optional): asymmetric chamfer size. Defaults to None.
     """
 
+    _applies_to = [BuildPart._tag(), BuildSketch._tag()]
+
     def __init__(
         self, *objects: Union[Edge, Vertex], length: float, length2: float = None
     ):
@@ -269,6 +274,8 @@ class Fillet(Compound):
         radius (float): fillet size - must be less than 1/2 local width
     """
 
+    _applies_to = [BuildPart._tag(), BuildSketch._tag()]
+
     def __init__(self, *objects: Union[Edge, Vertex], radius: float):
         context: Builder = Builder._get_context()
 
@@ -307,6 +314,8 @@ class Mirror(Compound):
         about (Plane, optional): reference plane. Defaults to "XZ".
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
+
+    _applies_to = [BuildPart._tag(), BuildSketch._tag(), BuildLine._tag()]
 
     def __init__(
         self,
@@ -362,6 +371,8 @@ class Offset(Compound):
     Raises:
         ValueError: Invalid object type
     """
+
+    _applies_to = [BuildPart._tag(), BuildSketch._tag(), BuildLine._tag()]
 
     def __init__(
         self,
@@ -443,6 +454,8 @@ class Scale(Compound):
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
 
+    _applies_to = [BuildPart._tag(), BuildSketch._tag(), BuildLine._tag()]
+
     def __init__(
         self,
         *objects: Shape,
@@ -505,6 +518,8 @@ class Split(Compound):
         keep (Keep, optional): selector for which segment to keep. Defaults to Keep.TOP.
         mode (Mode, optional): combination mode. Defaults to Mode.INTERSECT.
     """
+
+    _applies_to = [BuildPart._tag(), BuildSketch._tag(), BuildLine._tag()]
 
     def __init__(
         self,

--- a/src/build123d/build_line.py
+++ b/src/build123d/build_line.py
@@ -41,7 +41,7 @@ from build123d.direct_api import (
     Face,
     Plane,
 )
-from build123d.build_common import Builder, logger, validate_inputs
+from build123d.build_common import Builder, logger
 
 
 class BuildLine(Builder):
@@ -52,6 +52,10 @@ class BuildLine(Builder):
     Args:
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
+
+    @staticmethod
+    def _tag() -> str:
+        return "BuildLine"
 
     @property
     def _obj(self):
@@ -163,6 +167,8 @@ class CenterArc(Edge):
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
 
+    _applies_to = [BuildLine._tag()]
+
     def __init__(
         self,
         center: VectorLike,
@@ -233,6 +239,8 @@ class Helix(Wire):
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
 
+    _applies_to = [BuildLine._tag()]
+
     def __init__(
         self,
         pitch: float,
@@ -266,6 +274,8 @@ class JernArc(Edge):
         plane (Plane, optional): plane containing arc. Defaults to Plane.XY.
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
+
+    _applies_to = [BuildLine._tag()]
 
     def __init__(
         self,
@@ -310,6 +320,8 @@ class Line(Edge):
         ValueError: Two point not provided
     """
 
+    _applies_to = [BuildLine._tag()]
+
     def __init__(self, *pts: VectorLike, mode: Mode = Mode.ADD):
         context: BuildLine = BuildLine._get_context()
         validate_inputs(self, context)
@@ -338,6 +350,8 @@ class PolarLine(Edge):
     Raises:
         ValueError: Either angle or direction must be provided
     """
+
+    _applies_to = [BuildLine._tag()]
 
     def __init__(
         self,
@@ -380,6 +394,8 @@ class Polyline(Wire):
         ValueError: Three or more points not provided
     """
 
+    _applies_to = [BuildLine._tag()]
+
     def __init__(self, *pts: VectorLike, close: bool = False, mode: Mode = Mode.ADD):
         context: BuildLine = BuildLine._get_context()
         validate_inputs(self, context)
@@ -414,6 +430,8 @@ class RadiusArc(Edge):
     Raises:
         ValueError: Insufficient radius to connect end points
     """
+
+    _applies_to = [BuildLine._tag()]
 
     def __init__(
         self,
@@ -457,6 +475,8 @@ class SagittaArc(Edge):
         sagitta (float): arc height
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
+
+    _applies_to = [BuildLine._tag()]
 
     def __init__(
         self,
@@ -503,6 +523,8 @@ class Spline(Edge):
         periodic (bool, optional): make the spline periodic. Defaults to False.
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
+
+    _applies_to = [BuildLine._tag()]
 
     def __init__(
         self,
@@ -556,6 +578,8 @@ class TangentArc(Edge):
         ValueError: Two points are required
     """
 
+    _applies_to = [BuildLine._tag()]
+
     def __init__(
         self,
         *pts: VectorLike,
@@ -591,6 +615,8 @@ class ThreePointArc(Edge):
     Raises:
         ValueError: Three points must be provided
     """
+
+    _applies_to = [BuildLine._tag()]
 
     def __init__(self, *pts: VectorLike, mode: Mode = Mode.ADD):
         context: BuildLine = BuildLine._get_context()

--- a/src/build123d/build_part.py
+++ b/src/build123d/build_part.py
@@ -55,7 +55,6 @@ from build123d.direct_api import (
 from build123d.build_common import (
     Builder,
     logger,
-    validate_inputs,
     LocationList,
     WorkplaneList,
 )
@@ -71,6 +70,10 @@ class BuildPart(Builder):
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
 
     """
+
+    @staticmethod
+    def _tag() -> str:
+        return "BuildPart"
 
     @property
     def _obj(self):
@@ -269,6 +272,8 @@ class CounterBoreHole(Compound):
         mode (Mode, optional): combination mode. Defaults to Mode.SUBTRACT.
     """
 
+    _applies_to = [BuildPart._tag()]
+
     def __init__(
         self,
         radius: float,
@@ -324,6 +329,8 @@ class CounterSinkHole(Compound):
         counter_sink_angle (float, optional): cone angle. Defaults to 82.
         mode (Mode, optional): combination mode. Defaults to Mode.SUBTRACT.
     """
+
+    _applies_to = [BuildPart._tag()]
 
     def __init__(
         self,
@@ -385,6 +392,8 @@ class Extrude(Compound):
         taper (float, optional): taper angle. Defaults to 0.
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
+
+    _applies_to = [BuildPart._tag()]
 
     def __init__(
         self,
@@ -528,6 +537,8 @@ class Hole(Compound):
         mode (Mode, optional): combination mode. Defaults to Mode.SUBTRACT.
     """
 
+    _applies_to = [BuildPart._tag()]
+
     def __init__(
         self,
         radius: float,
@@ -577,6 +588,8 @@ class Loft(Solid):
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
 
+    _applies_to = [BuildPart._tag()]
+
     def __init__(self, *sections: Face, ruled: bool = False, mode: Mode = Mode.ADD):
 
         context: BuildPart = BuildPart._get_context()
@@ -619,6 +632,8 @@ class Revolve(Compound):
     Raises:
         ValueError: Invalid axis of revolution
     """
+
+    _applies_to = [BuildPart._tag()]
 
     def __init__(
         self,
@@ -686,6 +701,8 @@ class Section(Compound):
         mode (Mode, optional): combination mode. Defaults to Mode.INTERSECT.
     """
 
+    _applies_to = [BuildPart._tag()]
+
     def __init__(
         self,
         *section_by: Plane,
@@ -737,6 +754,8 @@ class Sweep(Compound):
         binormal (Union[Edge, Wire], optional): guide rotation along path. Defaults to None.
         mode (Mode, optional): combination. Defaults to Mode.ADD.
     """
+
+    _applies_to = [BuildPart._tag()]
 
     def __init__(
         self,
@@ -822,6 +841,8 @@ class Box(Compound):
         mode (Mode, optional): combine mode. Defaults to Mode.ADD.
     """
 
+    _applies_to = [BuildPart._tag()]
+
     def __init__(
         self,
         length: float,
@@ -873,6 +894,8 @@ class Cone(Compound):
             Defaults to (True, True, True).
         mode (Mode, optional): combine mode. Defaults to Mode.ADD.
     """
+
+    _applies_to = [BuildPart._tag()]
 
     def __init__(
         self,
@@ -931,6 +954,8 @@ class Cylinder(Compound):
         mode (Mode, optional): combine mode. Defaults to Mode.ADD.
     """
 
+    _applies_to = [BuildPart._tag()]
+
     def __init__(
         self,
         radius: float,
@@ -985,6 +1010,8 @@ class Sphere(Compound):
             Defaults to (True, True, True).
         mode (Mode, optional): combine mode. Defaults to Mode.ADD.
     """
+
+    _applies_to = [BuildPart._tag()]
 
     def __init__(
         self,
@@ -1045,6 +1072,8 @@ class Torus(Compound):
         mode (Mode, optional): combine mode. Defaults to Mode.ADD.
     """
 
+    _applies_to = [BuildPart._tag()]
+
     def __init__(
         self,
         major_radius: float,
@@ -1103,6 +1132,8 @@ class Wedge(Compound):
         rotation (RotationLike, optional): angles to rotate about axes. Defaults to (0, 0, 0).
         mode (Mode, optional): combine mode. Defaults to Mode.ADD.
     """
+
+    _applies_to = [BuildPart._tag()]
 
     def __init__(
         self,

--- a/src/build123d/build_sketch.py
+++ b/src/build123d/build_sketch.py
@@ -58,7 +58,6 @@ from build123d.direct_api import (
 from build123d.build_common import (
     Builder,
     logger,
-    validate_inputs,
     LocationList,
     WorkplaneList,
 )
@@ -72,6 +71,10 @@ class BuildSketch(Builder):
     Args:
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
+
+    @staticmethod
+    def _tag() -> str:
+        return "BuildSketch"
 
     @property
     def _obj(self) -> Compound:
@@ -222,6 +225,8 @@ class MakeHull(Face):
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
 
+    _applies_to = [BuildSketch._tag()]
+
     def __init__(self, *edges: Edge, mode: Mode = Mode.ADD):
         context: BuildSketch = BuildSketch._get_context()
         validate_inputs(self, context, edges)
@@ -251,6 +256,8 @@ class Circle(Compound):
         centered (tuple[bool, bool], optional): center options. Defaults to (True, True).
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
+
+    _applies_to = [BuildSketch._tag()]
 
     def __init__(
         self,
@@ -292,6 +299,8 @@ class Ellipse(Compound):
         centered (tuple[bool, bool], optional): center options. Defaults to (True, True).
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
+
+    _applies_to = [BuildSketch._tag()]
 
     def __init__(
         self,
@@ -341,6 +350,8 @@ class Polygon(Compound):
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
 
+    _applies_to = [BuildSketch._tag()]
+
     def __init__(
         self,
         *pts: VectorLike,
@@ -387,6 +398,8 @@ class Rectangle(Compound):
         centered (tuple[bool, bool], optional): center options. Defaults to (True, True).
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
+
+    _applies_to = [BuildSketch._tag()]
 
     def __init__(
         self,
@@ -436,6 +449,8 @@ class RegularPolygon(Compound):
         centered (tuple[bool, bool], optional): center options. Defaults to (True, True).
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
+
+    _applies_to = [BuildSketch._tag()]
 
     def __init__(
         self,
@@ -492,6 +507,8 @@ class SlotArc(Compound):
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
 
+    _applies_to = [BuildSketch._tag()]
+
     def __init__(
         self,
         arc: Union[Edge, Wire],
@@ -534,6 +551,8 @@ class SlotCenterPoint(Compound):
         rotation (float, optional): angles to rotate objects. Defaults to 0.
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
+
+    _applies_to = [BuildSketch._tag()]
 
     def __init__(
         self,
@@ -586,6 +605,8 @@ class SlotCenterToCenter(Compound):
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
 
+    _applies_to = [BuildSketch._tag()]
+
     def __init__(
         self,
         center_separation: float,
@@ -629,6 +650,8 @@ class SlotOverall(Compound):
         rotation (float, optional): angles to rotate objects. Defaults to 0.
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
+
+    _applies_to = [BuildSketch._tag()]
 
     def __init__(
         self,
@@ -681,6 +704,8 @@ class Text(Compound):
         rotation (float, optional): angles to rotate objects. Defaults to 0.
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
+
+    _applies_to = [BuildSketch._tag()]
 
     def __init__(
         self,
@@ -751,6 +776,8 @@ class Trapezoid(Compound):
     Raises:
         ValueError: Give angles result in an invalid trapezoid
     """
+
+    _applies_to = [BuildSketch._tag()]
 
     def __init__(
         self,

--- a/src/build123d/build_sketch.py
+++ b/src/build123d/build_sketch.py
@@ -177,13 +177,23 @@ class BuildSketch(Builder):
             )
 
     @classmethod
-    def _get_context(cls) -> "BuildSketch":
+    def _get_context(cls, caller=None) -> "BuildSketch":
         """Return the instance of the current builder"""
         logger.info(
             "Context requested by %s",
             type(inspect.currentframe().f_back.f_locals["self"]).__name__,
         )
-        return cls._current.get(None)
+
+        result = cls._current.get(None)
+        if caller is not None and result is None:
+            if hasattr(caller, "_applies_to"):
+                raise RuntimeError(
+                    f"No valid context found, use one of {caller._applies_to}"
+                )
+            else:
+                raise RuntimeError(f"No valid context found")
+
+        return result
 
 
 #
@@ -202,8 +212,8 @@ class MakeFace(Face):
     """
 
     def __init__(self, *edges: Edge, mode: Mode = Mode.ADD):
-        context: BuildSketch = BuildSketch._get_context()
-        validate_inputs(self, context, edges)
+        context: BuildSketch = BuildSketch._get_context(self)
+        context.validate_inputs(self, edges)
 
         self.edges = edges
         self.mode = mode
@@ -228,8 +238,8 @@ class MakeHull(Face):
     _applies_to = [BuildSketch._tag()]
 
     def __init__(self, *edges: Edge, mode: Mode = Mode.ADD):
-        context: BuildSketch = BuildSketch._get_context()
-        validate_inputs(self, context, edges)
+        context: BuildSketch = BuildSketch._get_context(self)
+        context.validate_inputs(self, edges)
 
         self.edges = edges
         self.mode = mode
@@ -265,8 +275,8 @@ class Circle(Compound):
         centered: tuple[bool, bool] = (True, True),
         mode: Mode = Mode.ADD,
     ):
-        context: BuildSketch = BuildSketch._get_context()
-        validate_inputs(self, context)
+        context: BuildSketch = BuildSketch._get_context(self)
+        context.validate_inputs(self)
 
         self.radius = radius
         self.centered = centered
@@ -310,8 +320,8 @@ class Ellipse(Compound):
         centered: tuple[bool, bool] = (True, True),
         mode: Mode = Mode.ADD,
     ):
-        context: BuildSketch = BuildSketch._get_context()
-        validate_inputs(self, context)
+        context: BuildSketch = BuildSketch._get_context(self)
+        context.validate_inputs(self)
 
         self.x_radius = x_radius
         self.y_radius = y_radius
@@ -359,8 +369,8 @@ class Polygon(Compound):
         centered: tuple[bool, bool] = (True, True),
         mode: Mode = Mode.ADD,
     ):
-        context: BuildSketch = BuildSketch._get_context()
-        validate_inputs(self, context)
+        context: BuildSketch = BuildSketch._get_context(self)
+        context.validate_inputs(self)
 
         self.pts = pts
         self.rotation = rotation
@@ -409,8 +419,8 @@ class Rectangle(Compound):
         centered: tuple[bool, bool] = (True, True),
         mode: Mode = Mode.ADD,
     ):
-        context: BuildSketch = BuildSketch._get_context()
-        validate_inputs(self, context)
+        context: BuildSketch = BuildSketch._get_context(self)
+        context.validate_inputs(self)
 
         self.width = width
         self.height = height
@@ -460,8 +470,8 @@ class RegularPolygon(Compound):
         centered: tuple[bool, bool] = (True, True),
         mode: Mode = Mode.ADD,
     ):
-        context: BuildSketch = BuildSketch._get_context()
-        validate_inputs(self, context)
+        context: BuildSketch = BuildSketch._get_context(self)
+        context.validate_inputs(self)
 
         self.radius = radius
         self.side_count = side_count
@@ -516,8 +526,8 @@ class SlotArc(Compound):
         rotation: float = 0,
         mode: Mode = Mode.ADD,
     ):
-        context: BuildSketch = BuildSketch._get_context()
-        validate_inputs(self, context)
+        context: BuildSketch = BuildSketch._get_context(self)
+        context.validate_inputs(self)
 
         self.arc = arc
         self.height = height
@@ -562,8 +572,8 @@ class SlotCenterPoint(Compound):
         rotation: float = 0,
         mode: Mode = Mode.ADD,
     ):
-        context: BuildSketch = BuildSketch._get_context()
-        validate_inputs(self, context)
+        context: BuildSketch = BuildSketch._get_context(self)
+        context.validate_inputs(self)
 
         center_v = Vector(center)
         point_v = Vector(point)
@@ -614,8 +624,8 @@ class SlotCenterToCenter(Compound):
         rotation: float = 0,
         mode: Mode = Mode.ADD,
     ):
-        context: BuildSketch = BuildSketch._get_context()
-        validate_inputs(self, context)
+        context: BuildSketch = BuildSketch._get_context(self)
+        context.validate_inputs(self)
 
         self.center_separation = center_separation
         self.height = height
@@ -660,8 +670,8 @@ class SlotOverall(Compound):
         rotation: float = 0,
         mode: Mode = Mode.ADD,
     ):
-        context: BuildSketch = BuildSketch._get_context()
-        validate_inputs(self, context)
+        context: BuildSketch = BuildSketch._get_context(self)
+        context.validate_inputs(self)
 
         self.width = width
         self.height = height
@@ -722,8 +732,8 @@ class Text(Compound):
         mode: Mode = Mode.ADD,
     ) -> Compound:
 
-        context: BuildSketch = BuildSketch._get_context()
-        validate_inputs(self, context)
+        context: BuildSketch = BuildSketch._get_context(self)
+        context.validate_inputs(self)
 
         self.txt = txt
         self.fontsize = fontsize
@@ -789,8 +799,8 @@ class Trapezoid(Compound):
         centered: tuple[bool, bool] = (True, True),
         mode: Mode = Mode.ADD,
     ):
-        context: BuildSketch = BuildSketch._get_context()
-        validate_inputs(self, context)
+        context: BuildSketch = BuildSketch._get_context(self)
+        context.validate_inputs(self)
 
         right_side_angle = left_side_angle if not right_side_angle else right_side_angle
 

--- a/src/build123d/build_sketch.py
+++ b/src/build123d/build_sketch.py
@@ -211,6 +211,8 @@ class MakeFace(Face):
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
     """
 
+    _applies_to = [BuildSketch._tag()]
+
     def __init__(self, *edges: Edge, mode: Mode = Mode.ADD):
         context: BuildSketch = BuildSketch._get_context(self)
         context.validate_inputs(self, edges)

--- a/tests/build_generic_tests.py
+++ b/tests/build_generic_tests.py
@@ -109,7 +109,7 @@ class AddTests(unittest.TestCase):
             Add(Edge.make_line((0, 0, 0), (1, 1, 1)))
 
     def test_unsupported_builder(self):
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             with TestBuilder():
                 Add(Edge.make_line((0, 0, 0), (1, 1, 1)))
 


### PR DESCRIPTION
**Commit 1**
Added staticmethod `_tag()` Since I wanted to call it in `_applies_to` as a static method, couldn't be a property
Added `_applies_to` to all objects and operations
Moved validate_inputs into Builder

**Commit 2**
Added an optional `caller` argument to `_get_context()`. It should always be called with `self`. When `caller` has an attribute `_applies_to`, I can provide a nicer error message

```python
In [1]: from build123d import *

In [2]: Box(1,2,3)
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Cell In [2], line 1
----> 1 Box(1,2,3)

File ~/Development/build123d/src/build123d/build_part.py:865, in Box.__init__(self, length, width, height, rotation, centered, mode)
...
RuntimeError: No valid context found, use one of ['BuildPart']

In [3]: Fillet(radius=2)
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Cell In [3], line 1
----> 1 Fillet(radius=2)
...
RuntimeError: No valid context found, use one of ['BuildPart', 'BuildSketch']

In [4]: with BuildPart() as test:
   ...:     Box(1,2,3)
   ...:     Circle(2)
   ...:
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Cell In [4], line 3
      1 with BuildPart() as test:
      2     Box(1,2,3)
----> 3     Circle(2)
...
RuntimeError: BuildPart doesn't have a Circle object or operation (Circle applies to ['BuildSketch'])
```