### PR TITLE
disable TestPyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,5 @@ jobs:
           path: dist
 
       - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
+        # with: # for testing with test.pypi.org
           # To test: repository-url: https://test.pypi.org/legacy/
-          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
will publish to PyPI directly rather than TestPyPI