### PR TITLE
Fix `RevoluteJoint` rotation

### DIFF
--- a/src/build123d/joints.py
+++ b/src/build123d/joints.py
@@ -292,8 +292,8 @@ class RevoluteJoint(Joint):
         rotation = Location(
             Plane(
                 origin=(0, 0, 0),
-                x_dir=self.angle_reference.rotate(Axis.Z, angle),
-                z_dir=(0, 0, 1),
+                x_dir=self.angle_reference.rotate(self.relative_axis, angle),
+                z_dir=self.relative_axis.direction,
             )
         )
         return (


### PR DESCRIPTION
Fixes #355.
The `relative_to()` method was rotating around `Axis.Z`, instead of `self.relative_axis`. This now matches what the other `Joint` classes are doing.

BTW, there is also this code just above the rotation which I think might be ok to remove:
```python
# Avoid strange rotations when angle is zero by using 360 instead
angle = 360.0 if angle == 0.0 else angle
```