### PR TITLE
add `location_at` operator ^ for edge/wire, and tighten helix default tolerance

### DIFF
--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -4874,6 +4874,7 @@ class Edge(Mixin1D, Shape):
         normal: VectorLike = (0, 0, 1),
         angle: float = 0.0,
         lefthand: bool = False,
+        tol: float = 1e-9,
     ) -> Wire:
         """make_helix
 
@@ -4889,6 +4890,7 @@ class Edge(Mixin1D, Shape):
             normal (VectorLike, optional): Defaults to (0, 0, 1).
             angle (float, optional): conical angle. Defaults to 0.0.
             lefthand (bool, optional): Defaults to False.
+            tol (float, optional): tolerance, Defaults to 1e-9 
 
         Returns:
             Wire: helix
@@ -4925,7 +4927,7 @@ class Edge(Mixin1D, Shape):
         topods_edge = edge_builder.Edge()
 
         # 4. Convert the edge made with 2d geometry to 3d
-        BRepLib.BuildCurves3d_s(topods_edge)
+        BRepLib.BuildCurves3d_s(topods_edge, tol)
 
         return cls(topods_edge)
 

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -4874,7 +4874,6 @@ class Edge(Mixin1D, Shape):
         normal: VectorLike = (0, 0, 1),
         angle: float = 0.0,
         lefthand: bool = False,
-        tol: float = 1e-9,
     ) -> Wire:
         """make_helix
 
@@ -4890,7 +4889,6 @@ class Edge(Mixin1D, Shape):
             normal (VectorLike, optional): Defaults to (0, 0, 1).
             angle (float, optional): conical angle. Defaults to 0.0.
             lefthand (bool, optional): Defaults to False.
-            tol (float, optional): tolerance, Defaults to 1e-9 
 
         Returns:
             Wire: helix
@@ -4927,7 +4925,7 @@ class Edge(Mixin1D, Shape):
         topods_edge = edge_builder.Edge()
 
         # 4. Convert the edge made with 2d geometry to 3d
-        BRepLib.BuildCurves3d_s(topods_edge, tol, MaxSegment=2000)
+        BRepLib.BuildCurves3d_s(topods_edge, 1e-9, MaxSegment=2000)
 
         return cls(topods_edge)
 

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -4927,7 +4927,7 @@ class Edge(Mixin1D, Shape):
         topods_edge = edge_builder.Edge()
 
         # 4. Convert the edge made with 2d geometry to 3d
-        BRepLib.BuildCurves3d_s(topods_edge, tol)
+        BRepLib.BuildCurves3d_s(topods_edge, tol, MaxSegments=2000)
 
         return cls(topods_edge)
 

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -4927,7 +4927,7 @@ class Edge(Mixin1D, Shape):
         topods_edge = edge_builder.Edge()
 
         # 4. Convert the edge made with 2d geometry to 3d
-        BRepLib.BuildCurves3d_s(topods_edge, tol, MaxSegments=2000)
+        BRepLib.BuildCurves3d_s(topods_edge, tol, MaxSegment=2000)
 
         return cls(topods_edge)
 

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -790,6 +790,10 @@ class Mixin1D:
         """Tangent on wire operator %"""
         return self.tangent_at(position)
 
+    def __xor__(self: Union[Edge, Wire], position: float) -> Location:
+        """Location on wire operator ^"""
+        return self.location_at(position)
+
     def offset_2d(
         self,
         distance: float,

--- a/tests/test_build_common.py
+++ b/tests/test_build_common.py
@@ -221,6 +221,14 @@ class TestCommonOperations(unittest.TestCase):
             (Wire.make_circle(10) % 0.5).to_tuple(), (0, -1, 0), 5
         )
 
+    def test_xor(self):
+        helix_loc = Edge.make_helix(2 * pi, 1, 1) ^ 0
+        self.assertTupleAlmostEquals(
+            helix_loc.position.to_tuple(), (1, 0, 0), 5
+        )
+        self.assertTupleAlmostEquals(
+            helix_loc.orientation.to_tuple(), (-45, 0, 180), 5
+        )
 
 class TestLocations(unittest.TestCase):
     def test_polar_locations(self):


### PR DESCRIPTION
This PR enables e.g. `wire^0` to return Location which is a companion with `wire@0 -> position` and `wire%0 -> tangent`. In the process of creating the test for the above I discovered the default `make_helix` tolerance was `1e-5` which is too coarse, I tightened to `1e-9`.