### PR TITLE
add new mass constants to __init__.py

### DIFF
--- a/src/build123d/__init__.py
+++ b/src/build123d/__init__.py
@@ -20,12 +20,16 @@ from build123d.topology import *
 from .version import version as __version__
 
 __all__ = [
-    # Measurement Units
+    # Length Constants
     "MM",
     "CM",
     "M",
     "IN",
     "FT",
+    # Mass Constants
+    "G",
+    "KG",
+    "LB",
     # Enums
     "Align",
     "ApproxOption",


### PR DESCRIPTION
This should allow the mass constants to be automatically available from an import.