### PR TITLE
fix handling of e.g. align=Align.MIN for Grid and HexLocations

### DIFF
--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -855,11 +855,11 @@ class HexLocations(LocationList):
         # Calculate the amount to offset the array to align it
         align_offset = []
         for i in range(2):
-            if align[i] == Align.MIN:
+            if self.align[i] == Align.MIN:
                 align_offset.append(0)
-            elif align[i] == Align.CENTER:
+            elif self.align[i] == Align.CENTER:
                 align_offset.append(-size[i] / 2)
-            elif align[i] == Align.MAX:
+            elif self.align[i] == Align.MAX:
                 align_offset.append(-size[i])
 
         # Align the points
@@ -1036,11 +1036,11 @@ class GridLocations(LocationList):
         size = [x_spacing * (x_count - 1), y_spacing * (y_count - 1)]
         align_offset = []
         for i in range(2):
-            if align[i] == Align.MIN:
+            if self.align[i] == Align.MIN:
                 align_offset.append(0.0)
-            elif align[i] == Align.CENTER:
+            elif self.align[i] == Align.CENTER:
                 align_offset.append(-size[i] / 2)
-            elif align[i] == Align.MAX:
+            elif self.align[i] == Align.MAX:
                 align_offset.append(-size[i])
 
         # Create the list of local locations


### PR DESCRIPTION
This fixes issue #342, which also applied to HexLocations. The code incorrectly referenced the input value `align` instead of the tuplified input value stored in `self.align`

All of these options work now for GridLocations and HexLocations:
```py
locs2 = HexLocations(1,1,2,align=(Align.MIN,Align.MIN,Align.MIN))
locs2 = HexLocations(1,1,2,align=(Align.MIN,Align.MIN))
locs2 = HexLocations(1,1,2,align=(Align.MIN))
locs2 = HexLocations(1,1,2,align=Align.MIN)
```