### PR TITLE
Fixing links in documentation to work with the new algebra big rename

### DIFF
--- a/docs/build_line.rst
+++ b/docs/build_line.rst
@@ -117,7 +117,7 @@ BuildLine to BuildSketch
 As mentioned previously, one of the two primary reasons to create BuildLine objects is to
 use them in BuildSketch.  When a BuildLine context manager exits and is within the scope of a
 BuildSketch context manager it will transfer the generated line to BuildSketch. The BuildSketch
-:class:`~build_sketch.MakeFace` or :class:`~build_sketch.MakeHull`  operations are then used
+:meth:`~operations_sketch.make_face` or :meth:`~operations_sketch.make_hull`  operations are then used
 to transform the line (specifically a list of Edges) into a Face - the native BuildSketch
 objects.
 
@@ -152,7 +152,7 @@ BuildLine to BuildPart
 **********************
 
 The other primary reasons to use BuildLine is to create paths for BuildPart
-:class:`~build_part.Sweep` operations. Here some curved and straight segments
+:meth:`~operations_part.sweep` operations. Here some curved and straight segments
 define a path:
 
 .. literalinclude:: buildline_examples.py
@@ -184,91 +184,91 @@ The following objects all can be used in BuildLine contexts.
 
 .. grid:: 3
 
-    .. grid-item-card:: :class:`~build_line.Bezier`
+    .. grid-item-card:: :class:`~objects_curve.Bezier`
 
         .. image:: assets/bezier_curve_example.svg
 
         +++
         Curve defined by control points and weights
 
-    .. grid-item-card:: :class:`~build_line.CenterArc`
+    .. grid-item-card:: :class:`~objects_curve.CenterArc`
 
         .. image:: assets/center_arc_example.svg
 
         +++
         Arc defined by center, radius, & angles
 
-    .. grid-item-card:: :class:`~build_line.EllipticalCenterArc`
+    .. grid-item-card:: :class:`~objects_curve.EllipticalCenterArc`
 
         .. image:: assets/elliptical_center_arc_example.svg
 
         +++
         Elliptical arc defined by center,  radii & angles
 
-    .. grid-item-card:: :class:`~build_line.Helix`
+    .. grid-item-card:: :class:`~objects_curve.Helix`
 
         .. image:: assets/helix_example.svg
 
         +++
         Helix defined pitch, radius and height
 
-    .. grid-item-card:: :class:`~build_line.JernArc`
+    .. grid-item-card:: :class:`~objects_curve.JernArc`
 
         .. image:: assets/jern_arc_example.svg
 
         +++
         Arc define by start point, tangent, radius and angle
 
-    .. grid-item-card:: :class:`~build_line.Line`
+    .. grid-item-card:: :class:`~objects_curve.Line`
 
         .. image:: assets/line_example.svg
 
         +++
         Line defined by end points
 
-    .. grid-item-card:: :class:`~build_line.PolarLine`
+    .. grid-item-card:: :class:`~objects_curve.PolarLine`
 
         .. image:: assets/polar_line_example.svg
 
         +++
         Line defined by start, angle and length
 
-    .. grid-item-card:: :class:`~build_line.Polyline`
+    .. grid-item-card:: :class:`~objects_curve.Polyline`
 
         .. image:: assets/polyline_example.svg
 
         +++
         Multiple line segments defined by points
 
-    .. grid-item-card:: :class:`~build_line.RadiusArc`
+    .. grid-item-card:: :class:`~objects_curve.RadiusArc`
 
         .. image:: assets/radius_arc_example.svg
 
         +++
         Arc define by two points and a radius
 
-    .. grid-item-card:: :class:`~build_line.SagittaArc`
+    .. grid-item-card:: :class:`~objects_curve.SagittaArc`
 
         .. image:: assets/sagitta_arc_example.svg
 
         +++
         Arc define by two points and a sagitta
 
-    .. grid-item-card:: :class:`~build_line.Spline`
+    .. grid-item-card:: :class:`~objects_curve.Spline`
 
         .. image:: assets/spline_example.svg
 
         +++
         Curve define by points
 
-    .. grid-item-card:: :class:`~build_line.TangentArc`
+    .. grid-item-card:: :class:`~objects_curve.TangentArc`
 
         .. image:: assets/tangent_arc_example.svg
 
         +++
         Curve define by two points and a tangent
 
-    .. grid-item-card:: :class:`~build_line.ThreePointArc`
+    .. grid-item-card:: :class:`~objects_curve.ThreePointArc`
 
         .. image:: assets/three_point_arc_example.svg
 

--- a/docs/cheat_sheet.rst
+++ b/docs/cheat_sheet.rst
@@ -16,46 +16,46 @@ Cheat Sheet
 
         .. grid-item-card:: 1D - BuildLine
 
-            | :class:`~build_generic.Add`
-            | :class:`~build_line.Bezier`
-            | :class:`~build_line.CenterArc`
-            | :class:`~build_line.EllipticalCenterArc`
-            | :class:`~build_line.Helix`
-            | :class:`~build_line.JernArc`
-            | :class:`~build_line.Line`
-            | :class:`~build_line.PolarLine`
-            | :class:`~build_line.Polyline`
-            | :class:`~build_line.RadiusArc`
-            | :class:`~build_line.SagittaArc`
-            | :class:`~build_line.Spline`
-            | :class:`~build_line.TangentArc`
-            | :class:`~build_line.ThreePointArc`
+            | :meth:`~operations_generic.add`
+            | :class:`~objects_curve.Bezier`
+            | :class:`~objects_curve.CenterArc`
+            | :class:`~objects_curve.EllipticalCenterArc`
+            | :class:`~objects_curve.Helix`
+            | :class:`~objects_curve.JernArc`
+            | :class:`~objects_curve.Line`
+            | :class:`~objects_curve.PolarLine`
+            | :class:`~objects_curve.Polyline`
+            | :class:`~objects_curve.RadiusArc`
+            | :class:`~objects_curve.SagittaArc`
+            | :class:`~objects_curve.Spline`
+            | :class:`~objects_curve.TangentArc`
+            | :class:`~objects_curve.ThreePointArc`
 
         .. grid-item-card:: 2D - BuildSketch
 
-            | :class:`~build_generic.Add`
-            | :class:`~build_sketch.Circle`
-            | :class:`~build_sketch.Ellipse`
-            | :class:`~build_sketch.Polygon`
-            | :class:`~build_sketch.Rectangle`
-            | :class:`~build_sketch.RectangleRounded`
-            | :class:`~build_sketch.RegularPolygon`
-            | :class:`~build_sketch.SlotArc`
-            | :class:`~build_sketch.SlotCenterPoint`
-            | :class:`~build_sketch.SlotCenterToCenter`
-            | :class:`~build_sketch.SlotOverall`
-            | :class:`~build_sketch.Text`
-            | :class:`~build_sketch.Trapezoid`
+            | :meth:`~operations_generic.add`
+            | :class:`~objects_sketch.Circle`
+            | :class:`~objects_sketch.Ellipse`
+            | :class:`~objects_sketch.Polygon`
+            | :class:`~objects_sketch.Rectangle`
+            | :class:`~objects_sketch.RectangleRounded`
+            | :class:`~objects_sketch.RegularPolygon`
+            | :class:`~objects_sketch.SlotArc`
+            | :class:`~objects_sketch.SlotCenterPoint`
+            | :class:`~objects_sketch.SlotCenterToCenter`
+            | :class:`~objects_sketch.SlotOverall`
+            | :class:`~objects_sketch.Text`
+            | :class:`~objects_sketch.Trapezoid`
 
         .. grid-item-card:: 3D - BuildPart
 
-            | :class:`~build_generic.Add`
-            | :class:`~build_part.Box`
-            | :class:`~build_part.Cone`
-            | :class:`~build_part.Cylinder`
-            | :class:`~build_part.Sphere`
-            | :class:`~build_part.Torus`
-            | :class:`~build_part.Wedge`
+            | :meth:`~operations_generic.add`
+            | :class:`~objects_part.Box`
+            | :class:`~objects_part.Cone`
+            | :class:`~objects_part.Cylinder`
+            | :class:`~objects_part.Sphere`
+            | :class:`~objects_part.Torus`
+            | :class:`~objects_part.Wedge`
 
 .. card:: Operations
 
@@ -63,38 +63,38 @@ Cheat Sheet
 
         .. grid-item-card:: 1D - BuildLine
 
-            | :class:`~build_generic.BoundingBox`
-            | :class:`~build_generic.Chamfer`
-            | :class:`~build_generic.Mirror`
-            | :class:`~build_generic.Offset`
-            | :class:`~build_generic.Scale`
-            | :class:`~build_generic.Split`
+            | :class:`~geometry.BoundBox`
+            | :meth:`~operations_generic.chamfer`
+            | :meth:`~operations_generic.mirror`
+            | :meth:`~operations_generic.offset`
+            | :meth:`~operations_generic.scale`
+            | :meth:`~operations_generic.split`
 
         .. grid-item-card:: 2D - BuildSketch
 
-            | :class:`~build_generic.Fillet`
-            | :class:`~build_sketch.MakeFace`
-            | :class:`~build_sketch.MakeHull`
-            | :class:`~build_generic.Mirror`
-            | :class:`~build_generic.Offset`
-            | :class:`~build_generic.Scale`
-            | :class:`~build_generic.Split`
+            | :meth:`~operations_generic.fillet`
+            | :meth:`~operations_sketch.make_face`
+            | :meth:`~operations_sketch.make_hull`
+            | :meth:`~operations_generic.mirror`
+            | :meth:`~operations_generic.offset`
+            | :meth:`~operations_generic.scale`
+            | :meth:`~operations_generic.split`
 
         .. grid-item-card:: 3D - BuildPart
 
-            | :class:`~build_part.CounterBoreHole`
-            | :class:`~build_part.CounterSinkHole`
-            | :class:`~build_part.Extrude`
-            | :class:`~build_part.Hole`
-            | :class:`~build_part.Loft`
-            | :class:`~build_generic.Fillet`
-            | :class:`~build_generic.Mirror`
-            | :class:`~build_generic.Offset`
-            | :class:`~build_part.Revolve`
-            | :class:`~build_generic.Scale`
-            | :class:`~build_part.Section`
-            | :class:`~build_generic.Split`
-            | :class:`~build_part.Sweep`
+            | :class:`~objects_part.CounterBoreHole`
+            | :class:`~objects_part.CounterSinkHole`
+            | :meth:`~operations_part.extrude`
+            | :class:`~objects_part.Hole`
+            | :meth:`~operations_part.loft`
+            | :meth:`~operations_generic.fillet`
+            | :meth:`~operations_generic.mirror`
+            | :meth:`~operations_generic.offset`
+            | :meth:`~operations_part.revolve`
+            | :meth:`~operations_generic.scale`
+            | :meth:`~operations_part.section`
+            | :meth:`~operations_generic.split`
+            | :meth:`~operations_part.sweep`
 
 .. card:: Selectors
 
@@ -126,13 +126,13 @@ Cheat Sheet
     +----------+------------------------------------------------------------+---------------------------------------------------+
     | Operator | Operand                                                    | Method                                            |
     +==========+============================================================+===================================================+
-    | >        | :class:`~build_enums.SortBy`, :class:`~build_common.Axis`  | :meth:`~topology.ShapeList.sort_by`               |
+    | >        | :class:`~build_enums.SortBy`, :class:`~geometry.Axis`  | :meth:`~topology.ShapeList.sort_by`               |
     +----------+------------------------------------------------------------+---------------------------------------------------+
-    | <        | :class:`~build_enums.SortBy`, :class:`~build_common.Axis`  | :meth:`~topology.ShapeList.sort_by`               |
+    | <        | :class:`~build_enums.SortBy`, :class:`~geometry.Axis`  | :meth:`~topology.ShapeList.sort_by`               |
     +----------+------------------------------------------------------------+---------------------------------------------------+
-    | >>       | :class:`~build_enums.SortBy`, :class:`~build_common.Axis`  | :meth:`~topology.ShapeList.group_by`\[-1\]        |
+    | >>       | :class:`~build_enums.SortBy`, :class:`~geometry.Axis`  | :meth:`~topology.ShapeList.group_by`\[-1\]        |
     +----------+------------------------------------------------------------+---------------------------------------------------+
-    | <<       | :class:`~build_enums.SortBy`, :class:`~build_common.Axis`  | :meth:`~topology.ShapeList.group_by`\[0\]         |
+    | <<       | :class:`~build_enums.SortBy`, :class:`~geometry.Axis`  | :meth:`~topology.ShapeList.group_by`\[0\]         |
     +----------+------------------------------------------------------------+---------------------------------------------------+
     | \|       | :class:`~geometry.Axis`, :class:`~build_enums.GeomType`    | :meth:`~topology.ShapeList.filter_by`             |
     +----------+------------------------------------------------------------+---------------------------------------------------+

--- a/docs/cheat_sheet.rst
+++ b/docs/cheat_sheet.rst
@@ -126,13 +126,13 @@ Cheat Sheet
     +----------+------------------------------------------------------------+---------------------------------------------------+
     | Operator | Operand                                                    | Method                                            |
     +==========+============================================================+===================================================+
-    | >        | :class:`~build_enums.SortBy`, :class:`~geometry.Axis`  | :meth:`~topology.ShapeList.sort_by`               |
+    | >        | :class:`~build_enums.SortBy`, :class:`~geometry.Axis`      | :meth:`~topology.ShapeList.sort_by`               |
     +----------+------------------------------------------------------------+---------------------------------------------------+
-    | <        | :class:`~build_enums.SortBy`, :class:`~geometry.Axis`  | :meth:`~topology.ShapeList.sort_by`               |
+    | <        | :class:`~build_enums.SortBy`, :class:`~geometry.Axis`      | :meth:`~topology.ShapeList.sort_by`               |
     +----------+------------------------------------------------------------+---------------------------------------------------+
-    | >>       | :class:`~build_enums.SortBy`, :class:`~geometry.Axis`  | :meth:`~topology.ShapeList.group_by`\[-1\]        |
+    | >>       | :class:`~build_enums.SortBy`, :class:`~geometry.Axis`      | :meth:`~topology.ShapeList.group_by`\[-1\]        |
     +----------+------------------------------------------------------------+---------------------------------------------------+
-    | <<       | :class:`~build_enums.SortBy`, :class:`~geometry.Axis`  | :meth:`~topology.ShapeList.group_by`\[0\]         |
+    | <<       | :class:`~build_enums.SortBy`, :class:`~geometry.Axis`      | :meth:`~topology.ShapeList.group_by`\[0\]         |
     +----------+------------------------------------------------------------+---------------------------------------------------+
     | \|       | :class:`~geometry.Axis`, :class:`~build_enums.GeomType`    | :meth:`~topology.ShapeList.filter_by`             |
     +----------+------------------------------------------------------------+---------------------------------------------------+

--- a/docs/introductory_examples.rst
+++ b/docs/introductory_examples.rst
@@ -25,7 +25,7 @@ They are organized from simple to complex, so working through them in order is t
 1. Simple Rectangular Plate
 ---------------------------------------------------
 
-Just about the simplest possible example, a rectangular :class:`~build_part.Box`.
+Just about the simplest possible example, a rectangular :class:`~objects_part.Box`.
 
 .. image:: assets/general_ex1.svg
     :align: center
@@ -84,7 +84,7 @@ Build a prismatic solid using extrusion.
 
     This time we can first create a 2D :class:`~build_sketch.BuildSketch` adding a
     :class:`~objects_sketch.Circle` and a subtracted :class:`~objects_sketch.Rectangle``
-    and then use :class:`~build_part.BuildPart`'s :class:`~operations_part.extrude` feature.
+    and then use :class:`~build_part.BuildPart`'s :meth:`~operations_part.extrude` feature.
 
     .. literalinclude:: general_examples.py
         :start-after: [Ex. 3]
@@ -93,7 +93,7 @@ Build a prismatic solid using extrusion.
 * **Algebra mode**
 
     This time we can first create a 2D :class:`~objects_sketch.Circle` with a subtracted
-    :class:`~objects_sketch.Rectangle`` and then use the :class:`~operations_part.extrude` operation for parts.
+    :class:`~objects_sketch.Rectangle`` and then use the :meth:`~operations_part.extrude` operation for parts.
 
     .. literalinclude:: general_examples_algebra.py
         :start-after: [Ex. 3]
@@ -113,7 +113,7 @@ variables for the line segments, but it will be useful in a later example.
 * **Builder mode**
 
     :class:`~build_sketch.BuildSketch` operates on closed Faces, and the operation
-    :class:`~operations_sketch.make_face` is used to convert the pending line segments
+    :meth:`~operations_sketch.make_face` is used to convert the pending line segments
     from :class:`~build_line.BuildLine` into a closed Face.
 
     .. literalinclude:: general_examples.py
@@ -125,7 +125,7 @@ variables for the line segments, but it will be useful in a later example.
     We start with an empty :class:`~topology.Curve` and add lines to it (note that
     ``Curve() + [line1, line2, line3]`` is much more efficient than ``line1 + line2 + line3``,
     see :ref:`algebra_performance`).
-    The operation :class:`~operations_sketch.make_face` is used to convert the line
+    The operation :meth:`~operations_sketch.make_face` is used to convert the line
     segments into a Face.
 
     .. literalinclude:: general_examples_algebra.py
@@ -219,9 +219,9 @@ Sometimes you need to create a number of features at various
 8. Polylines
 ---------------------------------------------------
 
-:class:`~objects_line.Polyline` allows creating a shape from a large number
+:class:`~objects_curve.Polyline` allows creating a shape from a large number
 of chained points connected by lines. This example uses a polyline to create
-one half of an i-beam shape, which is :class:`~operations_generic.mirror` ed to
+one half of an i-beam shape, which is :meth:`~operations_generic.mirror` ed to
 create the final profile.
 
 .. image:: assets/general_ex8.svg
@@ -243,8 +243,8 @@ create the final profile.
 9. Selectors, Fillets, and Chamfers
 ---------------------------------------------------
 
-This example introduces multiple useful and important concepts. Firstly :class:`~operations_generic.chamfer`
-and :class:`~operations_generic.fillet` can be used to "bevel" and "round" edges respectively. Secondly,
+This example introduces multiple useful and important concepts. Firstly :meth:`~operations_generic.chamfer`
+and :meth:`~operations_generic.fillet` can be used to "bevel" and "round" edges respectively. Secondly,
 these two methods require an edge or a list of edges to operate on. To select all
 edges, you could simply pass in ``*ex9.edges()`` (the star ``*`` operator unpacks the list).
 
@@ -278,7 +278,7 @@ be the highest z-dimension group.
 * **Builder mode**
 
     Using :class:`~build_enums.Select` ``.LAST`` you can select the most recently modified edges.
-    It is used to perform a :class:`~operations_generic.fillet` in this example. This example also
+    It is used to perform a :meth:`~operations_generic.fillet` in this example. This example also
     makes use of :class:`~objects_part.Hole` which automatically cuts through the entire part.
 
     .. literalinclude:: general_examples.py
@@ -289,7 +289,7 @@ be the highest z-dimension group.
 
     Using the pattern ``snapshot = obj.edges()`` before and ``last_edges = obj.edges() - snapshot`` after an
     operation allows to select the most recently modified edges (same for ``faces``, ``vertices``, ...).
-    It is used to perform a :class:`~operations_generic.fillet` in this example. This example also makes use
+    It is used to perform a :meth:`~operations_generic.fillet` in this example. This example also makes use
     of :class:`~objects_part.Hole`. Different to the *context mode*, you have to add the ``depth`` of the whole.
 
     .. literalinclude:: general_examples_algebra.py
@@ -312,7 +312,7 @@ be the highest z-dimension group.
     can be used to create a grid of points that are simultaneously used to place 4
     pentagons.
 
-    Lastly, :class:`~operations_part.extrude` can be used with a negative amount and ``Mode.SUBTRACT`` to
+    Lastly, :meth:`~operations_part.extrude` can be used with a negative amount and ``Mode.SUBTRACT`` to
     cut these from the parent.
 
     .. literalinclude:: general_examples.py
@@ -328,7 +328,7 @@ be the highest z-dimension group.
     :class:`~build_common.GridLocations` creates a grid of points that can be used in loops or list
     comprehensions as described earlier.
 
-    Lastly, :class:`~objects_part.extrude` can be used with a negative amount and cut (``-``) from the
+    Lastly, :meth:`~operations_part.extrude` can be used with a negative amount and cut (``-``) from the
     parent.
 
     .. literalinclude:: general_examples_algebra.py
@@ -407,9 +407,9 @@ consuming, and more difficult to maintain.
 
 * **Builder mode**
 
-    The :class:`~operations_part.sweep` method takes any pending faces and sweeps them through the provided
+    The :meth:`~operations_part.sweep` method takes any pending faces and sweeps them through the provided
     path (in this case the path is taken from the pending edges from ``ex14_ln``).
-    :class:`~operations_part.revolve` requires a single connected wire. The pending faces must lie on the
+    :meth:`~operations_part.revolve` requires a single connected wire. The pending faces must lie on the
     path.
 
     .. literalinclude:: general_examples.py
@@ -418,7 +418,7 @@ consuming, and more difficult to maintain.
 
 * **Algebra mode**
 
-    The :class:`~operations_part.sweep` method takes any faces and sweeps them through the provided
+    The :meth:`~operations_part.sweep` method takes any faces and sweeps them through the provided
     path (in this case the path is taken from the pending edges from ``ex14_ln``).
 
     .. literalinclude:: general_examples_algebra.py
@@ -661,7 +661,7 @@ It is highly recommended to view your sketch before you attempt to call revolve.
 
 Loft is a very powerful tool that can be used to join dissimilar shapes. In this case we make a
 conical-like shape from a circle and a rectangle that is offset vertically. In this case
-:class:`~operations_part.loft` automatically takes the pending faces that were added by the two BuildSketches.
+:meth:`~operations_part.loft` automatically takes the pending faces that were added by the two BuildSketches.
 Loft can behave unexpectedly when the input faces are not parallel to each other.
 
 .. image:: assets/general_ex24.svg
@@ -688,7 +688,7 @@ Loft can behave unexpectedly when the input faces are not parallel to each other
 
 * **Builder mode**
 
-    BuildSketch faces can be transformed with a 2D :class:`~operations_generic.offset`.
+    BuildSketch faces can be transformed with a 2D :meth:`~operations_generic.offset`.
 
     .. literalinclude:: general_examples.py
         :start-after: [Ex. 25]
@@ -696,7 +696,7 @@ Loft can behave unexpectedly when the input faces are not parallel to each other
 
 * **Algebra mode**
 
-    Sketch faces can be transformed with a 2D :class:`~operations_generic.offset`.
+    Sketch faces can be transformed with a 2D :meth:`~operations_generic.offset`.
 
     .. literalinclude:: general_examples_algebra.py
         :start-after: [Ex. 25]
@@ -710,9 +710,9 @@ corners (see :class:`~build_enums.Kind` in the Offset docs).
 ---------------------------------------------------
 
 Parts can also be transformed using an offset, but in this case with
-a 3D :class:`~operations_generic.offset`. Also commonly known as a shell, this allows creating thin walls
+a 3D :meth:`~operations_generic.offset`. Also commonly known as a shell, this allows creating thin walls
 using very few operations. This can also be offset inwards or outwards. Faces can be selected to be
-"deleted" using the ``openings`` parameter of :class:`~operations_generic.offset`.
+"deleted" using the ``openings`` parameter of :meth:`~operations_generic.offset`.
 
 Note that self intersecting edges and/or faces can break both 2D and 3D offsets.
 
@@ -854,7 +854,7 @@ rotates any "children" groups by default.
 
 In this example, a standard python for-loop is used along with a list of faces extracted from a sketch
 to progressively modify the extrusion amount. There are 7 faces in the sketch, so this results in 7
-separate calls to :class:`~operations_part.extrude`.
+separate calls to :meth:`~operations_part.extrude`.
 
 .. image:: assets/general_ex32.svg
     :align: center
@@ -940,7 +940,7 @@ progressively modify the size of each square.
 * **Builder mode**
 
     Here we create a :class:`~objects_sketch.SlotCenterToCenter` and then use a
-    :class:`~build_line.BuildLine` and :class:`~build_line.RadiusArc` to create an
+    :class:`~build_line.BuildLine` and :class:`~objects_curve.RadiusArc` to create an
     arc for two instances of :class:`~objects_sketch.SlotArc`.
 
     .. literalinclude:: general_examples.py
@@ -950,7 +950,7 @@ progressively modify the size of each square.
 * **Algebra mode**
 
     Here we create a :class:`~objects_sketch.SlotCenterToCenter` and then use
-    a :class:`~objects_line.RadiusArc` to create an arc for two instances of :class:`~operations_sketch.SlotArc`.
+    a :class:`~objects_curve.RadiusArc` to create an arc for two instances of :class:`~operations_sketch.SlotArc`.
 
     .. literalinclude:: general_examples_algebra.py
         :start-after: [Ex. 35]
@@ -962,7 +962,7 @@ progressively modify the size of each square.
 
 Sometimes you will want to extrude until a given face that could be non planar or
 where you might not know easily the distance you have to extrude to. In such
-cases you can use :class:`~operations_part.extrude` :class:`~build_enums.Until`
+cases you can use :meth:`~operations_part.extrude` :class:`~build_enums.Until`
 with ``Until.NEXT`` or ``Until.LAST``.
 
 .. image:: assets/general_ex36.svg

--- a/docs/selectors.rst
+++ b/docs/selectors.rst
@@ -60,7 +60,7 @@ ShapeList Class
 ---------------
 
 The builders include methods to extract Edges, Faces, Solids, Vertices, or Wires from the objects
-they are building. All of these methods return objects of a subclass of `list`, a :class:`~geometry.ShapeList` with
+they are building. All of these methods return objects of a subclass of `list`, a :class:`~topology.ShapeList` with
 custom filtering and sorting methods and operations as follows.
 
 Custom Sorting and Filtering

--- a/docs/tutorial_joints.rst
+++ b/docs/tutorial_joints.rst
@@ -92,7 +92,7 @@ or lid.
 Each joint has a label which identifies it - here the string "leaf" is used, the ``to_part``
 binds the joint to ``leaf_builder.part`` (i.e. the part being built), and ``joint_location``
 is specified as middle of the leaf along the edge of the pin. Note that
-:class:`~topology.Location` objects describe both a position and orientation which is
+:class:`~geometry.Location` objects describe both a position and orientation which is
 why there are two tuples (the orientation listed is rotate about the X axis 90 degrees).
 
 Step 3b: Hinge Joint
@@ -173,8 +173,8 @@ attached and is independent of the orientation of the hinge as it was constructe
 Step 4a: Relocate Box
 ---------------------
 
-Note that the position and orientation of the box's joints are given as a global :class:`~topology.Location`
-when created but will be translated to a relative :class:`~topology.Location` internally to allow the :class:`~topology.Joint`
+Note that the position and orientation of the box's joints are given as a global :class:`~geometry.Location`
+when created but will be translated to a relative :class:`~geometry.Location` internally to allow the :class:`~topology.Joint`
 to "move" with the parent object. This allows users the freedom to relocate objects without
 having to recreate or modify :class:`~topology.Joint`'s. Here is the box is moved upwards to show this
 property.
@@ -293,7 +293,7 @@ Conclusion
 
 Use a :class:`~topology.Joint` to locate two objects relative to each other with some degree of motion.
 Keep in mind that when using the ``connect_to`` method, ``self`` is always fixed
-and ``other`` will move to the appropriate :class:`~topology.Location`.
+and ``other`` will move to the appropriate :class:`~geometry.Location`.
 
 .. note::
 


### PR DESCRIPTION
This is untested due to me not knowing how to set up mocked RST docs, so please test.