### PR TITLE
Update pyproject.toml to fix typing error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 dependencies = [
     "cadquery-ocp ~= 7.7.1",
     "OCP-stubs @ git+https://github.com/CadQuery/OCP-stubs@7.7.0",
-    "typing_extensions >= 4.4.0, <5",
+    "typing_extensions >= 4.6.0, <5",
     "numpy >= 1.24.1, <2",
     "svgpathtools >= 1.5.1, <2",
     "anytree >= 2.8.0, <3",


### PR DESCRIPTION
Incorporate fix from  https://github.com/python/typing_extensions/issues/243

I believe this affects newer python versions while using typing_extensions<=4.5.0