### PR TITLE
Fix doc links to drafting objects and add to cheat sheet

### DIFF
--- a/docs/cheat_sheet.rst
+++ b/docs/cheat_sheet.rst
@@ -35,8 +35,8 @@ Cheat Sheet
             | :class:`~drafting.ArrowHead`
             | :class:`~objects_sketch.Circle`
             | :class:`~drafting.DimensionLine`
-            | :class:`~drafting.ExtensionLine`
             | :class:`~objects_sketch.Ellipse`
+            | :class:`~drafting.ExtensionLine`
             | :class:`~objects_sketch.Polygon`
             | :class:`~objects_sketch.Rectangle`
             | :class:`~objects_sketch.RectangleRounded`

--- a/docs/cheat_sheet.rst
+++ b/docs/cheat_sheet.rst
@@ -31,7 +31,11 @@ Cheat Sheet
 
         .. grid-item-card:: 2D - BuildSketch
 
+            | :class:`~drafting.Arrow`
+            | :class:`~drafting.ArrowHead`
             | :class:`~objects_sketch.Circle`
+            | :class:`~drafting.DimensionLine`
+            | :class:`~drafting.ExtensionLine`
             | :class:`~objects_sketch.Ellipse`
             | :class:`~objects_sketch.Polygon`
             | :class:`~objects_sketch.Rectangle`
@@ -42,6 +46,7 @@ Cheat Sheet
             | :class:`~objects_sketch.SlotCenterToCenter`
             | :class:`~objects_sketch.SlotOverall`
             | :class:`~objects_sketch.Text`
+            | :class:`~drafting.TechnicalDrawing`
             | :class:`~objects_sketch.Trapezoid`
 
         .. grid-item-card:: 3D - BuildPart

--- a/docs/objects.rst
+++ b/docs/objects.rst
@@ -200,14 +200,14 @@ Reference
 
 .. grid:: 3
 
-    .. grid-item-card:: :class:`~objects_sketch.Arrow`
+    .. grid-item-card:: :class:`~drafting.Arrow`
 
         .. image:: assets/arrow.svg
 
         +++
         Arrow with head and path for shaft
 
-    .. grid-item-card:: :class:`~objects_sketch.ArrowHead`
+    .. grid-item-card:: :class:`~drafting.ArrowHead`
 
         .. image:: assets/arrow_head.svg
 
@@ -222,7 +222,7 @@ Reference
         +++
         Circle defined by radius
 
-    .. grid-item-card:: :class:`~objects_sketch.DimensionLine`
+    .. grid-item-card:: :class:`~drafting.DimensionLine`
 
         .. image:: assets/d_line.svg
 
@@ -237,7 +237,7 @@ Reference
         +++
         Ellipse defined by major and minor radius
 
-    .. grid-item-card:: :class:`~objects_sketch.ExtensionLine`
+    .. grid-item-card:: :class:`~drafting.ExtensionLine`
 
         .. image:: assets/e_line.svg
 
@@ -300,7 +300,7 @@ Reference
         +++
         SlotOverall defined by end-to-end length and height
 
-    .. grid-item-card:: :class:`~objects_sketch.TechnicalDrawing`
+    .. grid-item-card:: :class:`~drafting.TechnicalDrawing`
 
         .. image:: assets/tech_drawing.svg
 


### PR DESCRIPTION
links were to e.g. `objects_sketch.Arrow` instead of `drafting.Arrow`