### PR TITLE
Return 0.0 for 1D and 2D shapes

### DIFF
--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -965,6 +965,14 @@ class Mixin1D:
 
         return return_value
 
+class Mixin2D:
+    """Methods to add to the Face and Shell classes"""
+
+    @property
+    def volume(self) -> float:
+        """volume - the volume of this Face or Shell, which is always zero"""
+        return 0.0
+
 
 class Mixin3D:
     """Additional methods to add to 3D Shape classes"""
@@ -5029,7 +5037,7 @@ class Edge(Mixin1D, Shape):
         return Axis(self.position_at(0), self.position_at(1) - self.position_at(0))
 
 
-class Face(Shape):
+class Face(Mixin2D, Shape):
     """a bounded surface that represents part of the boundary of a solid"""
 
     # pylint: disable=too-many-public-methods
@@ -5807,7 +5815,7 @@ class Face(Shape):
         return Compound.make_compound([self]).is_inside(point, tolerance)
 
 
-class Shell(Shape):
+class Shell(Mixin2D, Shape):
     """the outer boundary of a surface"""
 
     _dim = 2

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -658,6 +658,11 @@ class Mixin1D:
         """Are the start and end points equal?"""
         return BRep_Tool.IsClosed_s(self.wrapped)
 
+    @property
+    def volume(self) -> float:
+        """volume - the volume of this Edge or Wire, which is always zero"""
+        return 0.0
+
     def position_at(
         self, distance: float, position_mode: PositionMode = PositionMode.LENGTH
     ) -> Vector:
@@ -3806,6 +3811,12 @@ class Compound(Mixin3D, Shape):
         else:
             result = f"{self.__class__.__name__} at {id(self):#x}"
         return result
+
+    @property
+    def volume(self) -> float:
+        """volume - the volume of this Shape"""
+        # when density == 1, mass == volume
+        return sum(i.volume for i in self.children)
 
     def center(self, center_of: CenterOf = CenterOf.MASS) -> Vector:
         """Return center of object

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -970,14 +970,6 @@ class Mixin1D:
 
         return return_value
 
-class Mixin2D:
-    """Methods to add to the Face and Shell classes"""
-
-    @property
-    def volume(self) -> float:
-        """volume - the volume of this Face or Shell, which is always zero"""
-        return 0.0
-
 
 class Mixin3D:
     """Additional methods to add to 3D Shape classes"""
@@ -2251,11 +2243,11 @@ class Shape(NodeMixin):
 
         return properties.Mass()
 
-    @property
-    def volume(self) -> float:
-        """volume - the volume of this Shape"""
-        # when density == 1, mass == volume
-        return Shape.compute_mass(self)
+    # @property
+    # def volume(self) -> float:
+    #     """volume - the volume of this Shape"""
+    #     # when density == 1, mass == volume
+    #     return Shape.compute_mass(self)
 
     def _apply_transform(self, transformation: gp_Trsf) -> Self:
         """Private Apply Transform
@@ -3816,7 +3808,7 @@ class Compound(Mixin3D, Shape):
     def volume(self) -> float:
         """volume - the volume of this Shape"""
         # when density == 1, mass == volume
-        return sum(i.volume for i in self.solids())
+        return sum(i.volume for i in [*self.get_type(Solid), *self.get_type(Shell)])
 
     def center(self, center_of: CenterOf = CenterOf.MASS) -> Vector:
         """Return center of object
@@ -5048,7 +5040,7 @@ class Edge(Mixin1D, Shape):
         return Axis(self.position_at(0), self.position_at(1) - self.position_at(0))
 
 
-class Face(Mixin2D, Shape):
+class Face(Shape):
     """a bounded surface that represents part of the boundary of a solid"""
 
     # pylint: disable=too-many-public-methods
@@ -5076,6 +5068,11 @@ class Face(Mixin2D, Shape):
             face_vertices = flat_face.vertices().sort_by(Axis.Y)
             result = face_vertices[-1].Y - face_vertices[0].Y
         return result
+
+    @property
+    def volume(self) -> float:
+        """volume - the volume of this Face, which is always zero"""
+        return 0.0
 
     @property
     def geometry(self) -> str:
@@ -5622,7 +5619,9 @@ class Face(Mixin2D, Shape):
         chamfer_builder = BRepFilletAPI_MakeFillet2d(self.wrapped)
 
         vertex_edge_map = TopTools_IndexedDataMapOfShapeListOfShape()
-        TopExp.MapShapesAndAncestors_s(self.wrapped, ta.TopAbs_VERTEX, ta.TopAbs_EDGE, vertex_edge_map)
+        TopExp.MapShapesAndAncestors_s(
+            self.wrapped, ta.TopAbs_VERTEX, ta.TopAbs_EDGE, vertex_edge_map
+        )
 
         for v in vertices:
             edges = vertex_edge_map.FindFromKey(v.wrapped)
@@ -5642,7 +5641,7 @@ class Face(Mixin2D, Shape):
                 edge2 = [x for x in edges if x != reference_edge][0]
             else:
                 edge1, edge2 = edges
-          
+
             chamfer_builder.AddChamfer(
                 TopoDS.Edge_s(edge1.wrapped),
                 TopoDS.Edge_s(edge2.wrapped),
@@ -5826,10 +5825,19 @@ class Face(Mixin2D, Shape):
         return Compound.make_compound([self]).is_inside(point, tolerance)
 
 
-class Shell(Mixin2D, Shape):
+class Shell(Shape):
     """the outer boundary of a surface"""
 
     _dim = 2
+
+    @property
+    def volume(self) -> float:
+        """volume - the volume of this Shell if manifold, otherwise zero"""
+        # when density == 1, mass == volume
+        if self.is_manifold:
+            return Solid.make_solid(self).volume
+        else:
+            return 0.0
 
     @classmethod
     def make_shell(cls, faces: Iterable[Face]) -> Shell:
@@ -5855,6 +5863,12 @@ class Solid(Mixin3D, Shape):
     """a single solid"""
 
     _dim = 3
+
+    @property
+    def volume(self) -> float:
+        """volume - the volume of this Solid"""
+        # when density == 1, mass == volume
+        return Shape.compute_mass(self)
 
     @classmethod
     def make_solid(cls, shell: Shell) -> Solid:
@@ -6597,6 +6611,11 @@ class Vertex(Shape):
 
         super().__init__(ocp_vx)
         self.X, self.Y, self.Z = self.to_tuple()
+
+    @property
+    def volume(self) -> float:
+        """volume - the volume of this Vertex, which is always zero"""
+        return 0.0
 
     def to_tuple(self) -> tuple[float, float, float]:
         """Return vertex as three tuple of floats"""

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -970,14 +970,6 @@ class Mixin1D:
 
         return return_value
 
-class Mixin2D:
-    """Methods to add to the Face and Shell classes"""
-
-    @property
-    def volume(self) -> float:
-        """volume - the volume of this Face or Shell, which is always zero"""
-        return 0.0
-
 
 class Mixin3D:
     """Additional methods to add to 3D Shape classes"""

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -3816,7 +3816,7 @@ class Compound(Mixin3D, Shape):
     def volume(self) -> float:
         """volume - the volume of this Shape"""
         # when density == 1, mass == volume
-        return sum(i.volume for i in self.children)
+        return sum(i.volume for i in self.solids())
 
     def center(self, center_of: CenterOf = CenterOf.MASS) -> Vector:
         """Return center of object

--- a/tests/test_build_generic.py
+++ b/tests/test_build_generic.py
@@ -114,7 +114,7 @@ class AddTests(unittest.TestCase):
                     ]
                 )
             )
-        self.assertEqual(test.part.volume, 1125, 5)
+        self.assertAlmostEqual(test.part.volume, 1125, 5)
         with BuildPart() as test:
             add(Compound.make_compound([Edge.make_line((0, 0), (1, 1))]))
         self.assertEqual(len(test.pending_edges), 1)

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -1984,6 +1984,14 @@ class TestMixin1D(DirectApiTestCase):
         self.assertAlmostEqual(common.z_dir.Y, 0, 5)
         self.assertAlmostEqual(common.z_dir.Z, 0, 5)
 
+    def test_edge_volume(self):
+        edge = Edge.make_line((0,0),(1,1))
+        self.assertAlmostEqual(edge.volume, 0, 5)
+
+    def test_wire_volume(self):
+        wire = Wire.make_rect(1,1)
+        self.assertAlmostEqual(wire.volume, 0, 5)
+
 
 class TestMixin2D(DirectApiTestCase):
     """Test the 2D add in methods"""

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -1041,6 +1041,10 @@ class TestFace(DirectApiTestCase):
             5,
         )
 
+    def test_face_volume(self):
+        rect = Face.make_rect(1, 1)
+        self.assertAlmostEqual(rect.volume, 0, 5)
+
     def test_chamfer_2d(self):
         test_face = Face.make_rect(10, 10)
         test_face = test_face.chamfer_2d(
@@ -2008,19 +2012,6 @@ class TestMixin1D(DirectApiTestCase):
     def test_wire_volume(self):
         wire = Wire.make_rect(1,1)
         self.assertAlmostEqual(wire.volume, 0, 5)
-
-
-class TestMixin2D(DirectApiTestCase):
-    """Test the 2D add in methods"""
-
-    def test_face_volume(self):
-        rect = Face.make_rect(1, 1)
-        self.assertAlmostEqual(rect.volume, 0, 5)
-
-    def test_shell_volume(self):
-        box_faces = Solid.make_box(1, 1, 1).faces()
-        box_shell = Shell.make_shell(box_faces)
-        self.assertAlmostEqual(box_shell.volume, 0, 5)
 
 
 class TestMixin3D(DirectApiTestCase):
@@ -3078,6 +3069,17 @@ class TestShells(DirectApiTestCase):
         box_shell = Shell.make_shell(box_faces)
         self.assertVectorAlmostEquals(box_shell.center(), (0.5, 0.5, 0.5), 5)
 
+    def test_manifold_shell_volume(self):
+        box_faces = Solid.make_box(1, 1, 1).faces()
+        box_shell = Shell.make_shell(box_faces)
+        self.assertAlmostEqual(box_shell.volume, 1, 5)
+
+    def test_nonmanifold_shell_volume(self):
+        box_faces = Solid.make_box(1, 1, 1).faces()
+        nm_shell = Shell.make_shell(box_faces)
+        nm_shell -= nm_shell.faces()[0]
+        self.assertAlmostEqual(nm_shell.volume, 0, 5)
+
 
 class TestSolid(DirectApiTestCase):
     def test_make_solid(self):
@@ -3449,6 +3451,10 @@ class TestVertex(DirectApiTestCase):
         self.assertVectorAlmostEquals(Vector(Vertex((4, 5, 6))), (4, 5, 6), 7)
         self.assertVectorAlmostEquals(Vector(Vertex((7,))), (7, 0, 0), 7)
         self.assertVectorAlmostEquals(Vector(Vertex((8, 9))), (8, 9, 0), 7)
+
+    def test_vertex_volume(self):
+        v = Vertex(1, 1, 1)
+        self.assertAlmostEqual(v.volume, 0, 5)
 
     def test_vertex_add(self):
         test_vertex = Vertex(0, 0, 0)

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -1985,6 +1985,19 @@ class TestMixin1D(DirectApiTestCase):
         self.assertAlmostEqual(common.z_dir.Z, 0, 5)
 
 
+class TestMixin2D(DirectApiTestCase):
+    """Test the 2D add in methods"""
+
+    def test_face_volume(self):
+        rect = Face.make_rect(1, 1)
+        self.assertAlmostEqual(rect.volume, 0, 5)
+
+    def test_shell_volume(self):
+        box_faces = Solid.make_box(1, 1, 1).faces()
+        box_shell = Shell.make_shell(box_faces)
+        self.assertAlmostEqual(box_shell.volume, 0, 5)
+
+
 class TestMixin3D(DirectApiTestCase):
     """Test that 3D add ins"""
 

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -790,6 +790,23 @@ class TestCompound(DirectApiTestCase):
         self.assertLess(bbox.size.Z, 12.5)
         self.assertEqual(triad.volume, 0)
 
+    def test_volume(self):
+        e = Edge.make_line((0, 0), (1, 1))
+        self.assertAlmostEqual(e.volume, 0, 5)
+
+        f = Face.make_rect(1, 1)
+        self.assertAlmostEqual(f.volume, 0, 5)
+
+        b = Solid.make_box(1, 1, 1)
+        self.assertAlmostEqual(b.volume, 1, 5)
+
+        bb = Box(1, 1, 1)
+        self.assertAlmostEqual(bb.volume, 1, 5)
+
+        c = Compound(children=[e, f, b, bb, b.translate((0, 5, 0))])
+        self.assertAlmostEqual(c.volume, 3, 5)
+        # N.B. b and bb overlap but still add to Compound volume
+
 
 class TestEdge(DirectApiTestCase):
     def test_close(self):


### PR DESCRIPTION
Per https://github.com/gumyr/build123d/issues/319

Last remaining question: should `Shape.volume` be eliminated and instead have `Mixin3D.volume` ? `Shape.compute_mass` would possibly be affected as well.