### PR TITLE
Avoid type warnings when adding tuples to vectors

### DIFF
--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -237,7 +237,7 @@ class Vector:
 
         return result
 
-    def __sub__(self, vec: Vector) -> Vector:
+    def __sub__(self, vec: VectorLike) -> Vector:
         """Mathematical subtraction operator -"""
         return self.sub(vec)
 
@@ -252,7 +252,7 @@ class Vector:
 
         return result
 
-    def __add__(self, vec: Vector) -> Vector:
+    def __add__(self, vec: VectorLike) -> Vector:
         """Mathematical addition operator +"""
         return self.add(vec)
 


### PR DESCRIPTION
This simple typing fix avoids this warning from the tea cup example:

![Screenshot_20231105_121154](https://github.com/gumyr/build123d/assets/4929005/23bd020b-c26e-4078-b394-aed157186db1)
