### PR TITLE
Add ci

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,20 @@
+name: 'Setup'
+inputs:
+  python-version:  # id of input
+    description: 'Python version'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: install requirements
+      shell: bash
+      run: |
+        pip install wheel
+        pip install mypy
+        pip install pytest
+        pip install .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: run all tests & run type checker
+
+on: [push, pull_request]
+jobs:
+
+  setup:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [
+          "3.9",
+          "3.10",
+          #"3.11"
+          ]
+        os: [macos-latest, ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: install requirements
+        run: |
+          pip install wheel
+          pip install mypy
+          pip install pytest
+          pip install .
+
+      - name: test
+        run: |
+          python -m pytest
+
+      - name: typecheck
+        run: |
+          mypy --config-file mypy.ini src/build123d

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: run all tests & run type checker
 on: [push, pull_request]
 jobs:
 
-  setup:
+  tests:
     strategy:
       fail-fast: false
       matrix:
@@ -17,20 +17,29 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - name: python
-        uses: actions/setup-python@v4
+      - uses: ./.github/actions/setup
         with:
           python-version: ${{ matrix.python-version }}
-      - name: install requirements
-        run: |
-          pip install wheel
-          pip install mypy
-          pip install pytest
-          pip install .
-
       - name: test
         run: |
           python -m pytest
+  typecheck:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [
+          "3.9",
+          "3.10",
+          #"3.11"
+          ]
+        os: [macos-latest, ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: typecheck
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ docs/_build/
 *.step
 *.STEP
 *.stl
+
+#mypy cache
+.mypy_cache
+build

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,11 @@
+[mypy]
+no_implicit_optional=False
+
+[mypy-anytree.*]
+ignore_missing_imports = True
+
+[mypy-svgpathtools.*]
+ignore_missing_imports = True
+
+[mypy-vtkmodules.*]
+ignore_missing_imports = True

--- a/src/build123d.egg-info/requires.txt
+++ b/src/build123d.egg-info/requires.txt
@@ -1,0 +1,6 @@
+cadquery-ocp>=7.6.3a0
+OCP-stubs>=7.5.1
+typing_extensions<5,>=4.4.0
+numpy<2,>=1.24.1
+svgpathtools<2,>=1.5.1
+anytree<3,>=2.8.0


### PR DESCRIPTION
This adds the CI with the following workflows:

- Mypy Type-checking
  - excluded dependencies
  - allow implicit None
  - This currently fails with a lot of type issues.
- unittests
  - uses pytest 

I also changed the dependency of cadquery-ocp to >= 7.6.3 because 7.7.0 is just around the corner...
changes in the egg-info resulted from installing. should we maybe exclude this directory?