### PR TITLE
pyproject.toml -> remove commented version and set cadquery-ocp >= 7.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "build123d"
-# version = "0.1.0"
 dynamic = ["version"]
 authors = [
     {name = "Roger Maitland", email = "gumyr9@gmail.com"},
@@ -36,7 +35,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "cadquery-ocp ~= 7.7.1",
+    "cadquery-ocp >= 7.7.0",
     "typing_extensions >= 4.6.0, <5",
     "numpy >= 1.24.1, <2",
     "svgpathtools >= 1.5.1, <2",


### PR DESCRIPTION
Commented version string is currently erroneously picked up by readthedocs, and serves no purpose since versions are managed by setuptools_scm