### PR TITLE
Speed up test_pack.py by `fuse()`ing once per test case.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ venv.bak/
 
 #ide debris
 .vscode
+
+# Profiling debris.
+prof/

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -40,7 +40,7 @@ class TestPack(unittest.TestCase):
         packed = pack(test_boxes, 1)
         self.assertEqual(
             "bbox: 0.0 <= x <= 94.0, 0.0 <= y <= 86.0, -0.5 <= z <= 0.5",
-            str(reduce(operator.add, packed, Part()).bounding_box()))
+            str((Part() + packed).bounding_box()))
 
     def test_random_slots(self):
         """Test pack for 2D objects."""
@@ -52,7 +52,7 @@ class TestPack(unittest.TestCase):
         packed = pack(inputs, 1)
         self.assertEqual(
             "bbox: 0.0 <= x <= 124.0, 0.0 <= y <= 105.0, 0.0 <= z <= 0.0",
-            str(reduce(operator.add, packed, Sketch()).bounding_box()))
+            str((Sketch() + packed).bounding_box()))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A classic case of the win described by
https://build123d.readthedocs.io/en/latest/algebra_performance.html

Before, these test cases took 1.26s and 0.28s, making them the slowest and 8th-slowest test cases in the entire repo according to `py.test --durations=10`, and a full pytest run takes 12.31s.

After, these test cases both take 0.09s, and a full run takes 10.90s.

Also added `prof/` to `.gitignore` because using pytest's `--profile{-svg}` options creates this directory but it is unlikely to be usefully tracked by git.