### PR TITLE
revise publish.yml GH Action to use `pip wheel` instead of cibuildwheel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,23 +26,23 @@ jobs:
   #   secrets:
   #     pypi_token: ${{ secrets.pypi_token }} # consider using alternate strategy
 
-  build_wheels:
+  build_wheel:
     # This does the actual wheel building or if triggered manually via the workflow dispatch, or for a tag.
-    # this job does NOT publish the wheels
-    name: Build wheels on ubuntu-latest
+    # this job does NOT publish the wheel
+    name: Build wheel on ubuntu-latest
     runs-on: ubuntu-latest
-    if: (github.repository == 'gumyr/build123d' && ( startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels')))
+    if: (github.repository == 'gumyr/build123d' && ( startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build wheel')))
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build wheels
+      - name: Build wheel
         run: pip wheel -w wheelhouse .
 
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
 
-  # Do we need sdist wheels?
+  # Do we need sdist wheel?
   # build_sdist:
   #   name: Build source distribution
   #   runs-on: ubuntu-latest
@@ -57,7 +57,7 @@ jobs:
   #         path: dist/*.tar.gz
       
   upload_pypi:
-    needs: [build_wheels] #, build_sdist]
+    needs: [build_wheel] #, build_sdist]
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,17 +29,14 @@ jobs:
   build_wheels:
     # This does the actual wheel building or if triggered manually via the workflow dispatch, or for a tag.
     # this job does NOT publish the wheels
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-22.04, windows-2022, macos-11]
+    name: Build wheels on ubuntu-latest
+    runs-on: ubuntu-latest
     if: (github.repository == 'gumyr/build123d' && ( startsWith(github.ref, 'refs/tags/v') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Build all wheels')))
     steps:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        run: pip wheel -w wheelhouse .
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
The prior version erroneously used cibuildwheel, which is not needed for a pure python project.