### PR TITLE
Fix SVG import Y-axis and arc degrees.

### DIFF
--- a/src/build123d/importers.py
+++ b/src/build123d/importers.py
@@ -183,12 +183,12 @@ def import_svg_as_buildline_code(file_name: str) -> tuple[str, str]:
             class_name = type(curve).__name__
             if class_name == "Arc":
                 values = [
-                    (curve.__dict__["center"].real, curve.__dict__["center"].imag)
+                    (curve.__dict__["center"].real, -curve.__dict__["center"].imag)
                 ]
                 values.append(curve.__dict__["radius"].real)
                 values.append(curve.__dict__["radius"].imag)
-                values.append(curve.__dict__["theta"])
-                values.append(curve.__dict__["theta"] + curve.__dict__["delta"])
+                values.append(-curve.__dict__["theta"])
+                values.append(-(curve.__dict__["theta"] + curve.__dict__["delta"]))
                 values.append(degrees(curve.__dict__["phi"]))
                 if curve.__dict__["delta"] < 0.0:
                     values.append("AngularDirection.CLOCKWISE")
@@ -204,7 +204,7 @@ def import_svg_as_buildline_code(file_name: str) -> tuple[str, str]:
                 values = [curve.__dict__[parm] for parm in translator[class_name][1:]]
             values_str = ",".join(
                 [
-                    f"({v.real}, {v.imag})" if isinstance(v, complex) else str(v)
+                    f"({v.real}, {-v.imag})" if isinstance(v, complex) else str(v)
                     for v in values
                 ]
             )


### PR DESCRIPTION

I believe this fixes issue #300 as noted there with SVG imports being "flipped" and having arcs that are incorrect. I had similar issues with trying to import an SVG exported from KiCad, where using current version results in:

![Screenshot from 2023-10-15 11-24-11](https://github.com/gumyr/build123d/assets/202695/450e4a3e-d27e-43ee-b125-f735e4970e98)

And with these fixes:

![Screenshot from 2023-10-15 11-23-16](https://github.com/gumyr/build123d/assets/202695/cb5a0fa8-d6f4-4b50-89ee-d67603bdc132)

I'm happy to contribute a test for this, but the SVG import tests don't offer much in terms of the direction you'd want to go with such a test. I'm open to ideas.

Thanks!
