### PR TITLE
Add dependencies for Apple Silicon

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -107,8 +107,9 @@ A procedure for avoiding this issue is to install in a conda environment, which 
 	conda activate <YOUR ENVIRONMENT NAME>
 	conda install -c cadquery -c conda-forge cadquery=master
 	pip install --no-deps git+https://github.com/gumyr/build123d svgwrite svgpathtools anytree scipy ipython
+	pip install --no-deps git+https://github.com/jdegenstein/py-lib3mf
 	pip install --no-deps ocp_tessellate webcolors==1.12 numpy numpy-quaternion cachetools==5.2.0
-	pip install --no-deps ocp_vscode requests orjson urllib3 certifi numpy-stl
+	pip install --no-deps ocp_vscode requests orjson urllib3 certifi numpy-stl python_utils
 
 `You can track the issue here <https://github.com/CadQuery/ocp-build-system/issues/11#issuecomment-1407769681>`_
 


### PR DESCRIPTION
Two extra adds to make installation work for Apple silicon, need to manually install py_lib3mf from GitHub repo and pip install python_utils.