### PR TITLE
Make build123d default planes match OCP CAD Viewer

### DIFF
--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -1353,12 +1353,12 @@ class Plane:
     XZ      +x     +z     -y
     YX      +y     +x     -z
     ZY      +z     +y     -x
-    front   +x     +y     +z
-    back    -x     +y     -z
-    left    +z     +y     -x
-    right   -z     +y     +x
-    top     +x     -z     +y
-    bottom  +x     +z     -y
+    front   +x     +z     -y
+    back    -x     +z     -y
+    left    -y     +z     -x
+    right   +y     +z     +x
+    top     +x     +y     +z
+    bottom  +x     -y     -z
     ======= ====== ====== ======
 
     Args:
@@ -1419,37 +1419,37 @@ class Plane:
     @property
     def front(cls) -> Plane:
         """Front Plane"""
-        return Plane((0, 0, 0), (1, 0, 0), (0, 0, 1))
+        return Plane((0, 0, 0), (1, 0, 0), (0, -1, 0))
 
     @classmethod
     @property
     def back(cls) -> Plane:
         """Back Plane"""
-        return Plane((0, 0, 0), (-1, 0, 0), (0, 0, -1))
+        return Plane((0, 0, 0), (-1, 0, 0), (0, 1, 0))
 
     @classmethod
     @property
     def left(cls) -> Plane:
         """Left Plane"""
-        return Plane((0, 0, 0), (0, 0, 1), (-1, 0, 0))
+        return Plane((0, 0, 0), (0, -1, 0), (-1, 0, 0))
 
     @classmethod
     @property
     def right(cls) -> Plane:
         """Right Plane"""
-        return Plane((0, 0, 0), (0, 0, -1), (1, 0, 0))
+        return Plane((0, 0, 0), (0, 1, 0), (1, 0, 0))
 
     @classmethod
     @property
     def top(cls) -> Plane:
         """Top Plane"""
-        return Plane((0, 0, 0), (1, 0, 0), (0, 1, 0))
+        return Plane((0, 0, 0), (1, 0, 0), (0, 0, 1))
 
     @classmethod
     @property
     def bottom(cls) -> Plane:
         """Bottom Plane"""
-        return Plane((0, 0, 0), (1, 0, 0), (0, -1, 0))
+        return Plane((0, 0, 0), (1, 0, 0), (0, 0, -1))
 
     @staticmethod
     def get_topods_face_normal(face: TopoDS_Face) -> Vector:

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -1354,7 +1354,7 @@ class Plane:
     YX      +y     +x     -z
     ZY      +z     +y     -x
     front   +x     +z     -y
-    back    -x     +z     -y
+    back    -x     +z     +y
     left    -y     +z     -x
     right   +y     +z     +x
     top     +x     +y     +z

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -1795,20 +1795,20 @@ class TestPlane(DirectApiTestCase):
 
     def test_class_properties(self):
         """Validate
-        Name        xDir    yDir    zDir
-        =========== ======= ======= ======
-        XY          +x      +y      +z
-        YZ          +y      +z      +x
-        ZX          +z      +x      +y
-        XZ          +x      +z      -y
-        YX          +y      +x      -z
-        ZY          +z      +y      -x
-        front       +x      +y      +z
-        back        -x      +y      -z
-        left        +z      +y      -x
-        right       -z      +y      +x
-        top         +x      -z      +y
-        bottom      +x      +z      -y
+        Name    x_dir  y_dir  z_dir
+        ======= ====== ====== ======
+        XY      +x     +y     +z
+        YZ      +y     +z     +x
+        ZX      +z     +x     +y
+        XZ      +x     +z     -y
+        YX      +y     +x     -z
+        ZY      +z     +y     -x
+        front   +x     +z     -y
+        back    -x     +z     +y
+        left    -y     +z     -x
+        right   +y     +z     +x
+        top     +x     +y     +z
+        bottom  +x     -y     -z
         """
         planes = [
             (Plane.XY, (1, 0, 0), (0, 0, 1)),
@@ -1817,12 +1817,12 @@ class TestPlane(DirectApiTestCase):
             (Plane.XZ, (1, 0, 0), (0, -1, 0)),
             (Plane.YX, (0, 1, 0), (0, 0, -1)),
             (Plane.ZY, (0, 0, 1), (-1, 0, 0)),
-            (Plane.front, (1, 0, 0), (0, 0, 1)),
-            (Plane.back, (-1, 0, 0), (0, 0, -1)),
-            (Plane.left, (0, 0, 1), (-1, 0, 0)),
-            (Plane.right, (0, 0, -1), (1, 0, 0)),
-            (Plane.top, (1, 0, 0), (0, 1, 0)),
-            (Plane.bottom, (1, 0, 0), (0, -1, 0)),
+            (Plane.front, (1, 0, 0), (0, -1, 0)),
+            (Plane.back, (-1, 0, 0), (0, 1, 0)),
+            (Plane.left, (0, -1, 0), (-1, 0, 0)),
+            (Plane.right, (0, 1, 0), (1, 0, 0)),
+            (Plane.top, (1, 0, 0), (0, 0, 1)),
+            (Plane.bottom, (1, 0, 0), (0, 0, -1)),
         ]
         for plane, x_dir, z_dir in planes:
             self.assertVectorAlmostEquals(plane.x_dir, x_dir, 5)


### PR DESCRIPTION
Make the default planes in build123d match the behavior of OCP CAD Viewer and many other CAD software. In CQ-editor the "front" plane is the only one that is currently different (although may modify in my fork).