### PR TITLE
Add Face.make_bezier_surface()

### DIFF
--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -5718,8 +5718,7 @@ class Face(Shape):
             )
         if len(points) > 25 or len(points[0]) > 25:
             raise ValueError("The maximum number of control points is 25")
-        if weights && (len(points) != len(weights) or
-                       len(points[0]) != len(weights[0])):
+        if weights and (len(points) != len(weights) or len(points[0]) != len(weights[0])):
             raise ValueError("A weight must be provided for each control point")
 
         points_ = TColgp_HArray2OfPnt(1, len(points), 1, len(points[0]))

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -152,6 +152,7 @@ from OCP.gce import gce_MakeLin
 from OCP.GCPnts import GCPnts_AbscissaPoint
 from OCP.Geom import (
     Geom_BezierCurve,
+    Geom_BezierSurface,
     Geom_ConicalSurface,
     Geom_CylindricalSurface,
     Geom_Plane,
@@ -5688,6 +5689,54 @@ class Face(Shape):
         spline_geom = spline_builder.Surface()
 
         return cls(BRepBuilderAPI_MakeFace(spline_geom, Precision.Confusion_s()).Face())
+
+    @classmethod
+    def make_bezier_surface(
+        cls,
+        points: list[list[VectorLike]],
+        weights: list[list[float]] = None,
+    ) -> Face:
+        """make_bezier_surface
+
+        Construct a Bézier surface from the provided 2d array of points.
+
+        Args:
+            points (list[list[VectorLike]]): a 2D list of control points
+            weights (list[list[float]], optional): control point weights. Defaults to None.
+
+        Raises:
+            ValueError: Too few control points
+            ValueError: Too many control points
+            ValueError: A weight is required for each control point
+
+        Returns:
+            Face: a potentially non-planar face
+        """
+        if len(points) < 2 or len(points[0]) < 2:
+            raise ValueError(
+                "At least two control points must be provided (start, end)"
+            )
+        if len(points) > 25 or len(points[0]) > 25:
+            raise ValueError("The maximum number of control points is 25")
+        if weights && (len(points) != len(weights) or
+                       len(points[0]) != len(weights[0])):
+            raise ValueError("A weight must be provided for each control point")
+
+        points_ = TColgp_HArray2OfPnt(1, len(points), 1, len(points[0]))
+        for i, row in enumerate(points):
+            for j, point in enumerate(row):
+                points_.SetValue(i + 1, j + 1, Vector(point).to_pnt())
+
+        if weights:
+            weights_ = TColgp_HArray2OfPnt(1, len(weights), 1, len(weights[0]))
+            for i, row in enumerate(weights):
+                for j, weight in enumerate(row):
+                    weights_.SetValue(i + 1, j + 1, float(weight))
+            bezier = Geom_BezierSurface(points_, weights_)
+        else:
+            bezier = Geom_BezierSurface(points_)
+
+        return cls(BRepBuilderAPI_MakeFace(bezier, Precision.Confusion_s()).Face())
 
     @classmethod
     def make_surface(

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -1163,6 +1163,18 @@ class TestFace(DirectApiTestCase):
         self.assertVectorAlmostEquals(bbox.min, (0, 0, -1), 3)
         self.assertVectorAlmostEquals(bbox.max, (10, 10, 2), 2)
 
+    def test_bezier_surface(self):
+        points = [ [ (x, y,
+                      2 if x == 0 and y == 0 else
+                      1 if x == 0 or y == 0 else 0
+                      ) for x in range(-1,2)
+                    ] for y in range(-1, 2)
+                  ]
+        surface = Face.make_bezier_surface(points)
+        bbox = surface.bounding_box()
+        self.assertVectorAlmostEquals(bbox.min, (-1, -1, 0), 3)
+        self.assertVectorAlmostEquals(bbox.max, (+1, +1, +1), 3)
+
     def test_thicken(self):
         pnts = [
             [

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -1173,7 +1173,7 @@ class TestFace(DirectApiTestCase):
         surface = Face.make_bezier_surface(points)
         bbox = surface.bounding_box()
         self.assertVectorAlmostEquals(bbox.min, (-1, -1, 0), 3)
-        self.assertVectorAlmostEquals(bbox.max, (+1, +1, +1), 3)
+        self.assertVectorAlmostEquals(bbox.max, (+1, +1, +1), 1)
 
     def test_thicken(self):
         pnts = [


### PR DESCRIPTION
When making superellipses and superellipsoids with build123d, I have found I get the best results using Bézier curves and surfaces to approximate the shapes. Bézier curves are already supported, but Bézier surfaces were not - at least not without dropping down to OCP.

Here's a sketchy patch based on the code i'm using to construct Bézier surfaces. I have not tried installing build123d from source so I have not properly tested this myself, but I think it's a plausible start.