### PR TITLE
fillet/chamfer float comparison with zero via isclose abs_tol=1e-14

### DIFF
--- a/src/build123d/operations_generic.py
+++ b/src/build123d/operations_generic.py
@@ -28,7 +28,7 @@ license:
 """
 import copy
 import logging
-from math import radians, tan
+from math import radians, tan, isclose
 from typing import Union, Iterable
 
 from build123d.build_common import (
@@ -362,8 +362,16 @@ def chamfer(
         if not target.is_closed:
             object_list = filter(
                 lambda v: not (
-                    (Vector(*v.to_tuple()) - target.position_at(0)).length == 0
-                    or (Vector(*v.to_tuple()) - target.position_at(1)).length == 0
+                    isclose(
+                        (Vector(*v.to_tuple()) - target.position_at(0)).length,
+                        0.0,
+                        abs_tol=1e-14,
+                    )
+                    or isclose(
+                        (Vector(*v.to_tuple()) - target.position_at(1)).length,
+                        0.0,
+                        abs_tol=1e-14,
+                    )
                 ),
                 object_list,
             )
@@ -455,8 +463,16 @@ def fillet(
         if not target.is_closed:
             object_list = filter(
                 lambda v: not (
-                    (Vector(*v.to_tuple()) - target.position_at(0)).length == 0
-                    or (Vector(*v.to_tuple()) - target.position_at(1)).length == 0
+                    isclose(
+                        (Vector(*v.to_tuple()) - target.position_at(0)).length,
+                        0.0,
+                        abs_tol=1e-14,
+                    )
+                    or isclose(
+                        (Vector(*v.to_tuple()) - target.position_at(1)).length,
+                        0.0,
+                        abs_tol=1e-14,
+                    )
                 ),
                 object_list,
             )


### PR DESCRIPTION
Fixes failing test on apple silicon. Closes issue #478 

This fixes the following previously failing test:
```py
self = <test_build_part.TestMakeBrakeFormed testMethod=test_make_brake_formed>
    def test_make_brake_formed(self):
        # TODO: Fix so this test doesn't raise a DeprecationWarning from NumPy
        with BuildPart() as bp:
            with BuildLine() as bl:
                m1 = Polyline((0, 0), (5, 6), (10, 1))
>               fillet(m1.vertices(), 1)
```
As suspected, the behavior of floats on apple silicon is just a bit different. Comparison of a float with 0.0 is a possible source of architecture specific issues. Current recommendation adopted here is to use `math.isclose` with an appropriate `abs_tol` e.g. `1e-14`.