### PR TITLE
re-fix PolarLine elif angle is not None

### DIFF
--- a/src/build123d/objects_curve.py
+++ b/src/build123d/objects_curve.py
@@ -485,7 +485,7 @@ class PolarLine(BaseLineObject):
         if direction:
             direction = WorkplaneList.localize(direction)
             angle = Vector(1, 0, 0).get_angle(direction)
-        elif angle:
+        elif angle is not None:
             direction = polar_workplane.x_dir.rotate(
                 Axis((0, 0, 0), polar_workplane.z_dir),
                 angle,


### PR DESCRIPTION
not sure if the prior change from a few days ago was intentionally reverted, but here it is again applied to objects_curve.py