### PR TITLE
add Face.import_stl method

### DIFF
--- a/src/build123d/direct_api.py
+++ b/src/build123d/direct_api.py
@@ -204,6 +204,7 @@ from OCP.NCollection import NCollection_Utf8String
 from OCP.Precision import Precision
 from OCP.Prs3d import Prs3d_IsoAspect
 from OCP.Quantity import Quantity_Color, Quantity_ColorRGBA
+from OCP.RWStl import RWStl
 from OCP.ShapeAnalysis import ShapeAnalysis_FreeBounds
 from OCP.ShapeFix import ShapeFix_Face, ShapeFix_Shape, ShapeFix_Solid
 from OCP.ShapeUpgrade import ShapeUpgrade_UnifySameDomain
@@ -6105,6 +6106,31 @@ class Face(Shape):
         """
         return Compound.make_compound([self]).is_inside(point, tolerance)
 
+    @classmethod
+    def import_stl(cls, file_name: str) -> Face:
+        """import_stl
+
+        Extract shape from an STL file and return them as a Face object.
+
+        Args:
+            file_name (str): file path of STL file to import
+
+        Raises:
+            ValueError: Could not import file
+
+        Returns:
+            Face: contents of STL file
+        """
+        # Now read and return the shape
+        reader = RWStl.ReadFile_s(file_name)
+        face = TopoDS_Face()
+
+        BRep_Builder().MakeFace(face, reader)
+
+        if face.IsNull():
+            raise ValueError(f"Could not import {file_name}")
+
+        return cls.cast(face)
 
 class Shell(Shape):
     """the outer boundary of a surface"""


### PR DESCRIPTION
Uses `RWStl` class from OCP, does not verify that the STL is valid, nor does it "find edges". This is a subclass of Face since that is all we can reliably expect from an STL. This is primarily intended as a method to VIEW STLs alongside build123d objects.

This is a fast native method of OCP, so it handles large STL files easily.