### PR TITLE
improve SVG import color hadling

### DIFF
--- a/src/build123d/importers.py
+++ b/src/build123d/importers.py
@@ -247,7 +247,8 @@ def import_svg(
         else:  # should not happen
             raise ValueError(f"unexpected shape type: {type(face_or_wire).__name__}")
 
-        shape.color = Color(*color_and_label.color)
+        if shape.wrapped:
+            shape.color = Color(*color_and_label.color_for(shape.wrapped))
         shape.label = color_and_label.label
         shapes.append(shape)
 

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -1,7 +1,9 @@
+from io import StringIO
 import os
 import unittest
 from build123d import (
     BuildLine,
+    Color,
     Line,
     Bezier,
     RadiusArc,
@@ -76,6 +78,22 @@ class ImportSVG(unittest.TestCase):
             self.assertEqual(len(list(base_faces)), 1)
             self.assertEqual(len(list(hole_faces)), 2)
             self.assertEqual(len(list(test_wires)), 1)
+
+    def test_import_svg_colors(self):
+        svg_file = StringIO(
+            '<svg xmlns="http://www.w3.org/2000/svg">'
+            '<rect width="5" height="10" class="blue" fill="none" stroke="#0000ff"/>'
+            '<rect width="8" height="4" class="red" fill="#ff0000"/>'
+            '<rect width="12" height="3"/>'
+            '<path d="M0,0 H10" fill="red" stroke="blue"/>'
+            "</svg>"
+        )
+        svg = import_svg(svg_file)
+        self.assertEqual(len(svg), 4)
+        self.assertEqual(str(svg[0].color), str(Color(0, 0, 1, 1)))
+        self.assertEqual(str(svg[1].color), str(Color(1, 0, 0, 1)))
+        self.assertEqual(str(svg[2].color), str(Color(0, 0, 0, 1)))
+        self.assertEqual(str(svg[3].color), str(Color(0, 0, 1, 1)))
 
 
 class ImportBREP(unittest.TestCase):


### PR DESCRIPTION
I fixed a bug in `ocpsvg` regarding shapes declared as filled in an SVG document but that cannot be imported as faces, for example a single line segment. That included a better method to retrieve the correct color based on the imported OCP shape type.

This PR changes the SVG importer to use the new `color_for(shape)` method.
The behavior should be functionally identical except for aforementioned degenerate cases. I mostly want to push this change so `build123d` doesn't break when I deprecate the previously used `color` property from `ocpsvg`.