### PR TITLE
add subtraction test that currently fails due to OCCT clean issues

### DIFF
--- a/tests/test_build_part.py
+++ b/tests/test_build_part.py
@@ -104,6 +104,16 @@ class BuildPartTests(unittest.TestCase):
         self.assertTrue(isinstance(test._obj, Compound))
         self.assertAlmostEqual(test.part.volume, 8000 - (4000 / 3) * pi, 5)
 
+    def test_mode_subtract2(self):
+        """Note that this is known to fail due to OCCT clean issues"""
+        with BuildPart() as test:
+            Sphere(1)
+            Box(0.1, 3, 3, mode=Mode.SUBTRACT)
+        self.assertTrue(isinstance(test._obj, Compound))
+        self.assertAlmostEqual(
+            test.part.volume, 4 / 3 * pi * 1**3 - pi * 1**2 * 0.1, 0
+        )
+
     def test_mode_intersect(self):
         """Note that a negative volume is created"""
         with BuildPart() as test:


### PR DESCRIPTION
```
FAIL: test_mode_subtract2 (test_build_part.BuildPartTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "\sourcedir\tests\test_build_part.py", line 112, in test_mode_subtract2
    self.assertAlmostEqual(
AssertionError: 1.8846104014209444 != 3.874630939427411 within 0 places (1.9900205380064668 difference)
```
The part volume is supposed to be twice as high, or ~3.872. Note that there are also discrepancies between some of the volumes reported by build123d:
```
In [79]: test.part.volume
Out[79]: 1.8846104014209444

In [80]: test.part.volume*2
Out[80]: 3.7692208028418888

In [81]: test.solids()[1].volume
Out[81]: 1.9362315146088336

In [82]: test.solids()[1].volume*2
Out[82]: 3.872463029217667
```