### PR TITLE
topology.py -> Fix offset closed length check to include abs(distance)

### DIFF
--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -885,7 +885,7 @@ class Mixin1D:
                 self1 = line.position_at(1)
                 end0 = offset_wire.position_at(0)
                 end1 = offset_wire.position_at(1)
-                if (self0 - end0).length - distance <= TOLERANCE:
+                if (self0 - end0).length - abs(distance) <= TOLERANCE:
                     edge0 = Edge.make_line(self0, end0)
                     edge1 = Edge.make_line(self1, end1)
                 else:


### PR DESCRIPTION
Fixes this behavior by correcting the closed segment length check to include `abs(distance)` to account for negative offset amounts. 
![image](https://github.com/gumyr/build123d/assets/16868537/4d1ec232-acd6-4d5d-b20e-2e2fb409a206)
