### PR TITLE
Speed up pytest execution wall time by ~37%.

### DIFF
--- a/tests/test_drafting.py
+++ b/tests/test_drafting.py
@@ -297,9 +297,8 @@ class ExtensionLineTestCase(unittest.TestCase):
 
 class TestTechnicalDrawing(unittest.TestCase):
     def test_basic_drawing(self):
-        with BuildSketch() as drawing:
-            TechnicalDrawing(design_date=date(2023, 9, 17), sheet_number=1)
-        bbox = drawing.sketch.bounding_box()
+        drawing = TechnicalDrawing(design_date=date(2023, 9, 17), sheet_number=1)
+        bbox = drawing.bounding_box()
         self.assertGreater(bbox.size.X, 280)
         self.assertGreater(bbox.size.Y, 195)
         self.assertGreater(len(drawing.faces()), 110)


### PR DESCRIPTION
Before: `644 passed in 19.89s`.
After: `644 passed in 12.47s`.

Running with `python -m pytest --durations=5` showed this test case was a huge outlier, and timing its execution showed a huge disparity between the time `TechnicalDrawing` thought it took to run and the time its caller saw et up. Dropping the Builder context makes these times lineup.

Tested the individual test case speed-up with `hyperfine -- 'python -m pytest tests/test_drafting.py::TestTechnicalDrawing::test_basic_drawing'` which reports before & after of:

```
Benchmark 1: python -m pytest tests/test_drafting.py::TestTechnicalDrawing::test_basic_drawing
  Time (mean ± σ):      9.488 s ±  0.534 s    [User: 9.525 s, System: 1.478 s]
  Range (min … max):    9.117 s … 10.929 s    10 runs

Benchmark 1: python -m pytest tests/test_drafting.py::TestTechnicalDrawing::test_basic_drawing
  Time (mean ± σ):      1.951 s ±  0.040 s    [User: 2.292 s, System: 1.111 s]
  Range (min … max):    1.871 s …  2.020 s    10 runs
```

I dug a little into why it was so much slower under the builder and the answer seems to be ~13k calls to deepcopy, but I haven't dug deeper yet to figure out if there's a way to "transfer" to the builder rather than making copies.

(full disclosure: the next-slowest test case is test_pack.py that I added very recently; I'll be looking into speeding that up next :) )