### PR TITLE
Add Vector.distance_from_plane.

### DIFF
--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -449,9 +449,9 @@ class Vector:
         """Minimum unsigned distance between vector and plane"""
         return plane.wrapped.Distance(self.to_pnt())
 
-    def signed_distance_from_plane(point: Vector, plane: Plane) -> float:
+    def signed_distance_from_plane(self, plane: Plane) -> float:
         """Signed distance from plane to point vector."""
-        return (point - plane.origin).dot(plane.z_dir)
+        return (self - plane.origin).dot(plane.z_dir)
     
     def project_to_plane(self, plane: Plane) -> Vector:
         """Vector is projected onto the plane provided as input.

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -449,6 +449,10 @@ class Vector:
         """Minimum distance between vector and plane"""
         raise NotImplementedError("Have not needed this yet, but OCCT supports it!")
 
+    def distance_from_plane(point: Vector, plane: Plane) -> float:
+        """Signed distance from plane to point vector."""
+        return (point - plane.origin).dot(plane.z_dir)
+    
     def project_to_plane(self, plane: Plane) -> Vector:
         """Vector is projected onto the plane provided as input.
 

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -445,11 +445,11 @@ class Vector:
 
         return line * (self.dot(line) / (line_length * line_length))
 
-    def distance_to_plane(self):
-        """Minimum distance between vector and plane"""
-        raise NotImplementedError("Have not needed this yet, but OCCT supports it!")
+    def distance_to_plane(self, plane: Plane) -> float:
+        """Minimum unsigned distance between vector and plane"""
+        return plane.wrapped.Distance(self.to_pnt())
 
-    def distance_from_plane(point: Vector, plane: Plane) -> float:
+    def signed_distance_from_plane(point: Vector, plane: Plane) -> float:
         """Signed distance from plane to point vector."""
         return (point - plane.origin).dot(plane.z_dir)
     

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -2486,6 +2486,18 @@ class TestVector(DirectApiTestCase):
         self.assertEqual(a, b)
         self.assertEqual(a, c)
 
+    def test_vector_distance(self):
+        """
+        Test line distance from plane.
+        """
+        v = Vector(1,2,3)
+        self.assertAlmostEqual(1, v.distance_from_plane(Plane.YZ))
+        self.assertAlmostEqual(2, v.distance_from_plane(Plane.ZX))
+        self.assertAlmostEqual(3, v.distance_from_plane(Plane.XY))
+        self.assertAlmostEqual(-1, v.distance_from_plane(Plane.ZY))
+        self.assertAlmostEqual(-2, v.distance_from_plane(Plane.XZ))
+        self.assertAlmostEqual(-3, v.distance_from_plane(Plane.YX))
+
     def test_vector_project(self):
         """
         Test line projection and plane projection methods of Vector

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -2537,9 +2537,7 @@ class TestVector(DirectApiTestCase):
         )
 
     def test_vector_not_implemented(self):
-        v = Vector(1, 2, 3)
-        with self.assertRaises(NotImplementedError):
-            v.distance_to_plane()
+        pass
 
     def test_vector_special_methods(self):
         v = Vector(1, 2, 3)

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -2491,12 +2491,20 @@ class TestVector(DirectApiTestCase):
         Test line distance from plane.
         """
         v = Vector(1,2,3)
-        self.assertAlmostEqual(1, v.distance_from_plane(Plane.YZ))
-        self.assertAlmostEqual(2, v.distance_from_plane(Plane.ZX))
-        self.assertAlmostEqual(3, v.distance_from_plane(Plane.XY))
-        self.assertAlmostEqual(-1, v.distance_from_plane(Plane.ZY))
-        self.assertAlmostEqual(-2, v.distance_from_plane(Plane.XZ))
-        self.assertAlmostEqual(-3, v.distance_from_plane(Plane.YX))
+
+        self.assertAlmostEqual(1, v.signed_distance_from_plane(Plane.YZ))
+        self.assertAlmostEqual(2, v.signed_distance_from_plane(Plane.ZX))
+        self.assertAlmostEqual(3, v.signed_distance_from_plane(Plane.XY))
+        self.assertAlmostEqual(-1, v.signed_distance_from_plane(Plane.ZY))
+        self.assertAlmostEqual(-2, v.signed_distance_from_plane(Plane.XZ))
+        self.assertAlmostEqual(-3, v.signed_distance_from_plane(Plane.YX))
+
+        self.assertAlmostEqual(1, v.distance_to_plane(Plane.YZ))
+        self.assertAlmostEqual(2, v.distance_to_plane(Plane.ZX))
+        self.assertAlmostEqual(3, v.distance_to_plane(Plane.XY))
+        self.assertAlmostEqual(1, v.distance_to_plane(Plane.ZY))
+        self.assertAlmostEqual(2, v.distance_to_plane(Plane.XZ))
+        self.assertAlmostEqual(3, v.distance_to_plane(Plane.YX))
 
     def test_vector_project(self):
         """


### PR DESCRIPTION
I added this new function instead of adding implementation to `Vector.distance_to_plane`.
`distance_to_plane` says `raise NotImplementedError("Have not needed this yet, but OCCT supports it!")` which implied that the implementation would be passed down to OCCT, but I did not see an appropriate function to call upon.  Also, it was not clear to me if `distance_to_plane` was meant to be an unsigned distance.  For those reasons, I left it alone and added `distance_from_plane` that returns a signed distance.