### PR TITLE
Include rounding in Plane(face) and Plane(loc)

### DIFF
--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -1828,7 +1828,9 @@ class Plane(metaclass=PlaneMeta):
                     BRep_Tool.Surface_s(arg_face.wrapped).Position().XDirection()
                 )
             )
+            self.x_dir = Vector(round(i, 14) for i in self.x_dir)
             self.z_dir = Plane.get_topods_face_normal(arg_face.wrapped)
+            self.z_dir = Vector(round(i, 14) for i in self.z_dir)
         elif arg_location:
             topo_face = BRepBuilderAPI_MakeFace(
                 Plane.XY.wrapped, -1.0, 1.0, -1.0, 1.0
@@ -1836,7 +1838,9 @@ class Plane(metaclass=PlaneMeta):
             topo_face.Move(arg_location.wrapped)
             self._origin = arg_location.position
             self.x_dir = Vector(BRep_Tool.Surface_s(topo_face).Position().XDirection())
+            self.x_dir = Vector(round(i, 14) for i in self.x_dir)
             self.z_dir = Plane.get_topods_face_normal(topo_face)
+            self.z_dir = Vector(round(i, 14) for i in self.z_dir)
         elif arg_origin:
             self._origin = Vector(arg_origin)
             self.x_dir = Vector(arg_x_dir) if arg_x_dir else None


### PR DESCRIPTION
Platform specific handling of floats is causing tests on aarch64 to fail in relation to orientation. After a lot of investigation and test runs using flyci, rounding to 14 decimal places seems to provide reliable behavior on both x86_64 and aarch64. 

This is related to issue #478 and fixes one of the two failing tests mentioned there. This was not, as previously postulated, related to quaternion vs. orientation vector comparison.