### PR TITLE
add posibility to compare vertices

### DIFF
--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -6632,6 +6632,15 @@ class Vertex(Shape):
             raise StopIteration
         return value
 
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Vertex):
+            return NotImplemented
+
+        return self.to_tuple() == other.to_tuple()
+
+    def __hash__(self) -> int:
+        return hash(self.to_tuple())
+
 
 class Wire(Mixin1D, Shape):
     """A series of connected, ordered edges, that typically bounds a Face"""

--- a/tests/test_build_line.py
+++ b/tests/test_build_line.py
@@ -49,7 +49,7 @@ class BuildLineTests(unittest.TestCase):
             TangentArc((1, 1), (2, 0), tangent=l1 % 1)
             self.assertEqual(len(test.vertices()), 3)
             self.assertEqual(len(test.edges()), 2)
-            self.assertEqual(len(test.vertices(Select.LAST)), 2)
+            self.assertEqual(len(test.vertices(Select.LAST)), 1)
             self.assertEqual(len(test.edges(Select.LAST)), 1)
             self.assertEqual(len(test.edges(Select.ALL)), 2)
 

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -3372,6 +3372,13 @@ class TestVertex(DirectApiTestCase):
         with self.assertRaises(NotImplementedError):
             Vertex(1, 2, 3) & Vertex(5, 6, 7)
 
+    def test_vertex_compare(self):
+        self.assertEqual(Vertex(1, 2, 3), Vertex(1, 2, 3))
+        self.assertNotEqual(Vertex(1, 2, 3), Vertex(3, 2, 1))
+
+    def test_vertex_compare_wrong_type(self):
+        self.assertNotEqual(Vertex(1, 2, 3), (1, 2, 3))
+
 
 class TestWire(DirectApiTestCase):
     def test_ellipse_arc(self):


### PR DESCRIPTION
Add possibility to compare Vertices.

After these changes I have a problem with 1 testcase: test_basic_functions 

```python
    def test_basic_functions(self):
        """Test creating a line and returning properties and methods"""
        with BuildLine() as test:
            l1 = Line((0, 0), (1, 1))
            TangentArc((1, 1), (2, 0), tangent=l1 % 1)
            self.assertEqual(len(test.vertices()), 3)
            self.assertEqual(len(test.edges()), 2)
            self.assertEqual(len(test.vertices(Select.LAST)), 2)
            self.assertEqual(len(test.edges(Select.LAST)), 1)
            self.assertEqual(len(test.edges(Select.ALL)), 2)
```

`test.vertices(Select.LAST)` is expected to return 2 new later created points, but technically point (1.1) is already created by the `Line` while  `TangentArc` only adds point (2.0).

My proposal is to adapt this test case so `test.vertices(Select.LAST)` is expected to return 1 point. The problem is: I am not familiar enough with the code base to fully understand the impact of this behavior change. Is this proposal OK for you?