### PR TITLE
Fix inverse in RegularPolygon minor diameter

### DIFF
--- a/src/build123d/objects_sketch.py
+++ b/src/build123d/objects_sketch.py
@@ -309,7 +309,7 @@ class RegularPolygon(BaseSketchObject):
         if major_radius:
             rad = radius
         else:
-            rad = radius * cos(pi / side_count)
+            rad = radius / cos(pi / side_count)
 
         self.radius = rad
         self.side_count = side_count

--- a/tests/test_build_sketch.py
+++ b/tests/test_build_sketch.py
@@ -267,13 +267,13 @@ class TestBuildSketchObjects(unittest.TestCase):
     
     def test_regular_polygon_minor_radius(self):
         with BuildSketch() as test:
-            r = RegularPolygon(1, 3, False)
-        self.assertAlmostEqual(r.radius, 0.5, 5)
+            r = RegularPolygon(0.5, 3, False)
+        self.assertAlmostEqual(r.radius, 1, 5)
         self.assertEqual(r.side_count, 3)
         self.assertEqual(r.rotation, 0)
         self.assertEqual(r.align, (Align.CENTER, Align.CENTER))
         self.assertEqual(r.mode, Mode.ADD)
-        self.assertAlmostEqual(test.sketch.area, (3 * sqrt(3) / 4) * 0.5**2, 5)
+        self.assertAlmostEqual(test.sketch.area, (3 * sqrt(3) / 4) * (.5*2)**2, 5)
         self.assertTupleAlmostEquals(
             test.sketch.faces()[0].normal_at().to_tuple(), (0, 0, 1), 5
         )


### PR DESCRIPTION
Currently `RegularPolygon(... , major_radius=False)` scales the radius down, when it should scale it up. This PR inverts that behavior to the way that it should work
```py
from build123d import *
from math import cos,pi

d = 1
n = 6
tr = .01

with BuildSketch() as s:
    Circle(d/2)

with BuildSketch() as s2:
    Circle(d/2*cos(pi/n))

with BuildSketch() as s3:
    RegularPolygon(d/2,n,True)

with BuildSketch() as s4:
    RegularPolygon(d/2,n,False)

with BuildSketch() as s5:
    RegularPolygon(d/2/cos(pi/n)**2,n,False)

print(f" {s.sketch.bounding_box().size.Y=}")
print(f"{s2.sketch.bounding_box().size.Y=}")
print(f"{s3.sketch.bounding_box().size.Y=}")
print(f"{s4.sketch.bounding_box().size.Y=}")
print(f"{s5.sketch.bounding_box().size.Y=}")
```
Current (wrong behavior):
```
 s.sketch.bounding_box().size.Y=1.0
s2.sketch.bounding_box().size.Y=0.8660254037844387
s3.sketch.bounding_box().size.Y=0.8660254037844386
s4.sketch.bounding_box().size.Y=0.75
s5.sketch.bounding_box().size.Y=1.0
```