### PR TITLE
Documentation Typos

### DIFF
--- a/docs/algebra_definition.rst
+++ b/docs/algebra_definition.rst
@@ -12,7 +12,7 @@ Objects and arithmetic
 
 :math:`C^2` is the set of all ``Sketch`` objects ``s`` with ``s._dim = 2``
 
-:math:`C^1` is the set of all ``Curve`` objects ``c`` with ``c._dim = 3``
+:math:`C^1` is the set of all ``Curve`` objects ``c`` with ``c._dim = 1``
 
 **Neutral elements:**
 
@@ -49,7 +49,7 @@ with :math:`B^3 \subset C^3, B^2 \subset C^2` and :math:`B^1 \subset C^1`
 
     :math:`\; a \; \& \; b :=` ``a.intersect(b)`` for each operation
 
-    * :math:`\&` is not defined for :math:`n=1` in build123d 
+    * :math:`\&` is not defined for :math:`n=1` in build123d
     * The following relationship holds: :math:`a \; \& \; b = (a + b) + -(a + (-b)) + -(b + (-a))`
 
 
@@ -66,12 +66,12 @@ Locations, planes and location arithmentic
 
 **Set definitions:**
 
-:math:`L  := \lbrace` ``Location((x, y, z), (a, b, c))`` :math:`: x,y,z \in R \land a,b,c \in R \rbrace\;` 
-    
+:math:`L  := \lbrace` ``Location((x, y, z), (a, b, c))`` :math:`: x,y,z \in R \land a,b,c \in R \rbrace\;`
+
     with :math:`a,b,c` being angles in degrees.
 
-:math:`P  := \lbrace` ``Plane(o, x, z)`` :math:`: o,x,z ∈ R^3 \land \|x\| = \|z\| = 1\rbrace` 
-    
+:math:`P  := \lbrace` ``Plane(o, x, z)`` :math:`: o,x,z ∈ R^3 \land \|x\| = \|z\| = 1\rbrace`
+
     with ``o`` being the origin and ``x``, ``z`` the x- and z-direction of the plane.
 
 Neutral element: :math:`\; l_0 \in L`: ``Location()``
@@ -79,7 +79,7 @@ Neutral element: :math:`\; l_0 \in L`: ``Location()``
 **Operations:**
 
 :math:`*: L \times L \rightarrow L` with :math:`(l_1,l_2) \mapsto l_1 * l_2`
-    
+
     :math:`\; l_1 * l_2 :=`  ``l1 * l2`` (multiply two locations)
 
 :math:`*: P \times L \rightarrow P` with :math:`(p,l) \mapsto p * l`

--- a/docs/introductory_examples.rst
+++ b/docs/introductory_examples.rst
@@ -662,7 +662,7 @@ example.
 
 * **Algebra mode**
 
-    Use the operator ``*`` to relocate the plane (post-mulitplication!).
+    Use the operator ``*`` to relocate the plane (post-multiplication!).
 
     .. literalinclude:: general_examples_algebra.py
         :start-after: [Ex. 22]

--- a/docs/location_arithmetic.rst
+++ b/docs/location_arithmetic.rst
@@ -26,7 +26,6 @@ For the following use the helper function:
 
         show_object(face, name="face")
         show_object(location_symbol(loc), name="location")
-    
 
     .. image:: assets/location-example-01.png
 
@@ -40,7 +39,6 @@ For the following use the helper function:
 
         show_object(face, name="face")
         show_object(plane_symbol(plane), name="plane")
-    
 
     .. image:: assets/location-example-07.png
 
@@ -53,7 +51,7 @@ Relative positioning to a plane
 1. **Position an object on a plane relative to the plane**
 
     .. code-block:: python
-        
+
         loc = Location((0.1, 0.2, 0.3), (10, 20, 30))
 
         face = loc * Rectangle(1,2)
@@ -65,11 +63,10 @@ Relative positioning to a plane
         show_object(face, name="face")
         show_object(location_symbol(loc), name="location")
         show_object(box, name="box")
-    
 
     .. image:: assets/location-example-02.png
 
-    The ``x``, ``y``, ``z`` components of ``Pos(0.2, 0.4, 0.1)`` are relative to the ``x``-axis, ``y``-axis or 
+    The ``x``, ``y``, ``z`` components of ``Pos(0.2, 0.4, 0.1)`` are relative to the ``x``-axis, ``y``-axis or
     ``z``-axis of the underlying location ``loc``.
 
     Note: ``Plane(loc) *``, ``Plane(face.location) *`` and ``loc *`` are equivalent in this example.
@@ -87,7 +84,6 @@ Relative positioning to a plane
         show_object(face, name="face")
         show_object(location_symbol(loc), name="location")
         show_object(box, name="box")
-    
 
     .. image:: assets/location-example-03.png
 
@@ -107,7 +103,6 @@ Relative positioning to a plane
         show_object(face, name="face")
         show_object(location_symbol(loc), name="location")
         show_object(box, name="box")
-    
 
     .. image:: assets/location-example-04.png
 
@@ -127,11 +122,10 @@ Relative positioning to a plane
         show_object(location_symbol(loc), name="location")
         show_object(box, name="box")
         show_object(location_symbol(loc *  Rot(20, 40, 80), 0.5), options={"color":(0, 255, 255)}, name="local_location")
-    
 
     .. image:: assets/location-example-05.png
 
-    The box is positioned via ``Pos(0.2, 0.4, 0.1)`` relativce to the location ``loc *  Rot(20, 40, 80)``
+    The box is positioned via ``Pos(0.2, 0.4, 0.1)`` relative to the location ``loc *  Rot(20, 40, 80)``
 
 4. **Position and rotate an object relative to a location**
 
@@ -147,7 +141,6 @@ Relative positioning to a plane
         show_object(location_symbol(loc), name="location")
         show_object(box, name="box")
         show_object(location_symbol(loc * Pos(0.2, 0.4, 0.1), 0.5), options={"color":(0, 255, 255)}, name="local_location")
-    
 
     .. image:: assets/location-example-06.png
 

--- a/docs/slide_latch.py
+++ b/docs/slide_latch.py
@@ -22,7 +22,7 @@ with BuildPart() as latch:
         offset(amount=-2)
         fillet(slide_hole.vertices(), 1)
     extrude(amount=-68, mode=Mode.SUBTRACT)
-    # Slot for the hangle to slide in
+    # Slot for the handle to slide in
     with BuildSketch(latch.faces().sort_by(Axis.Z)[-1]):
         SlotOverall(32, 8)
     extrude(amount=-2, mode=Mode.SUBTRACT)

--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -131,7 +131,7 @@ interchange objects between the two systems by transferring the ``wrapped`` obje
 Self Intersection
 *****************
 
-Avoid creating objects that intersect themselves - even if at a single vertex - as these topoplogies 
+Avoid creating objects that intersect themselves - even if at a single vertex - as these topologies
 will almost certainly be invalid (even if :meth:`~topology.Shape.is_valid` reports a ``True`` value).
 An example of where this my arise is with the thread of a screw (or any helical shape) where after
 one complete revolution the part may contact itself. One is likely be more successful if the part

--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -800,7 +800,7 @@ class HexLocations(LocationList):
         align (Union[Align, tuple[Align, Align]], optional): align min, center, or max of object.
             Defaults to (Align.CENTER, Align.CENTER).
 
-    Atributes:
+    Attributes:
         apothem (float): radius of the inscribed circle
         xCount (int): number of points ( > 0 )
         yCount (int): number of points ( > 0 )
@@ -889,7 +889,7 @@ class PolarLocations(LocationList):
         endpoint (bool, optional): If True, `start_angle` + `angular_range` is the last sample.
             Otherwise, it is not included. Defaults to False.
 
-    Atributes:
+    Attributes:
         local_locations (list{Location}): locations relative to workplane
 
     Raises:
@@ -936,7 +936,7 @@ class Locations(LocationList):
     Args:
         pts (Union[VectorLike, Vertex, Location]): sequence of points to push
 
-    Atributes:
+    Attributes:
         local_locations (list{Location}): locations relative to workplane
 
     """

--- a/src/build123d/drafting.py
+++ b/src/build123d/drafting.py
@@ -166,7 +166,7 @@ class Draft:
         arrow_length (float): arrow head length. Defaults to 3.0.
         line_width (float): thickness of all lines. Defaults to 0.5.
         pad_around_text (float): amount of padding around text. Defaults to 2.0.
-        unit (Unit): measurement unit. Defautls to Unit.MM.
+        unit (Unit): measurement unit. Defaults to Unit.MM.
         number_display (NumberDisplay): numbers as decimal or fractions.
             Default to NumberDisplay.DECIMAL.
         display_units (bool): control the display of units with numbers. Defaults to True.
@@ -582,7 +582,7 @@ class TechnicalDrawing(BaseSketchObject):
         sub_title (str, optional): drawing sub title. Defaults to "Sub Title".
         drawing_number (str, optional): Defaults to "B3D-1".
         sheet_number (int, optional): Defaults to None.
-        drawing_scale (float, optional): displayes as 1:value. Defaults to 1.0.
+        drawing_scale (float, optional): displays as 1:value. Defaults to 1.0.
         nominal_text_size (float, optional): size of title text. Defaults to 10.0.
         line_width (float, optional): Defaults to 0.5.
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.

--- a/src/build123d/exporters.py
+++ b/src/build123d/exporters.py
@@ -977,7 +977,7 @@ class ExportSVG(Export2D):
 
         Raises:
             ValueError: Duplicate layer name
-            ValueError: Unknow linetype
+            ValueError: Unknown linetype
 
         Returns:
             Self: Drawing with an additional layer
@@ -985,7 +985,7 @@ class ExportSVG(Export2D):
         if name in self._layers:
             raise ValueError(f"Duplicate layer name '{name}'.")
         if line_type.value not in Export2D.LINETYPE_DEFS:
-            raise ValueError(f"Unknow linetype `{line_type.value}`.")
+            raise ValueError(f"Unknown linetype `{line_type.value}`.")
         layer = ExportSVG._Layer(
             name=name,
             fill_color=fill_color,

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -361,7 +361,7 @@ class Vector:
         return self - normal * (((self - base).dot(normal)) / normal.length**2)
 
     def __neg__(self) -> Vector:
-        """Flip direction of vector opertor -"""
+        """Flip direction of vector operator -"""
         return self * -1
 
     def __abs__(self) -> float:

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -1775,7 +1775,7 @@ class Plane(metaclass=Plane_meta):
             ValueError: Axis doesn't intersect plane
 
         Returns:
-            Plane: plane with new ogin
+            Plane: plane with new origin
 
         """
         if type(locator).__name__ == "Vertex":

--- a/src/build123d/joints.py
+++ b/src/build123d/joints.py
@@ -113,7 +113,7 @@ class RigidJoint(Joint):
 
         Args:
             other (Joint): joint to connect to
-            angle (float, optional): angle in degrees. Deaults to range min.
+            angle (float, optional): angle in degrees. Defaults to range min.
             angles (RotationLike, optional): angles about axes in degrees. Defaults to
                 range minimums.
             position (float, optional): linear position. Defaults to linear range min.
@@ -148,7 +148,7 @@ class RigidJoint(Joint):
 
         Args:
             other (RigidJoint): relative to joint
-            angle (float, optional): angle in degrees. Deaults to range min.
+            angle (float, optional): angle in degrees. Defaults to range min.
             angles (RotationLike, optional): angles about axes in degrees. Defaults to
                 range minimums.
             position (float, optional): linear position. Defaults to linear range min.
@@ -206,7 +206,7 @@ class RevoluteJoint(Joint):
 
     Attributes:
         angle (float): angle of joint
-        angle_reference (Vector): reference for angular poitions
+        angle_reference (Vector): reference for angular positions
         angular_range (tuple[float,float]): min and max angular position of joint
         relative_axis (Axis): joint axis relative to bound part
 
@@ -259,7 +259,7 @@ class RevoluteJoint(Joint):
 
         Args:
             other (RigidJoint): relative to joint
-            angle (float, optional): angle in degrees. Deaults to range min.
+            angle (float, optional): angle in degrees. Defaults to range min.
 
         Returns:
             TypeError: other must of type RigidJoint
@@ -274,7 +274,7 @@ class RevoluteJoint(Joint):
 
         Args:
             other (RigidJoint): relative to joint
-            angle (float, optional): angle in degrees. Deaults to range min.
+            angle (float, optional): angle in degrees. Defaults to range min.
 
         Raises:
             TypeError: other must of type RigidJoint
@@ -373,7 +373,7 @@ class LinearJoint(Joint):
 
         Args:
             other (Joint): joint to connect to
-            angle (float, optional): angle in degrees. Deaults to range min.
+            angle (float, optional): angle in degrees. Defaults to range min.
             position (float, optional): linear position. Defaults to linear range min.
 
         Raises:
@@ -400,7 +400,7 @@ class LinearJoint(Joint):
 
         Args:
             other (Joint): joint to connect to
-            angle (float, optional): angle in degrees. Deaults to range min.
+            angle (float, optional): angle in degrees. Defaults to range min.
             position (float, optional): linear position. Defaults to linear range min.
 
         Raises:
@@ -480,7 +480,7 @@ class CylindricalJoint(Joint):
         axis (Axis): joint axis
         linear_position (float): linear joint position
         rotational_position (float): revolute joint angle in degrees
-        angle_reference (Vector): reference for angular poitions
+        angle_reference (Vector): reference for angular positions
         angular_range (tuple[float,float]): min and max angular position of joint
         linear_range (tuple[float,float]): min and max positional values
         relative_axis (Axis): joint axis relative to bound part
@@ -551,7 +551,7 @@ class CylindricalJoint(Joint):
         Args:
             other (Joint): joint to connect to
             position (float, optional): linear position. Defaults to linear range min.
-            angle (float, optional): angle in degrees. Deaults to range min.
+            angle (float, optional): angle in degrees. Defaults to range min.
 
         Raises:
             TypeError: other must be of type RigidJoint
@@ -568,7 +568,7 @@ class CylindricalJoint(Joint):
         Args:
             other (Joint): joint to connect to
             position (float, optional): linear position. Defaults to linear range min.
-            angle (float, optional): angle in degrees. Deaults to range min.
+            angle (float, optional): angle in degrees. Defaults to range min.
 
         Raises:
             TypeError: other must be of type RigidJoint

--- a/src/build123d/mesher.py
+++ b/src/build123d/mesher.py
@@ -6,7 +6,7 @@ by:   Gumyr
 date: Aug 9th 2023
 
 desc:
-    This module provides the Mesher class that implements exporting and importing 
+    This module provides the Mesher class that implements exporting and importing
     both 3MF and STL mesh files.  It uses the 3MF Consortium's Lib3MF library
     (see https://github.com/3MFConsortium/lib3mf).
 
@@ -188,7 +188,7 @@ class Mesher:
             name_space (str): categorizer of different metadata entries
             name (str): metadata label
             value (str): metadata content
-            metadata_type (str): metadata trype
+            metadata_type (str): metadata type
             must_preserve (bool): metadata must not be removed if unused
         """
         # Get an existing meta data group if there is one
@@ -367,7 +367,7 @@ class Mesher:
             part_number (str, optional): part #. Defaults to None.
             uuid_value (uuid, optional): value from uuid package. Defaults to None.
 
-        Rasises:
+        Raises:
             RuntimeError: 3mf mesh is invalid
             Warning: Degenerate shape skipped
             Warning: 3mf mesh is not manifold

--- a/src/build123d/persistence.py
+++ b/src/build123d/persistence.py
@@ -83,9 +83,9 @@ def serialize_location(location: TopLoc_Location) -> bytes:
     """
     if location is None:
         return None
-    transfo = location.Transformation()
-    translation = transfo.TranslationPart()
-    rotation = transfo.GetRotation()
+    transform = location.Transformation()
+    translation = transform.TranslationPart()
+    rotation = transform.GetRotation()
     # convert floats in bytes
     translation_bytes = bytearray()
     for i in range(1, 4):
@@ -126,10 +126,10 @@ def deserialize_location(buffer: bytes) -> TopLoc_Location:
     )
 
     # Create the TopLoc_Location object
-    transfo = gp_Trsf()
-    transfo.SetTransformation(rotation, translation)
+    transform = gp_Trsf()
+    transform.SetTransformation(rotation, translation)
 
-    return TopLoc_Location(transfo)
+    return TopLoc_Location(transform)
 
 
 def reduce_shape(shape: TopoDS_Shape) -> tuple:

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -2558,7 +2558,7 @@ class Shape(NodeMixin):
         Args:
             to_fuse (sequence Shape): shapes to fuse
             glue (bool, optional): performance improvement for some shapes. Defaults to False.
-            tol (float, optional): tolerarance. Defaults to None.
+            tol (float, optional): tolerance. Defaults to None.
 
         Returns:
             Shape: fused shape
@@ -6682,7 +6682,7 @@ class Wire(Shape, Mixin1D):
     def param_at_point(self, point: VectorLike) -> float:
         """Parameter at point on Wire"""
 
-        # OCP doesn't support this so this algoritm finds the edge that contains the
+        # OCP doesn't support this so this algorithm finds the edge that contains the
         # point, finds the u value/fractional distance of the point on that edge and
         # sums up the length of the edges from the start to the edge with the point.
 
@@ -6785,7 +6785,7 @@ class Wire(Shape, Mixin1D):
 
         # Select the wire containing the start and end points
         wire_segments = edges_to_wires(modified_edges + original_edges)
-        trimed_wire = filter(
+        trimmed_wire = filter(
             lambda w: all(
                 [
                     w.distance_to(p) <= TOLERANCE
@@ -6794,9 +6794,9 @@ class Wire(Shape, Mixin1D):
             ),
             wire_segments,
         )
-        if not trimed_wire:
+        if not trimmed_wire:
             raise RuntimeError("Invalid trim result")
-        return next(trimed_wire)
+        return next(trimmed_wire)
 
     def order_edges(self) -> ShapeList[Edge]:
         """Return the edges in self ordered by wire direction and orientation"""
@@ -6993,7 +6993,7 @@ class Wire(Shape, Mixin1D):
             distance (float): chamfer length
             distance2 (float): chamfer length
             vertices (Iterable[Vertex]): vertices to chamfer
-            edge (Edge): identifies the side where length is measured. The virtices must be
+            edge (Edge): identifies the side where length is measured. The vertices must be
                 part of the edge
 
         Returns:
@@ -7282,7 +7282,7 @@ class Joint(ABC):
         self.connected_to = other
 
     @abstractmethod
-    def connect_to(self, other: Joint, **kwags):
+    def connect_to(self, other: Joint, **kwargs):
         """All derived classes must provide a connect_to method"""
         raise NotImplementedError
 

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -3095,7 +3095,7 @@ class Shape(NodeMixin):
         Extrude self in the provided direction.
 
         Args:
-            direction (VectorLike): direction and magnitue of extrusion
+            direction (VectorLike): direction and magnitude of extrusion
 
         Raises:
             ValueError: Unsupported class
@@ -3147,7 +3147,7 @@ class Shape(NodeMixin):
         * Shells generate Compounds
 
         Args:
-            direction (VectorLike): direction and magnitue of extrusion
+            direction (VectorLike): direction and magnitude of extrusion
 
         Raises:
             ValueError: Unsupported class

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -438,7 +438,7 @@ class TestCadObjects(DirectApiTestCase):
         tangent_arc = Edge.make_tangent_arc(
             Vector(1, 1),  # starts at 1, 1
             Vector(0, 1),  # tangent at start of arc is in the +y direction
-            Vector(2, 1),  # arc cureturn_valuees 180 degrees and ends at 2, 1
+            Vector(2, 1),  # arc cureturn_values 180 degrees and ends at 2, 1
         )
         self.assertVectorAlmostEquals(tangent_arc.start_point(), (1, 1, 0), 3)
         self.assertVectorAlmostEquals(tangent_arc.end_point(), (2, 1, 0), 3)
@@ -1521,12 +1521,12 @@ class TestLocation(DirectApiTestCase):
 
     def test_eq(self):
         loc = Location((1, 2, 3), (4, 5, 6))
-        diff_posistion = Location((10, 20, 30), (4, 5, 6))
+        diff_position = Location((10, 20, 30), (4, 5, 6))
         diff_orientation = Location((1, 2, 3), (40, 50, 60))
         same = Location((1, 2, 3), (4, 5, 6))
 
         self.assertEqual(loc, same)
-        self.assertNotEqual(loc, diff_posistion)
+        self.assertNotEqual(loc, diff_position)
         self.assertNotEqual(loc, diff_orientation)
 
     def test_neg(self):
@@ -1647,11 +1647,11 @@ class TestMatrix(DirectApiTestCase):
         mz.rotate(Axis.Z, 30 * DEG2RAD)
         matrix_almost_equal(mz, m_rotate_z_30)
 
-        # Test matrix multipy vector
+        # Test matrix multiply vector
         v = Vector(1, 0, 0)
         self.assertVectorAlmostEquals(mz.multiply(v), (root_3_over_2, 1 / 2, 0), 7)
 
-        # Test matrix multipy matrix
+        # Test matrix multiply matrix
         m_rotate_xy_30 = [
             [root_3_over_2, 0, 1 / 2, 0],
             [1 / 4, root_3_over_2, -root_3_over_2 / 2, 0],
@@ -2617,7 +2617,7 @@ class TestShape(DirectApiTestCase):
         self.assertEqual(len(visible), 6)
         self.assertEqual(len(hidden), 2)
 
-        # Hidden coutour edges
+        # Hidden contour edges
         hole = box - cyl
         visible, hidden = hole.project_to_viewport((-20, 20, 20))
         self.assertEqual(len(visible), 13)

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,4 +1,4 @@
-# write me the test for testing the persistence module with unnitest
+# write me the test for testing the persistence module with unittest
 
 import unittest
 from build123d.persistence import (


### PR DESCRIPTION
Fixed a few typos I found in the docs.  Looks like a few of the files with typos had some trailing spaces that my editor removed too - let me know if that is an issue.