### PR TITLE
fix Wire.offset_2d inheritance bug

### DIFF
--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -6065,9 +6065,9 @@ class Wire(Shape, Mixin1D):
         obj = downcast(offset.Shape())
 
         if isinstance(obj, TopoDS_Compound):
-            return_value = [self.__class__(el.wrapped) for el in Compound(obj)]
+            return_value = [Wire(el.wrapped) for el in Compound(obj)]
         else:
-            return_value = [self.__class__(obj)]
+            return_value = [Wire(obj)]
 
         return return_value
 


### PR DESCRIPTION
when offset_2d is called on an inheritance class of Wire, the inherited constructor is called and fails.
With this PR the result of offset_2d is always a list[Wire]

before:

``` python
arc=bd.CenterArc(center=(0,0), radius=24, start_angle=180, arc_size=180)
arc.offset_2d(distance=8)

---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[5], line 2
      1 arc=bd.CenterArc(center=(0,0), radius=24, start_angle=180, arc_size=180)
----> 2 arc.offset_2d(distance=8)[0]

File [~/dev/cad/build123d/src/build123d/topology.py:6076](https://file+.vscode-resource.vscode-cdn.net/home/simon/Nextcloud/airg/equipment/random/~/dev/cad/build123d/src/build123d/topology.py:6076), in Wire.offset_2d(self, distance, kind)
   6074     return_value = [self.__class__(el.wrapped) for el in Compound(obj)]
   6075 else:
-> 6076     return_value = [self.__class__(obj)]
   6078 return return_value

TypeError: CenterArc.__init__() missing 3 required positional arguments: 'radius', 'start_angle', and 'arc_size'

```

this could be circumvented by doing arc.wires()[0].offset_2d but is not an elegant way. especially with #261 