### PR TITLE
added further initializers to Plane

### DIFF
--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -627,17 +627,7 @@ class Workplanes(WorkplaneList):
             if isinstance(obj, Plane):
                 self.workplanes.append(obj)
             elif isinstance(obj, (Location, Face)):
-                if isinstance(obj, Face):
-                    face = obj
-                    origin = face.center()
-                else:
-                    face = Face.make_rect(1, 1).move(obj)
-                    origin = obj.position
-
-                x_dir = Vector(face._geom_adaptor().Position().XDirection())
-                z_dir = face.normal_at(origin)
-
-                self.workplanes.append(Plane(origin=origin, x_dir=x_dir, z_dir=z_dir))
+                self.workplanes.append(Plane(obj))
             else:
                 raise ValueError(f"Workplanes does not accept {type(obj)}")
         super().__init__(self.workplanes)

--- a/src/build123d/direct_api.py
+++ b/src/build123d/direct_api.py
@@ -3790,6 +3790,13 @@ class Plane:
         """Reverse z direction of plane"""
         return Plane(self.origin, self.x_dir, -self.z_dir)
 
+    def __mul__(self, location: Location) -> Plane:
+        if not isinstance(location, Location):
+            raise RuntimeError(
+                "Planes can only be multiplied with Locations to relocate them"
+            )
+        return Plane(self.to_location() * location)
+
     def __repr__(self):
         """To String
 

--- a/src/build123d/direct_api.py
+++ b/src/build123d/direct_api.py
@@ -3786,6 +3786,10 @@ class Plane:
         """Are planes not equal"""
         return not self.__eq__(other)
 
+    def __neg__(self) -> Plane:
+        """Reverse z direction of plane"""
+        return Plane(self.origin, self.x_dir, -self.z_dir)
+
     def __repr__(self):
         """To String
 

--- a/src/build123d/direct_api.py
+++ b/src/build123d/direct_api.py
@@ -3703,8 +3703,9 @@ class Plane:
                     face = Face.make_rect(1, 1).move(obj)
                     origin = obj.position
                 elif hasattr(obj, "wrapped") and isinstance(
-                    obj.wrapped, TopoDS_Face
-                ):  # is it a face?
+                    obj.wrapped,
+                    TopoDS_Face,  # check the wrapped class to identify faces
+                ):
                     face = obj
                     origin = face.center()
                 else:

--- a/src/build123d/direct_api.py
+++ b/src/build123d/direct_api.py
@@ -3679,11 +3679,6 @@ class Plane:
         ...
 
     @overload
-    def __init__(self, plane: "Compound"):  # pragma: no cover
-        """Return a plane aligned with the location of a given Compound, e.g. BuildSketch.sketch"""
-        ...
-
-    @overload
     def __init__(
         self,
         origin: VectorLike,
@@ -3703,15 +3698,6 @@ class Plane:
                 if isinstance(obj, Plane):
                     # be sure to return a new Plane, hence take location of plane and continue
                     obj = obj.to_location()
-                elif hasattr(obj, "wrapped") and isinstance(
-                    obj.wrapped, TopoDS_Compound
-                ):  # is it a Compound?
-                    # we don't want the location of the underlying workplane, but the faces location
-                    faces = list(obj)
-                    if len(faces) == 1:
-                        obj = faces[0].location
-                    else:
-                        raise TypeError("Only sketches with single face supported")
 
                 if isinstance(obj, Location):
                     face = Face.make_rect(1, 1).move(obj)

--- a/tests/direct_api_tests.py
+++ b/tests/direct_api_tests.py
@@ -323,6 +323,38 @@ class TestCadObjects(unittest.TestCase):
             p2.y_dir, (-p.z_dir).cross(p.x_dir).normalized(), 6
         )
 
+    def test_plane_mul(self):
+        p = Plane(origin=(1, 2, 3), x_dir=(1, 0, 0), z_dir=(0, 0, 1))
+        p2 = p * Location((1, 2, -1), (0, 0, 45))
+        self.assertTupleAlmostEquals(p2.origin, (2, 4, 2), 6)
+        self.assertTupleAlmostEquals(
+            p2.x_dir, (math.sqrt(2) / 2, math.sqrt(2) / 2, 0), 6
+        )
+        self.assertTupleAlmostEquals(
+            p2.y_dir, (-math.sqrt(2) / 2, math.sqrt(2) / 2, 0), 6
+        )
+        self.assertTupleAlmostEquals(p2.z_dir, (0, 0, 1), 6)
+
+        p2 = p * Location((1, 2, -1), (0, 45, 0))
+        self.assertTupleAlmostEquals(p2.origin, (2, 4, 2), 6)
+        self.assertTupleAlmostEquals(
+            p2.x_dir, (math.sqrt(2) / 2, 0, -math.sqrt(2) / 2), 6
+        )
+        self.assertTupleAlmostEquals(p2.y_dir, (0, 1, 0), 6)
+        self.assertTupleAlmostEquals(
+            p2.z_dir, (math.sqrt(2) / 2, 0, math.sqrt(2) / 2), 6
+        )
+
+        p2 = p * Location((1, 2, -1), (45, 0, 0))
+        self.assertTupleAlmostEquals(p2.origin, (2, 4, 2), 6)
+        self.assertTupleAlmostEquals(p2.x_dir, (1, 0, 0), 6)
+        self.assertTupleAlmostEquals(
+            p2.y_dir, (0, math.sqrt(2) / 2, math.sqrt(2) / 2), 6
+        )
+        self.assertTupleAlmostEquals(
+            p2.z_dir, (0, -math.sqrt(2) / 2, math.sqrt(2) / 2), 6
+        )
+
     def test_plane_equal(self):
         # default orientation
         self.assertEqual(

--- a/tests/direct_api_tests.py
+++ b/tests/direct_api_tests.py
@@ -307,6 +307,20 @@ class TestCadObjects(unittest.TestCase):
         self.assertTupleAlmostEquals(f.location.position, p.to_location().position, 6)
         self.assertTupleAlmostEquals(f.location.orientation, p.to_location().orientation, 6)
 
+    def test_plane_neg(self):
+        p = Plane(
+            origin=(1, 2, 3),
+            x_dir=Vector(1, 2, 3).normalized(),
+            z_dir=Vector(4, 5, 6).normalized(),
+        )
+        p2 = -p
+        self.assertTupleAlmostEquals(p2.origin, p.origin, 6)
+        self.assertTupleAlmostEquals(p2.x_dir, p.x_dir, 6)
+        self.assertTupleAlmostEquals(p2.z_dir, -p.z_dir, 6)
+        self.assertTupleAlmostEquals(
+            p2.y_dir, (-p.z_dir).cross(p.x_dir).normalized(), 6
+        )
+
     def test_plane_equal(self):
         # default orientation
         self.assertEqual(

--- a/tests/direct_api_tests.py
+++ b/tests/direct_api_tests.py
@@ -266,6 +266,47 @@ class TestCadObjects(unittest.TestCase):
         e = Shape.cast(BRepBuilderAPI_MakeEdge(gp_Pnt(0, 0, 0), gp_Pnt(1, 1, 0)).Edge())
         self.assertEqual(2, len(e.vertices()))
 
+    def test_plane_init(self):
+        # rotated location around z
+        loc = Location((0, 0, 0), (0, 0, 45))
+        p = Plane(loc)
+        self.assertTupleAlmostEquals(p.origin, (0, 0, 0), 6)
+        self.assertTupleAlmostEquals(
+            p.x_dir, (math.sqrt(2) / 2, math.sqrt(2) / 2, 0), 6
+        )
+        self.assertTupleAlmostEquals(
+            p.y_dir, (-math.sqrt(2) / 2, math.sqrt(2) / 2, 0), 6
+        )
+        self.assertTupleAlmostEquals(p.z_dir, (0, 0, 1), 6)
+        self.assertTupleAlmostEquals(loc.position, p.to_location().position, 6)
+        self.assertTupleAlmostEquals(loc.orientation, p.to_location().orientation, 6)
+
+        # rotated location around x and origin <> (0,0,0)
+        loc = Location((0, 2, -1), (45, 0, 0))
+        p = Plane(loc)
+        self.assertTupleAlmostEquals(p.origin, (0, 2, -1), 6)
+        self.assertTupleAlmostEquals(p.x_dir, (1, 0, 0), 6)
+        self.assertTupleAlmostEquals(
+            p.y_dir, (0, math.sqrt(2) / 2, math.sqrt(2) / 2), 6
+        )
+        self.assertTupleAlmostEquals(
+            p.z_dir, (0, -math.sqrt(2) / 2, math.sqrt(2) / 2), 6
+        )
+        self.assertTupleAlmostEquals(loc.position, p.to_location().position, 6)
+        self.assertTupleAlmostEquals(loc.orientation, p.to_location().orientation, 6)
+
+        # from a face
+        f = Face.make_rect(1, 2).located(Location((1, 2, 3), (45, 0, 45)))
+        p = Plane(f)
+        self.assertTupleAlmostEquals(p.origin, (1, 2, 3), 6)
+        self.assertTupleAlmostEquals(p.x_dir, (math.sqrt(2) / 2, 0.5, 0.5), 6)
+        self.assertTupleAlmostEquals(p.y_dir, (-math.sqrt(2) / 2, 0.5, 0.5), 6)
+        self.assertTupleAlmostEquals(
+            p.z_dir, (0, -math.sqrt(2) / 2, math.sqrt(2) / 2), 6
+        )
+        self.assertTupleAlmostEquals(f.location.position, p.to_location().position, 6)
+        self.assertTupleAlmostEquals(f.location.orientation, p.to_location().orientation, 6)
+
     def test_plane_equal(self):
         # default orientation
         self.assertEqual(

--- a/tests/direct_api_tests.py
+++ b/tests/direct_api_tests.py
@@ -305,7 +305,9 @@ class TestCadObjects(unittest.TestCase):
             p.z_dir, (0, -math.sqrt(2) / 2, math.sqrt(2) / 2), 6
         )
         self.assertTupleAlmostEquals(f.location.position, p.to_location().position, 6)
-        self.assertTupleAlmostEquals(f.location.orientation, p.to_location().orientation, 6)
+        self.assertTupleAlmostEquals(
+            f.location.orientation, p.to_location().orientation, 6
+        )
 
     def test_plane_neg(self):
         p = Plane(


### PR DESCRIPTION
This is not a finished PR, since we should discuss the implementation of Compound (keep it, drop it, change it)
Currently it supports sketches with one single face in order to get the correct direction of this single face. We could also use the underlying workplane of the sketch or drop Compounds

What do you think?

When we have agreed, I'll finish the PR and add tests and streamline class Workplanes (the logic moved to Plane inits now)
