### PR TITLE
Fix "1d" sweep

### DIFF
--- a/src/build123d/operations_generic.py
+++ b/src/build123d/operations_generic.py
@@ -1035,7 +1035,7 @@ def sweep(
     new_faces = []
     if edge_list:
         for sec in section_list:
-            swept = Face.sweep(sec, path_wire)  # Could generate a shell here
+            swept = Face.sweep(sec, path_wire, transition)
             new_faces.extend(swept.faces())
 
     if context is not None:

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -5385,15 +5385,15 @@ class Face(Shape):
         return sewn_faces
 
     @classmethod
-    def sweep(cls, profile: Edge, path: Union[Edge, Wire]) -> Face:
+    def sweep(cls, profile: Union[Edge, Wire], path: Union[Edge, Wire], transition=Transition.RIGHT) -> Face:
         """Sweep a 1D profile along a 1D path"""
-        if isinstance(path, Edge):
-            path = Wire.make_wire([path])
-        # Ensure the edges in the path are ordered correctly
+        profile = profile.to_wire()
         path = Wire.make_wire(path.order_edges())
-        pipe_sweep = BRepOffsetAPI_MakePipe(path.wrapped, profile.wrapped)
-        pipe_sweep.Build()
-        return Face(pipe_sweep.Shape())
+        builder = BRepOffsetAPI_MakePipeShell(path.wrapped)
+        builder.Add(profile.wrapped, False, False)
+        builder.SetTransitionMode(Solid._transModeDict[transition])
+        builder.Build()
+        return Shape.cast(builder.Shape())
 
     @classmethod
     def make_surface_from_array_of_points(

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -5388,12 +5388,12 @@ class Face(Shape):
     def sweep(cls, profile: Union[Edge, Wire], path: Union[Edge, Wire], transition=Transition.RIGHT) -> Face:
         """Sweep a 1D profile along a 1D path"""
         profile = profile.to_wire()
-        path = Wire.make_wire(path.order_edges())
+        path = Wire.make_wire(path.to_wire().order_edges())
         builder = BRepOffsetAPI_MakePipeShell(path.wrapped)
         builder.Add(profile.wrapped, False, False)
         builder.SetTransitionMode(Solid._transModeDict[transition])
         builder.Build()
-        return Shape.cast(builder.Shape())
+        return Shape.cast(builder.Shape()).clean().face()
 
     @classmethod
     def make_surface_from_array_of_points(

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -4269,6 +4269,9 @@ class Curve(Compound):
     def wires(self) -> list[Wire]:
         """A list of wires created from the edges"""
         return Wire.combine(self.edges())
+    
+    def to_wire(self) -> Wire:
+        return Wire.make_wire(self.edges())
 
 
 class Edge(Mixin1D, Shape):


### PR DESCRIPTION
```py
with BuildSketch() as s:
    spine = Polyline((0,0), (1,10), (10,10), mode=PRIVATE)
    sect = spine.wire().perpendicular_line(2, 0)
    sweep(sect, spine, transition=Transition.RIGHT)
```

### Before
<img width="296" alt="Screenshot1" src="https://github.com/gumyr/build123d/assets/149267773/bb237834-04ed-4b1d-aaf2-73ecd4ebdd48">

### After
<img width="293" alt="Screenshot" src="https://github.com/gumyr/build123d/assets/149267773/d9fdad2f-11e6-4ab4-a506-a74165d5990e">
