### PR TITLE
Small doc change: Area() to property area

### DIFF
--- a/docs/advantages.rst
+++ b/docs/advantages.rst
@@ -47,7 +47,7 @@ an instance variable as with standard python programming for direct use.
 
     with BuildSketch() as plan:
         r = Rectangle(width, height)
-        print(r.Area())
+        print(r.area)
         ...
 
 Operators

--- a/docs/advantages.rst
+++ b/docs/advantages.rst
@@ -68,7 +68,7 @@ features to these points without knowing their numeric values.
         ...
         l5 = Polyline(...)
         l6 = Polyline(...)
-        spline(l5 @ 1, l6 @ 0, tangents=(l5 % 1, l6 % 0))
+        Spline(l5 @ 1, l6 @ 0, tangents=(l5 % 1, l6 % 0))
 
 
 Last Operation Objects


### PR DESCRIPTION
Small changes to documentation 
- `Rectangle.Area()` does not (anymore?) exist but `Rectangle.area` is now a property.
- `spline` changed to `Spline` in examples