### PR TITLE
add direction argument to chamfer.

### DIFF
--- a/src/build123d/operations_generic.py
+++ b/src/build123d/operations_generic.py
@@ -278,6 +278,8 @@ def chamfer(
         ValueError: no objects provided
         ValueError: objects must be Edges
         ValueError: objects must be Vertices
+        ValueError: Only one of length2 or angle should be provided
+        ValueError: Face can only be used in conjunction with length2 or angle
     """
     context: Builder = Builder._get_context("chamfer")
     if length2 and angle:

--- a/src/build123d/operations_generic.py
+++ b/src/build123d/operations_generic.py
@@ -258,6 +258,7 @@ def chamfer(
     length: float,
     length2: float = None,
     angle: float = None,
+    face: Face = None,
 ) -> Union[Sketch, Part]:
     """Generic Operation: chamfer
 
@@ -270,6 +271,8 @@ def chamfer(
         length (float): chamfer size
         length2 (float, optional): asymmetric chamfer size. Defaults to None.
         angle (float, optional): chamfer angle in degrees. Defaults to None.
+        face (Face): identifies the side where length is measured. The edge(s) must
+            be part of the face
 
     Raises:
         ValueError: no objects provided
@@ -283,6 +286,9 @@ def chamfer(
     if angle:
         length2 = length * tan(radians(angle))
 
+    if face and not (length2 or angle):
+        raise ValueError("Face can only be used in conjunction with length2 or angle")
+
     length2 = length if length2 is None else length2
 
     if (objects is None and context is None) or (
@@ -293,6 +299,7 @@ def chamfer(
     object_list = (
         [*objects] if isinstance(objects, (list, tuple, filter)) else [objects]
     )
+
     validate_inputs(context, "chamfer", object_list)
 
     if context is not None:
@@ -308,7 +315,7 @@ def chamfer(
 
         if not all([isinstance(obj, Edge) for obj in object_list]):
             raise ValueError("3D chamfer operation takes only Edges")
-        new_part = target.chamfer(length, length2, list(object_list))
+        new_part = target.chamfer(length, length2, list(object_list), face)
 
         if context is not None:
             context._add_to_context(new_part, mode=Mode.REPLACE)

--- a/src/build123d/operations_generic.py
+++ b/src/build123d/operations_generic.py
@@ -258,7 +258,7 @@ def chamfer(
     length: float,
     length2: float = None,
     angle: float = None,
-    face: Face = None,
+    reference: Union[Edge,Face] = None,
 ) -> Union[Sketch, Part]:
     """Generic Operation: chamfer
 
@@ -271,15 +271,15 @@ def chamfer(
         length (float): chamfer size
         length2 (float, optional): asymmetric chamfer size. Defaults to None.
         angle (float, optional): chamfer angle in degrees. Defaults to None.
-        face (Face): identifies the side where length is measured. The edge(s) must
-            be part of the face
+        reference (Union[Edge,Face]): identifies the side where length is measured. Edge(s) must
+            be part of the face. Vertex/Vertices must be part of edge
 
     Raises:
         ValueError: no objects provided
         ValueError: objects must be Edges
         ValueError: objects must be Vertices
         ValueError: Only one of length2 or angle should be provided
-        ValueError: Face can only be used in conjunction with length2 or angle
+        ValueError: reference can only be used in conjunction with length2 or angle
     """
     context: Builder = Builder._get_context("chamfer")
     if length2 and angle:
@@ -288,8 +288,8 @@ def chamfer(
     if angle:
         length2 = length * tan(radians(angle))
 
-    if face and not (length2 or angle):
-        raise ValueError("Face can only be used in conjunction with length2 or angle")
+    if reference and not (length2 or angle):
+        raise ValueError("reference can only be used in conjunction with length2 or angle")
 
     length2 = length if length2 is None else length2
 
@@ -317,7 +317,7 @@ def chamfer(
 
         if not all([isinstance(obj, Edge) for obj in object_list]):
             raise ValueError("3D chamfer operation takes only Edges")
-        new_part = target.chamfer(length, length2, list(object_list), face)
+        new_part = target.chamfer(length, length2, list(object_list), reference)
 
         if context is not None:
             context._add_to_context(new_part, mode=Mode.REPLACE)
@@ -334,7 +334,7 @@ def chamfer(
         for face in target.faces():
             vertices_in_face = [v for v in face.vertices() if v in object_list]
             if vertices_in_face:
-                new_faces.append(face.chamfer_2d(length, length2, vertices_in_face))
+                new_faces.append(face.chamfer_2d(length, length2, vertices_in_face, reference))
             else:
                 new_faces.append(face)
         new_sketch = Sketch(Compound.make_compound(new_faces).wrapped)

--- a/src/build123d/operations_generic.py
+++ b/src/build123d/operations_generic.py
@@ -360,7 +360,7 @@ def chamfer(
                 ),
                 object_list,
             )
-        new_wire = target.chamfer_2d(length, length2, object_list)
+        new_wire = target.chamfer_2d(length, length2, object_list, edge)
         if context is not None:
             context._add_to_context(new_wire, mode=Mode.REPLACE)
         return new_wire

--- a/src/build123d/operations_generic.py
+++ b/src/build123d/operations_generic.py
@@ -360,7 +360,7 @@ def chamfer(
                 ),
                 object_list,
             )
-        new_wire = target.chamfer_2d(length, length2, object_list, edge)
+        new_wire = target.chamfer_2d(length, length2, object_list, reference)
         if context is not None:
             context._add_to_context(new_wire, mode=Mode.REPLACE)
         return new_wire

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -1106,6 +1106,10 @@ class Mixin3D:
         Returns:
             Any:  Chamfered solid
         """
+        if face:
+            if any((edge for edge in edge_list if edge not in face.edges())):
+                raise ValueError("Some edges are not part of the face")
+
         native_edges = [e.wrapped for e in edge_list]
 
         # make a edge --> faces mapping
@@ -1138,14 +1142,10 @@ class Mixin3D:
             new_shape = self.__class__(chamfer_builder.Shape())
             if not new_shape.is_valid():
                 raise Standard_Failure
-        except StdFail_NotDone as err:
+        except (StdFail_NotDone, Standard_Failure) as err:
             raise ValueError(
                 "Failed creating a chamfer, try a smaller length value(s)"
             ) from err
-        except Standard_Failure as err:
-            if face:
-                raise ValueError("Some edges are not part of the face") from err
-            raise ValueError(str(err)) from err
 
         return new_shape
 

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -5459,7 +5459,7 @@ class Face(Shape):
         return self.__class__(fillet_builder.Shape())
 
     def chamfer_2d(
-        self, distance: float, distance2: float, vertices: Iterable[Vertex]
+        self, distance: float, distance2: float, vertices: Iterable[Vertex], edge: Edge=None,
     ) -> Face:
         """Apply 2D chamfer to a face
 
@@ -5479,8 +5479,20 @@ class Face(Shape):
             edges = edge_map[vertex]
             if len(edges) < 2:
                 raise ValueError("Cannot chamfer at this location")
+            
+            if edge:
+                if edge not in edges:
+                    raise ValueError("One or more vertices are not part of edge")
 
-            edge1, edge2 = edges
+                edge1 = edge
+                edge2 = [x for x in edges if x != edge][0]
+
+            else:
+                edge1, edge2 = edges
+
+            if edge in edges:
+                pass
+
 
             chamfer_builder.AddChamfer(
                 TopoDS.Edge_s(edge1.wrapped),

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -5464,9 +5464,11 @@ class Face(Shape):
         """Apply 2D chamfer to a face
 
         Args:
-          distance: float:
-          distance2: float:
-          vertices: Iterable[Vertex]:
+        distance (float): chamfer length
+        distance2 (float): chamfer length
+        vertices (Iterable[Vertex]): vertices to chamfer
+        edge (Edge): identifies the side where length is measured. The virtices must be
+            part of the edge
 
         Returns:
 
@@ -6907,7 +6909,7 @@ class Wire(Shape, Mixin1D):
         return Face.make_from_wires(self).fillet_2d(radius, vertices).outer_wire()
 
     def chamfer_2d(
-        self, distance: float, distance2: float, vertices: Iterable[Vertex]
+        self, distance: float, distance2: float, vertices: Iterable[Vertex], edge:Edge = None
     ) -> Wire:
         """chamfer_2d
 
@@ -6917,13 +6919,15 @@ class Wire(Shape, Mixin1D):
             distance (float): chamfer length
             distance2 (float): chamfer length
             vertices (Iterable[Vertex]): vertices to chamfer
+            edge (Edge): identifies the side where length is measured. The virtices must be
+                part of the edge
 
         Returns:
             Wire: chamfered wire
         """
         return (
             Face.make_from_wires(self)
-            .chamfer_2d(distance, distance2, vertices)
+            .chamfer_2d(distance, distance2, vertices, edge)
             .outer_wire()
         )
 

--- a/tests/test_build_generic.py
+++ b/tests/test_build_generic.py
@@ -31,6 +31,7 @@ from build123d import *
 from build123d import Builder, LocationList
 
 
+
 def _assertTupleAlmostEquals(self, expected, actual, places, msg=None):
     """Check Tuples"""
     for i, j in zip(actual, expected):
@@ -228,28 +229,19 @@ class ChamferTests(unittest.TestCase):
             chamfer(test.edges().filter_by(Axis.Z), length=1, angle=60)
         self.assertAlmostEqual(test.part.volume, 1000 - 4 * 0.5 * 10 * sqrt(3), 5)
 
-    def test_part_chamfer_asym_length_face(self):
+    def test_part_chamfer_asym_length_reference(self):
         with BuildPart() as test:
             Box(10, 10, 10)
             face = test.faces().sort_by(Axis.Z)[-1]
-            chamfer(face.edge(), length=1, length2=sqrt(3), face=face)
+            chamfer(face.edge(), length=1, length2=sqrt(3), reference=face)
         self.assertAlmostEqual(test.part.volume, 1000 - 1 * 0.5 * 10 * sqrt(3), 5)
 
-    def test_part_chamfer_asym_angle_face(self):
+    def test_part_chamfer_asym_angle_reference(self):
         with BuildPart() as test:
             Box(10, 10, 10)
             face = test.faces().sort_by(Axis.Z)[-1]
-            chamfer(face.edge(), length=1, angle=60,face=face)
+            chamfer(face.edge(), length=1, angle=60,reference=face)
         self.assertAlmostEqual(test.part.volume, 1000 - 1 * 0.5 * 10 * sqrt(3), 5)
-
-    def test_part_chamfer_face_without_length2_or_angel(self):
-        with BuildPart() as test:
-            Box(10, 10, 10)
-            face = test.faces().sort_by(Axis.Z)[-1]
-            self.assertRaises(ValueError, chamfer, face.edge(), length=1, face=face)
-
-    def test_part_chamfer_face_no_objects(self):
-        self.assertRaises(ValueError, chamfer, None, length=1)
 
     def test_sketch_chamfer(self):
         with BuildSketch() as test:
@@ -278,6 +270,23 @@ class ChamferTests(unittest.TestCase):
             chamfer(test.vertices(), length=1, angle=60)
         self.assertAlmostEqual(test.sketch.area, 100 - 4 * 0.5 * sqrt(3), 5)
 
+    def test_sketch_chamfer_asym_angle_reference(self):
+        with BuildSketch() as test:
+            Rectangle(10, 10)
+            edge = test.edges().sort_by(Axis.Y)[0]
+            vertex = edge.vertex()
+            chamfer(vertex, length=1, angle=60, reference=edge)
+        self.assertAlmostEqual(test.sketch.area, 100 - 0.5 * sqrt(3), 5)
+
+    def test_sketch_chamfer_asym_length_reference(self):
+        with BuildSketch() as test:
+            Rectangle(10, 10)
+            edge = test.edges().sort_by(Axis.Y)[0]
+            vertex = edge.vertex()
+            chamfer(vertex, length=1, length2=sqrt(3), reference=edge)
+        self.assertAlmostEqual(test.sketch.area, 100 - 0.5 * sqrt(3), 5)
+        self.assertAlmostEqual(test.edges().sort_by(Axis.Y)[0].length, 9)        
+
     def test_errors(self):
         with self.assertRaises(TypeError):
             with BuildLine():
@@ -297,6 +306,15 @@ class ChamferTests(unittest.TestCase):
             with BuildSketch() as square:
                 Rectangle(10, 10)
                 chamfer(square.edges(), length=1, length2=sqrt(3), angle=60)
+
+        with self.assertRaises(ValueError):
+            chamfer(None, length=1)
+
+        with self.assertRaises(ValueError):
+            with BuildPart() as test:
+                Box(10, 10, 10)
+                face = test.faces().sort_by(Axis.Z)[-1]
+                chamfer(face.edge(), length=1, reference=face)
 
 class FilletTests(unittest.TestCase):
     def test_part_chamfer(self):

--- a/tests/test_build_generic.py
+++ b/tests/test_build_generic.py
@@ -242,6 +242,15 @@ class ChamferTests(unittest.TestCase):
             chamfer(face.edge(), length=1, angle=60,face=face)
         self.assertAlmostEqual(test.part.volume, 1000 - 1 * 0.5 * 10 * sqrt(3), 5)
 
+    def test_part_chamfer_face_without_length2_or_angel(self):
+        with BuildPart() as test:
+            Box(10, 10, 10)
+            face = test.faces().sort_by(Axis.Z)[-1]
+            self.assertRaises(ValueError, chamfer, face.edge(), length=1, face=face)
+
+    def test_part_chamfer_face_no_objects(self):
+        self.assertRaises(ValueError, chamfer, None, length=1)
+
     def test_sketch_chamfer(self):
         with BuildSketch() as test:
             Rectangle(10, 10)

--- a/tests/test_build_generic.py
+++ b/tests/test_build_generic.py
@@ -287,6 +287,28 @@ class ChamferTests(unittest.TestCase):
         self.assertAlmostEqual(test.sketch.area, 100 - 0.5 * sqrt(3), 5)
         self.assertAlmostEqual(test.edges().sort_by(Axis.Y)[0].length, 9)        
 
+    def test_wire_chamfer(self):
+        with BuildLine() as test:
+            Polyline((0,0), (10,0), (10,10))
+            chamfer(objects=test.vertices(), length=1)
+
+        self.assertAlmostEqual(test.wire().length, 9 + 9 + sqrt(2))
+
+    def test_wire_chamfer_length2(self):
+        with BuildLine() as test:
+            Polyline((0,0), (10,0), (10,10))
+            chamfer(objects=test.vertices(), length=1, length2=2)
+
+        self.assertAlmostEqual(test.wire().length, 9 + 8 + sqrt(1**1 + 2**2))
+    
+    def test_wire_chamfer_length2_edge(self):
+        with BuildLine() as test:
+            Polyline((0,0), (10,0), (10,10))
+            edge = test.edges().sort_by(Axis.Y)[0]
+            chamfer(objects=test.vertices(), length=1, length2=2, reference=edge)
+
+        self.assertAlmostEqual(test.edges().sort_by(Axis.Y)[0].length, 9)
+
     def test_errors(self):
         with self.assertRaises(TypeError):
             with BuildLine():
@@ -315,6 +337,11 @@ class ChamferTests(unittest.TestCase):
                 Box(10, 10, 10)
                 face = test.faces().sort_by(Axis.Z)[-1]
                 chamfer(face.edge(), length=1, reference=face)
+
+        with self.assertRaises(ValueError):
+            with BuildLine() as test:
+                Polyline((0,0), (10,0), (10,10))
+                chamfer(test.edge(), length=1)
 
 class FilletTests(unittest.TestCase):
     def test_part_chamfer(self):

--- a/tests/test_build_generic.py
+++ b/tests/test_build_generic.py
@@ -228,6 +228,20 @@ class ChamferTests(unittest.TestCase):
             chamfer(test.edges().filter_by(Axis.Z), length=1, angle=60)
         self.assertAlmostEqual(test.part.volume, 1000 - 4 * 0.5 * 10 * sqrt(3), 5)
 
+    def test_part_chamfer_asym_length_face(self):
+        with BuildPart() as test:
+            Box(10, 10, 10)
+            face = test.faces().sort_by(Axis.Z)[-1]
+            chamfer(face.edge(), length=1, length2=sqrt(3), face=face)
+        self.assertAlmostEqual(test.part.volume, 1000 - 1 * 0.5 * 10 * sqrt(3), 5)
+
+    def test_part_chamfer_asym_angle_face(self):
+        with BuildPart() as test:
+            Box(10, 10, 10)
+            face = test.faces().sort_by(Axis.Z)[-1]
+            chamfer(face.edge(), length=1, angle=60,face=face)
+        self.assertAlmostEqual(test.part.volume, 1000 - 1 * 0.5 * 10 * sqrt(3), 5)
+
     def test_sketch_chamfer(self):
         with BuildSketch() as test:
             Rectangle(10, 10)

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -3283,6 +3283,13 @@ class TestWire(DirectApiTestCase):
             squaroid.length, 4 * (1 - 2 * 0.1 + 0.1 * math.sqrt(2)), 5
         )
 
+    def test_chamfer_2d_edge(self):
+        square = Wire.make_rect(1, 1)
+        edge = square.edges().sort_by(Axis.Y)[0]
+        vertex = edge.vertices().sort_by(Axis.X)[0]
+        square = square.chamfer_2d(distance=0.1, distance2=0.2,vertices=[vertex], edge=edge)
+        self.assertAlmostEqual(square.edges().sort_by(Axis.Y)[0].length, 0.9)
+
     def test_make_convex_hull(self):
         # overlapping_edges = [
         #     Edge.make_circle(10, end_angle=60),

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -1815,11 +1815,34 @@ class TestMixin1D(DirectApiTestCase):
 
 class TestMixin3D(DirectApiTestCase):
     """Test that 3D add ins"""
-
     def test_chamfer(self):
+        box = Solid.make_box(1, 1, 1)
+        chamfer_box = box.chamfer(0.1, None, box.edges().sort_by(Axis.Z)[-1:])
+        self.assertAlmostEqual(chamfer_box.volume, 1 - 0.005, 5)
+
+    def test_chamfer_asym_length(self):
         box = Solid.make_box(1, 1, 1)
         chamfer_box = box.chamfer(0.1, 0.2, box.edges().sort_by(Axis.Z)[-1:])
         self.assertAlmostEqual(chamfer_box.volume, 1 - 0.01, 5)
+
+    def test_chamfer_asym_length_with_face(self):
+        box = Solid.make_box(1, 1, 1)
+        face = box.faces().sort_by(Axis.Z)[0]
+        edge = [face.edges().sort_by(Axis.Y)[0]]
+        chamfer_box = box.chamfer(0.1, 0.2, edge, face=face)
+        self.assertAlmostEqual(chamfer_box.volume, 1 - 0.01, 5)
+
+
+    def test_chamfer_too_high_length(self):
+        box = Solid.make_box(1, 1, 1)
+        face = box.faces
+        self.assertRaises(ValueError, box.chamfer, 2, None, box.edges().sort_by(Axis.Z)[-1:])
+
+    def test_chamfer_edge_not_part_of_face(self):
+        box = Solid.make_box(1, 1, 1)
+        edge = box.edges().sort_by(Axis.Z)[-1:]
+        face = box.faces().sort_by(Axis.Z)[0]
+        self.assertRaises(ValueError, box.chamfer, 0.1, None, edge, face=face)
 
     def test_hollow(self):
         shell_box = Solid.make_box(1, 1, 1).hollow([], thickness=-0.1)

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -977,6 +977,37 @@ class TestFace(DirectApiTestCase):
             5,
         )
 
+    def test_chamfer_2d(self):
+        test_face = Face.make_rect(10,10)
+        test_face = test_face.chamfer_2d(distance=1,distance2=2, vertices=test_face.vertices())
+        self.assertAlmostEqual(test_face.area, 100 - 4 * 0.5 * 1 * 2)
+
+    def test_chamfer_2d_reference(self):
+        test_face = Face.make_rect(10,10)
+        edge = test_face.edges().sort_by(Axis.Y)[0]
+        vertex = edge.vertices().sort_by(Axis.X)[0]
+        test_face = test_face.chamfer_2d(distance=1,distance2=2, vertices=[vertex], edge=edge)
+        self.assertAlmostEqual(test_face.area, 100 - 0.5 * 1 * 2)
+        self.assertAlmostEqual(test_face.edges().sort_by(Axis.Y)[0].length, 9)
+        self.assertAlmostEqual(test_face.edges().sort_by(Axis.X)[0].length, 8)
+
+    def test_chamfer_2d_reference_inverted(self):
+        test_face = Face.make_rect(10,10)
+        edge = test_face.edges().sort_by(Axis.Y)[0]
+        vertex = edge.vertices().sort_by(Axis.X)[0]
+        test_face = test_face.chamfer_2d(distance=2,distance2=1, vertices=[vertex], edge=edge)
+        self.assertAlmostEqual(test_face.area, 100 - 0.5 * 1 * 2)
+        self.assertAlmostEqual(test_face.edges().sort_by(Axis.Y)[0].length, 8)
+        self.assertAlmostEqual(test_face.edges().sort_by(Axis.X)[0].length, 9)
+
+    def test_chamfer_2d_error_checking(self):
+        with self.assertRaises(ValueError):
+            test_face = Face.make_rect(10,10)
+            edge = test_face.edges().sort_by(Axis.Y)[0]
+            vertex = edge.vertices().sort_by(Axis.X)[0]
+            other_edge = test_face.edges().sort_by(Axis.Y)[-1]
+            test_face = test_face.chamfer_2d(distance=1,distance2=2, vertices=[vertex], edge=other_edge)
+
     def test_make_rect(self):
         test_face = Face.make_plane()
         self.assertVectorAlmostEquals(test_face.normal_at(), (0, 0, 1), 5)


### PR DESCRIPTION
When performing an asymmetrical chamfer on a 3d object, the implementation picks the first face it can find where the edge is part of and uses this as the direction of the first argument `length`. This issue results in inconstant chamfers in complex objects (usually on an object where conditionally the number of edges are altered).

I added a face argument to the chamfer functions. Now the users can control the direction of asymmetrical chamfers.

Let me know what you think.