### PR TITLE
fix some typing issues

### DIFF
--- a/src/build123d/build_generic.py
+++ b/src/build123d/build_generic.py
@@ -94,13 +94,14 @@ class Add(Compound):
         context.validate_inputs(self, objects)
 
         if isinstance(context, BuildPart):
-            rotation_value = (0, 0, 0) if rotation is None else rotation
-            rotate = (
-                Rotation(*rotation_value)
-                if isinstance(rotation_value, tuple)
-                else rotation
-            )
-            objects = [obj.moved(rotate) for obj in objects]
+            if rotation is None:
+                rotation = Rotation(0, 0, 0)
+            elif isinstance(rotation, float):
+                raise ValueError("Float values of rotation are not valid for BuildPart")
+            elif isinstance(rotation, tuple):
+                rotation = Rotation(*rotation)
+
+            objects = tuple([obj.moved(rotation) for obj in objects])
             new_edges = [obj for obj in objects if isinstance(obj, Edge)]
             new_wires = [obj for obj in objects if isinstance(obj, Wire)]
             new_faces = [obj for obj in objects if isinstance(obj, Face)]
@@ -396,10 +397,9 @@ class Offset(Compound):
         self.kind = kind
         self.mode = mode
 
-        edges = []
-        faces = []
-        edges = []
-        solids = []
+        edges: list[Edge] = []
+        faces: list[Face] = []
+        solids: list[Solid] = []
         for obj in objects:
             if isinstance(obj, Compound):
                 edges.extend(obj.get_type(Edge))
@@ -468,8 +468,8 @@ class Scale(Compound):
 
         if not objects:
             objects = [context._obj]
-
-        self.objects = objects
+        
+        self.objects = list(objects)
         self.by = by
         self.mode = mode
 

--- a/src/build123d/direct_api.py
+++ b/src/build123d/direct_api.py
@@ -52,6 +52,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    Type,
     TypeVar,
     Union,
 )
@@ -3627,7 +3628,7 @@ class Shape(NodeMixin):
 
 
 # This TypeVar allows IDEs to see the type of objects within the ShapeList
-T = TypeVar("T", bound=Shape)
+T = TypeVar("T", Shape, Vector)
 
 
 class ShapeList(list[T]):
@@ -4851,7 +4852,7 @@ class Compound(Shape, Mixin3D):
         return tcast(Compound, self._bool_op(self, to_intersect, intersect_op))
 
     def get_type(
-        self, obj_type: Union[Edge, Face, Shell, Solid, Wire]
+        self, obj_type: Union[Type[Edge], Type[Face], Type[Shell], Type[Solid], Type[Wire]]
     ) -> list[Union[Edge, Face, Shell, Solid, Wire]]:
         """get_type
 


### PR DESCRIPTION
this is a first attempt to make mypy a little more happy.

There is a ton of mypy errors coming from the fact that for axis and planes there are "class-properties" defined (e.g. Axis.X). It looks like that is [deprecated in python 3.11](https://docs.python.org/3/whatsnew/3.11.html#language-builtins) relevant issue:  python/cpython#89519.

I think there are three ways to move forward with this:
- setting the values directly on the class (without property). The downside is that those values could be mutable and cause some troubles when modified by the user
- removing the property. Downside: added verbosity
- creating a custom getter class with `__call__()`.
- using some metaclass magic

I can take a look at how to implement one of the later two if changing the signature is not an option for you.