### PR TITLE
setuptools_scm versioning to pip install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Packaging debris
 dist/
 *.egg-info/
+src/build123d/_version.py
 
 # Testing debris
 __pycache__/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+# exclude build123d._dev from sdists
+prune src/build123d/_dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,17 @@
 [build-system]
+
 requires = [
-    "setuptools>=42",
+    "setuptools>=45",
     "wheel",
+    "setuptools_scm[toml]>=6.2",
 ]
+
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "build123d"
-version = "0.1.0"
+#version = "0.1.0" # Uncomment this for the next release?
+dynamic = ["version"]
 authors = [
     {name = "Roger Maitland", email = "gumyr9@gmail.com"},
 ]
@@ -39,3 +43,12 @@ dependencies = [
     "svgpathtools >= 1.5.1, <2",
     "anytree >= 2.8.0, <3"
 ]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+# exclude build123d._dev from wheels
+exclude = ["_dev"]
+
+[tool.setuptools_scm]
+write_to = "src/build123d/_version.py"
+

--- a/src/build123d/__init__.py
+++ b/src/build123d/__init__.py
@@ -17,7 +17,6 @@ __all__ = [
     "Align",
     "AngularDirection",
     "CenterOf",
-    "Direction",
     "FontStyle",
     "FrameMethod",
     "GeomType",

--- a/src/build123d/__init__.py
+++ b/src/build123d/__init__.py
@@ -1,4 +1,4 @@
-from ._version import __version__
+from .version import version as __version__
 from build123d.build_common import *
 from build123d.build_line import *
 from build123d.build_sketch import *

--- a/src/build123d/__init__.py
+++ b/src/build123d/__init__.py
@@ -1,3 +1,4 @@
+from ._version import __version__
 from build123d.build_common import *
 from build123d.build_line import *
 from build123d.build_sketch import *
@@ -16,6 +17,7 @@ __all__ = [
     "Align",
     "AngularDirection",
     "CenterOf",
+    "Direction",
     "FontStyle",
     "FrameMethod",
     "GeomType",

--- a/src/build123d/_dev/scm_version.py
+++ b/src/build123d/_dev/scm_version.py
@@ -1,0 +1,7 @@
+import os.path as pth
+
+try:
+    from setuptools_scm import get_version
+    version = get_version(root=pth.join("..", "..", ".."), relative_to=__file__)
+except Exception:
+    raise ImportError("setuptools_scm broken or not installed")

--- a/src/build123d/version.py
+++ b/src/build123d/version.py
@@ -1,0 +1,15 @@
+try:
+    try:
+        from ._dev.scm_version import version
+    except ImportError:
+        from ._version import version
+except Exception:
+    import warnings
+
+    warnings.warn(
+        f'could not determine {__name__.split(".")[0]} package version; '
+        "this indicates a broken installation"
+    )
+    del warnings
+
+    version = "0.0.0"


### PR DESCRIPTION
Decided to delete the previous PR, as it had a lot of incorrect changes. I tested this PR locally and it worked properly.

The only thing I am not sure of was if this will be properly ignored by tests.

The goal of this is to add something similar to what CadQuery has:
```py
>>> import cadquery as cq
>>> cq.__version__
'2.2.1.dev8+g6c8030d'
```