### PR TITLE
Fix Apple Silicon install instructions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -106,9 +106,10 @@ A procedure for avoiding this issue is to install in a conda environment, which 
 	conda create -n <YOUR ENVIRONMENT NAME> python=3.10
 	conda activate <YOUR ENVIRONMENT NAME>
 	conda install -c cadquery -c conda-forge cadquery=master
-	pip install --no-deps git+https://github.com/gumyr/build123d svgwrite svgpathtools anytree scipy ipython
-	pip install --no-deps ocp_tessellate webcolors==1.12 numpy numpy-quaternion cachetools==5.2.0
-	pip install --no-deps ocp_vscode requests orjson urllib3 certifi numpy-stl
+	pip install svgwrite svgpathtools anytree scipy ipython \
+            ocp_tessellate webcolors==1.12 numpy numpy-quaternion cachetools==5.2.0 \
+            ocp_vscode requests orjson urllib3 certifi numpy-stl
+        pip install --no-deps git+https://github.com/gumyr/build123d
 
 `You can track the issue here <https://github.com/CadQuery/ocp-build-system/issues/11#issuecomment-1407769681>`_
 


### PR DESCRIPTION
I had to go through a bit of troubleshooting to install build123d on my M1 mac. The instructions said to install dependencies using the `--no-deps` argument which is problematic because child dependencies still need to be resolved for the top-level dependencies. The only place `--no-deps` should be used is with the `build123d` package itself. The only direct dependency that wasn't installable using pip was `cadquery-ocp`, which is already installed from the previous conda install command.

I've also updated the list of pip dependencies based on the latest `pyproject.toml` and condensed them into a single command, with the build123d install being the final package installed.

Note that I've only tested this using micromamba, but I'm assuming it woud be the same when using conda. I tested on a fresh environment and it appears to have worked:

```
>>> from build123d import *
>>> print(Solid.make_box(1,2,3).show_topology(limit_class="Face"))
Solid        at 0x10ce88cb0, Center(0.5, 1.0, 1.5)
└── Shell    at 0x136b71b70, Center(0.5, 1.0, 1.5)
    ├── Face at 0x103036130, Center(0.0, 1.0, 1.5)
    ├── Face at 0x14467c630, Center(1.0, 1.0, 1.5)
    ├── Face at 0x14467c8f0, Center(0.5, 0.0, 1.5)
    ├── Face at 0x144865ab0, Center(0.5, 2.0, 1.5)
    ├── Face at 0x1448659f0, Center(0.5, 1.0, 0.0)
    └── Face at 0x144865a70, Center(0.5, 1.0, 3.0)

>>>
```

Success! 🎉

Hopefully github will have arm64 build support finished this year and we won't have to deal w/ it much longer.