### PR TITLE
Trapezoid width is now fully controlled by width param

### DIFF
--- a/src/build123d/objects_sketch.py
+++ b/src/build123d/objects_sketch.py
@@ -621,13 +621,32 @@ class Trapezoid(BaseSketchObject):
         reduction_right = (
             0 if right_side_angle == 90 else height / tan(radians(right_side_angle))
         )
-        if reduction_left + reduction_right >= width:
+
+        top_width_left = width / 2
+        top_width_right = width / 2
+        bot_width_left = width / 2
+        bot_width_right = width / 2
+
+        if reduction_left > 0:
+            top_width_left -= reduction_left
+        else:
+            bot_width_left += reduction_left
+
+        if reduction_right > 0:
+            top_width_right -= reduction_right
+        else:
+            bot_width_right += reduction_right
+
+        if (bot_width_left + bot_width_right) < 0:
+            raise ValueError("Trapezoid bottom invalid - change angles")
+        if (top_width_left + top_width_right) < 0:
             raise ValueError("Trapezoid top invalid - change angles")
+
         pts = []
-        pts.append(Vector(-width / 2, -height / 2))
-        pts.append(Vector(width / 2, -height / 2))
-        pts.append(Vector(width / 2 - reduction_right, height / 2))
-        pts.append(Vector(-width / 2 + reduction_left, height / 2))
+        pts.append(Vector(-bot_width_left, -height / 2))
+        pts.append(Vector(bot_width_right, -height / 2))
+        pts.append(Vector(top_width_right, height / 2))
+        pts.append(Vector(-top_width_left, height / 2))
         pts.append(pts[0])
         face = Face.make_from_wires(Wire.make_polygon(pts))
         super().__init__(face, rotation, self.align, mode)

--- a/tests/test_build_sketch.py
+++ b/tests/test_build_sketch.py
@@ -382,6 +382,18 @@ class TestBuildSketchObjects(unittest.TestCase):
             with BuildSketch() as test:
                 Trapezoid(6, 2, 30)
 
+        with self.assertRaises(ValueError):
+            with BuildSketch() as test:
+                Trapezoid(6, 2, 150)
+
+        with BuildSketch() as test:
+            t = Trapezoid(12,8,135,90)
+        self.assertEqual(t.width, 12)
+        self.assertEqual(t.trapezoid_height, 8)
+        self.assertEqual(t.left_side_angle, 135)
+        self.assertEqual(t.right_side_angle, 90)
+        self.assertAlmostEqual(test.sketch.area, 8 * (12 + 4) / 2, 5)
+
     def test_triangle(self):
         tri = Triangle(a=3, b=4, c=5)
         self.assertAlmostEqual(tri.area, (3 * 4) / 2, 5)


### PR DESCRIPTION
Should address https://github.com/gumyr/build123d/issues/380 

```py
zz = Trapezoid(10,10,70)
print(zz.bounding_box().size)

zz2 = Trapezoid(10,10,90)
print(zz2.bounding_box().size)

zz3 = Trapezoid(10,10,110)
print(zz3.bounding_box().size)

zz4 = Trapezoid(10,10,110,90)
print(zz4.bounding_box().size)

zz5 = Trapezoid(10,10,90,110)
print(zz5.bounding_box().size)
```
returns:
```py
Vector: (10.0, 10.0, 0.0)
Vector: (10.0, 10.0, 0.0)
Vector: (10.0, 10.0, 0.0)
Vector: (10.0, 10.0, 0.0)
Vector: (10.0, 10.0, 0.0)
```