### PR TITLE
PyPI Publish GH Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,80 @@
+name: Wheel building and publishing
+
+on:
+  # schedule:
+  workflow_dispatch:
+  push:
+  pull_request:
+
+jobs:
+  test_wheel_building:
+    #
+    permissions:
+      contents: none
+    uses: someactionyml.yml #TODO: replace with wheel build action
+    if: (github.event_name == 'push') # || github.event_name == 'pull_request')
+    with:
+      upload_to_pypi: false
+      targets: |
+        - cp311-manylinux_x86_64
+
+    secrets:
+      pypi_token: ${{ secrets.pypi_token }} # consider using alternate strategy
+
+  build_wheel:
+    # This does the actual wheel building or if triggered manually via the workflow dispatch, or for a tag.
+    # this job does NOT publish the wheels
+    permissions:
+      contents: none
+    uses: someactionyml.yml #TODO: replace with wheel build action
+    if: (github.repository == 'gumyr/build123d' && ( startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels')))
+    with:
+      # We upload to PyPI for all tags starting with v but not ones ending in .dev
+      upload_to_pypi: ${{ startsWith(github.ref, 'refs/tags/v') && !endsWith(github.ref, '.dev') && (github.event_name == 'push') }}
+      # For nightly wheels as well as when building with the 'Build all wheels' label, we disable
+      # the build isolation 
+      # the latest stable versions of all other build-time dependencies.
+      env: |
+        CIBW_BEFORE_BUILD: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels')) && 'pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple') || '' }}'
+        CIBW_BUILD_FRONTEND: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels')) && 'pip; args: --no-build-isolation') || 'build' }}'
+      targets: |
+        # Linux wheels
+
+        - cp39-manylinux_x86_64
+        - cp310-manylinux_x86_64
+        - cp311-manylinux_x86_64
+        #- cp312-manylinux_x86_64
+
+        # MacOS X wheels
+        
+        - cp39*macosx_x86_64
+        - cp310*macosx_x86_64
+        - cp311*macosx_x86_64
+        #- cp312*macosx_x86_64
+
+        - cp39*macosx_arm64
+        - cp310*macosx_arm64
+        - cp311*macosx_arm64
+        #- cp312*macosx_arm64
+
+        # Windows wheels
+        
+        - cp39*win_amd64
+        - cp310*win_amd64
+        - cp311*win_amd64
+        #- cp312*win_amd64
+
+  pypi-publish:
+    # this job publishes the wheels built above
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/build123d
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    # TODO: ? retrieve your distributions here 
+
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,7 @@ jobs:
       # For nightly wheels as well as when building with the 'Build all wheels' label, we disable
       # the build isolation 
       # the latest stable versions of all other build-time dependencies.
+      # need to tweak env according to https://github.com/pypa/cibuildwheel
       env: |
         CIBW_BEFORE_BUILD: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels')) && 'pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple') || '' }}'
         CIBW_BUILD_FRONTEND: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels')) && 'pip; args: --no-build-isolation') || 'build' }}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,81 +1,84 @@
 name: Wheel building and publishing
 
 on:
-  # schedule:
   workflow_dispatch:
-  push:
   pull_request:
+  push:
+    branches:
+      - main  #check branch
+  release:
+    types:
+      - published
 
 jobs:
-  test_wheel_building:
-    #
-    permissions:
-      contents: none
-    uses: someactionyml.yml #TODO: replace with wheel build action
-    if: (github.event_name == 'push') # || github.event_name == 'pull_request')
-    with:
-      upload_to_pypi: false
-      targets: |
-        - cp311-manylinux_x86_64
+  # may be useful to have a wheel building test here eventually (untested):
+  # test_wheel_building:
+  #   #
+  #   permissions:
+  #     contents: none
+  #   uses: someactionyml.yml #TODO: replace with wheel build action
+  #   if: (github.event_name == 'push') # || github.event_name == 'pull_request')
+  #   with:
+  #     upload_to_pypi: false
+  #     targets: |
+  #       - cp311-manylinux_x86_64
 
-    secrets:
-      pypi_token: ${{ secrets.pypi_token }} # consider using alternate strategy
+  #   secrets:
+  #     pypi_token: ${{ secrets.pypi_token }} # consider using alternate strategy
 
-  build_wheel:
+  build_wheels:
     # This does the actual wheel building or if triggered manually via the workflow dispatch, or for a tag.
     # this job does NOT publish the wheels
-    permissions:
-      contents: none
-    uses: someactionyml.yml #TODO: replace with wheel build action
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, windows-2022, macos-11]
     if: (github.repository == 'gumyr/build123d' && ( startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels')))
-    with:
-      # We upload to PyPI for all tags starting with v but not ones ending in .dev
-      upload_to_pypi: ${{ startsWith(github.ref, 'refs/tags/v') && !endsWith(github.ref, '.dev') && (github.event_name == 'push') }}
-      # For nightly wheels as well as when building with the 'Build all wheels' label, we disable
-      # the build isolation 
-      # the latest stable versions of all other build-time dependencies.
-      # need to tweak env according to https://github.com/pypa/cibuildwheel
-      env: |
-        CIBW_BEFORE_BUILD: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels')) && 'pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple') || '' }}'
-        CIBW_BUILD_FRONTEND: '${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels')) && 'pip; args: --no-build-isolation') || 'build' }}'
-      targets: |
-        # Linux wheels
+    steps:
+      - uses: actions/checkout@v4
 
-        - cp39-manylinux_x86_64
-        - cp310-manylinux_x86_64
-        - cp311-manylinux_x86_64
-        #- cp312-manylinux_x86_64
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.16.2
 
-        # MacOS X wheels
-        
-        - cp39*macosx_x86_64
-        - cp310*macosx_x86_64
-        - cp311*macosx_x86_64
-        #- cp312*macosx_x86_64
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
 
-        - cp39*macosx_arm64
-        - cp310*macosx_arm64
-        - cp311*macosx_arm64
-        #- cp312*macosx_arm64
+  # Do we need sdist wheels?
+  # build_sdist:
+  #   name: Build source distribution
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-        # Windows wheels
-        
-        - cp39*win_amd64
-        - cp310*win_amd64
-        - cp311*win_amd64
-        #- cp312*win_amd64
+  #     - name: Build sdist
+  #       run: pipx run build --sdist
 
-  pypi-publish:
-    # this job publishes the wheels built above
-    name: Upload release to PyPI
+  #     - uses: actions/upload-artifact@v3
+  #       with:
+  #         path: dist/*.tar.gz
+      
+  upload_pypi:
+    needs: [build_wheels] #, build_sdist]
     runs-on: ubuntu-latest
     environment:
       name: pypi
       url: https://pypi.org/p/build123d
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    # if: github.event_name == 'release' && github.event.action == 'published'
+    # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
+    if: (github.repository == 'gumyr/build123d' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     steps:
-    # TODO: ? retrieve your distributions here 
+      - uses: actions/download-artifact@v3
+        with:
+          # unpacks default artifact into dist/
+          # if `name: artifact` is omitted, the action will create extra parent dir
+          name: artifact
+          path: dist
 
-    - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # To test: repository-url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   push:
     branches:
-      - main  #check branch
+      - dev #check branch
   release:
     types:
       - published


### PR DESCRIPTION
This is ready for testing, it is setup to publish to the PyPI testing target (not any real PyPI target). There may need to be some changes made to `pyproject.toml` but I have not done that yet. Further info about `pyproject.toml` is here:

https://cibuildwheel.readthedocs.io/en/stable/options/