### PR TITLE
Fix offset of faces with holes

### DIFF
--- a/src/build123d/operations_generic.py
+++ b/src/build123d/operations_generic.py
@@ -593,11 +593,12 @@ def offset(
             outer_wire = outer_wire.fix_degenerate_edges(min_edge_length)
         inner_wires = []
         for inner_wire in face.inner_wires():
-            offset_wire = inner_wire.offset_2d(-amount, kind=kind)
-            if min_edge_length is not None:
-                inner_wires.append(offset_wire.fix_degenerate_edges(min_edge_length))
-            else:
-                inner_wires.append(offset_wire)
+            try:
+                offset_wire = inner_wire.offset_2d(-amount, kind=kind)
+                if min_edge_length is not None:
+                    inner_wires.append(offset_wire.fix_degenerate_edges(min_edge_length))
+                else:
+                    inner_wires.append(offset_wire)
         new_faces.append(Face.make_from_wires(outer_wire, inner_wires))
     if edges:
         if len(edges) == 1 and edges[0].geom_type() == "LINE":

--- a/src/build123d/operations_generic.py
+++ b/src/build123d/operations_generic.py
@@ -599,6 +599,8 @@ def offset(
                     inner_wires.append(offset_wire.fix_degenerate_edges(min_edge_length))
                 else:
                     inner_wires.append(offset_wire)
+            except:
+                pass
         new_faces.append(Face.make_from_wires(outer_wire, inner_wires))
     if edges:
         if len(edges) == 1 and edges[0].geom_type() == "LINE":

--- a/tests/test_build_generic.py
+++ b/tests/test_build_generic.py
@@ -591,6 +591,14 @@ class OffsetTests(unittest.TestCase):
         o_line = offset(line, amount=3.177)
         self.assertEqual(len(o_line.edges()), 19)
 
+    def test_offset_face_with_inner_wire(self):
+        # offset amount causes the inner wire to have zero area
+        b = Rectangle(1, 1)
+        b -= RegularPolygon(.25, 3)
+        b = offset(b, amount=0.125)
+        self.assertAlmostEqual(b.area, 1 ** 2 + 2 * 0.125 * 2 + pi * 0.125 ** 2, 5)
+        self.assertEqual(len(b.face().inner_wires()), 0)
+    
     def test_offset_bad_type(self):
         with self.assertRaises(TypeError):
             offset(Vertex(), amount=1)

--- a/tests/test_build_generic.py
+++ b/tests/test_build_generic.py
@@ -592,12 +592,25 @@ class OffsetTests(unittest.TestCase):
         self.assertEqual(len(o_line.edges()), 19)
 
     def test_offset_face_with_inner_wire(self):
-        # offset amount causes the inner wire to have zero area
+        # offset amount causes the inner wire to have zero length
         b = Rectangle(1, 1)
         b -= RegularPolygon(.25, 3)
         b = offset(b, amount=0.125)
         self.assertAlmostEqual(b.area, 1 ** 2 + 2 * 0.125 * 2 + pi * 0.125 ** 2, 5)
         self.assertEqual(len(b.face().inner_wires()), 0)
+
+    def test_offset_face_with_min_length(self):
+        c = Circle(.5)
+        c = offset(c, amount=0.125, min_edge_length=0.1)
+        self.assertAlmostEqual(c.area, pi * (0.5 + 0.125) ** 2, 5)
+    
+    def test_offset_face_with_min_length_and_inner(self):
+        # offset amount causes the inner wire to have zero length
+        c = Circle(.5)
+        c -= RegularPolygon(.25, 3)
+        c = offset(c, amount=0.125, min_edge_length=0.1)
+        self.assertAlmostEqual(c.area, pi * (0.5 + 0.125) ** 2, 5)
+        self.assertEqual(len(c.face().inner_wires()), 0)
     
     def test_offset_bad_type(self):
         with self.assertRaises(TypeError):


### PR DESCRIPTION
Currently, offset of faces with holes can fail when the length of the inner wires reaches zero. This causes confusion for users especially with offsets of text that frequently contains holes.

This PR fixes that issue by silently deleting the inner wires if there is an exception while offsetting them. This example now works properly:
```py
with BuildSketch() as s:
    t = Text("build", 20)
    offset(amount=5, mode=Mode.ADD)
```
![image](https://github.com/gumyr/build123d/assets/16868537/b23bc7ef-0010-4392-82ff-5e9dfe3f9421)
