### PR TITLE
pack(): update to support Shape, not just Part.

### DIFF
--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -142,9 +142,9 @@ is split into multiple sections - say 180° of a helix - which are then stored i
 Packing Objects on a Plane
 **************************
 
-When designing independent parts it's common to place each at or near
-the global origin, which can make it tricky to visualize many parts at
-once. :meth:`pack.pack` will translate the `Part`s passed to it so
+When designing independent shapes it's common to place each at or near
+the global origin, which can make it tricky to visualize many shapes at
+once. :meth:`pack.pack` will translate the `Shape`s passed to it so
 that they don't overlap, with an optional padding/spacing.  Here's the
 result of packing a bunch of overlapping boxes (left) using some
 padding (right):

--- a/src/build123d/objects_sketch.py
+++ b/src/build123d/objects_sketch.py
@@ -495,14 +495,17 @@ class SlotOverall(BaseSketchObject):
         self.width = width
         self.slot_height = height
 
-        face = Face.make_from_wires(
-            Wire.make_wire(
-                [
-                    Edge.make_line(Vector(-width / 2 + height / 2, 0, 0), Vector()),
-                    Edge.make_line(Vector(), Vector(+width / 2 - height / 2, 0, 0)),
-                ]
-            ).offset_2d(height / 2)
-        )
+        if width != height:
+            face = Face.make_from_wires(
+                Wire.make_wire(
+                    [
+                        Edge.make_line(Vector(-width / 2 + height / 2, 0, 0), Vector()),
+                        Edge.make_line(Vector(), Vector(+width / 2 - height / 2, 0, 0)),
+                    ]
+                ).offset_2d(height / 2)
+            )
+        else:
+            face = Circle(width/2, mode=mode).face()
         super().__init__(face, rotation, align, mode)
 
 

--- a/src/build123d/pack.py
+++ b/src/build123d/pack.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable, Collection, Optional, cast
 
-from build123d import Location, Part
+from build123d import Location, Shape
 
 def _pack2d(objects: Collection[object],
             width_fn: Callable[[object], float],
@@ -98,13 +98,13 @@ def _pack2d(objects: Collection[object],
         translations.append((o[0], node.x, node.y))
     return [(t[1], t[2]) for t in sorted(translations, key=lambda t: t[0])]
 
-def pack(objects: Collection[Part], padding: float) -> Collection[Part]:
+def pack(objects: Collection[Shape], padding: float) -> Collection[Shape]:
     """Pack objects in a squarish area in Plane.XY."""
     bounding_boxes = {o: o.bounding_box().size + (padding, padding) for o in objects}
     translations = _pack2d(
         objects,
-        width_fn=lambda o: bounding_boxes[cast(Part, o)].X,
-        length_fn=lambda o: bounding_boxes[cast(Part, o)].Y)
+        width_fn=lambda o: bounding_boxes[cast(Shape, o)].X,
+        length_fn=lambda o: bounding_boxes[cast(Shape, o)].Y)
     translated = [
         Location((t[0]-o.bounding_box().min.X, t[1]-o.bounding_box().min.Y, 0)) * o
         for (o,t) in zip(objects, translations)

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -12,7 +12,7 @@ import random
 import unittest
 from functools import reduce
 
-from build123d import Box, Part, pack
+from build123d import *
 
 class TestPack(unittest.TestCase):
     """Tests for the pack helper."""
@@ -41,6 +41,18 @@ class TestPack(unittest.TestCase):
         self.assertEqual(
             "bbox: 0.0 <= x <= 94.0, 0.0 <= y <= 86.0, -0.5 <= z <= 0.5",
             str(reduce(operator.add, packed, Part()).bounding_box()))
+
+    def test_random_slots(self):
+        """Test pack for 2D objects."""
+        random.seed(123456)
+        # 50 is an arbitrary number that is large enough to exercise
+        # different aspects of the packer while still completing quickly.
+        inputs = [SlotOverall(random.randint(1,20), random.randint(1,20)) for _ in range(50)]
+        # Not raising in this call shows successfull non-overlap.
+        packed = pack(inputs, 1)
+        self.assertEqual(
+            "bbox: 0.0 <= x <= 124.0, 0.0 <= y <= 105.0, 0.0 <= z <= 0.0",
+            str(reduce(operator.add, packed, Sketch()).bounding_box()))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Also fix SlotOverall so that passing it equal height and width doesn't error out and instead reduces to a Circle. (bug discovered while writing the new test case).

h/t for suggestion by @gumyr in [code review](https://github.com/gumyr/build123d/pull/374#issuecomment-1805912573).