### PR TITLE
add 3 mass units (grams, kilograms, pounds)

### DIFF
--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -96,9 +96,9 @@ FT = 12 * IN
 THOU = IN / 1000
 
 # MASS CONSTANTS
-GM = 1
-KG = 1000 * GM
-LB = 453.59237 * GM
+G = 1
+KG = 1000 * G
+LB = 453.59237 * G
 
 operations_apply_to = {
     "add": ["BuildPart", "BuildSketch", "BuildLine"],

--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -86,6 +86,8 @@ logger = logging.getLogger("build123d")
 #
 # CONSTANTS
 #
+
+# LENGTH CONSTANTS
 MM = 1
 CM = 10 * MM
 M = 1000 * MM
@@ -93,6 +95,10 @@ IN = 25.4 * MM
 FT = 12 * IN
 THOU = IN / 1000
 
+# MASS CONSTANTS
+GM = 1
+KG = 1000 * GM
+LB = 453.59237 * GM
 
 operations_apply_to = {
     "add": ["BuildPart", "BuildSketch", "BuildLine"],


### PR DESCRIPTION
adding mass units for easier conversion of mass within build123d, e.g. for checking that CAD results are accurate