### PR TITLE
match target types for extrude with extrude-until

### DIFF
--- a/src/build123d/operations_part.py
+++ b/src/build123d/operations_part.py
@@ -61,7 +61,7 @@ def extrude(
     amount: float = None,
     dir: VectorLike = None,
     until: Until = None,
-    target: Shape = None,
+    target: Union[Compound, Solid] = None,
     both: bool = False,
     taper: float = 0.0,
     clean: bool = True,


### PR DESCRIPTION
I have not tested this, but it seems logical that the target type for extrude should match extrude-until.