### PR TITLE
Update .readthedocs.yaml to ubuntu-22.04

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-22.04"
   tools:
     python: "3.9"
   apt_packages:


### PR DESCRIPTION
trying to fix readthedocs builds unable to install cadquery-ocp==7.7.1 from pypi with manylinux 2.35