### PR TITLE
Return `GeomType` enum, from `Shape.geom_type()`

### DIFF
--- a/src/build123d/build_enums.py
+++ b/src/build123d/build_enums.py
@@ -25,6 +25,7 @@ license:
     limitations under the License.
 
 """
+
 from __future__ import annotations
 from enum import Enum, auto
 
@@ -103,25 +104,25 @@ class FrameMethod(Enum):
         return f"<{self.__class__.__name__}.{self.name}>"
 
 
-class GeomType(str, Enum):
+class GeomType(Enum):
     """CAD geometry object type"""
 
-    PLANE = 'PLANE'
-    CYLINDER = 'CYLINDER'
-    CONE = 'CONE'
-    SPHERE = 'SPHERE'
-    TORUS = 'TORUS'
-    BEZIER = 'BEZIER'
-    BSPLINE = 'BSPLINE'
-    REVOLUTION = 'REVOLUTION'
-    EXTRUSION = 'EXTRUSION'
-    OFFSET = 'OFFSET'
-    LINE = 'LINE'
-    CIRCLE = 'CIRCLE'
-    ELLIPSE = 'ELLIPSE'
-    HYPERBOLA = 'HYPERBOLA'
-    PARABOLA = 'PARABOLA'
-    OTHER = 'OTHER'
+    PLANE = auto()
+    CYLINDER = auto()
+    CONE = auto()
+    SPHERE = auto()
+    TORUS = auto()
+    BEZIER = auto()
+    BSPLINE = auto()
+    REVOLUTION = auto()
+    EXTRUSION = auto()
+    OFFSET = auto()
+    LINE = auto()
+    CIRCLE = auto()
+    ELLIPSE = auto()
+    HYPERBOLA = auto()
+    PARABOLA = auto()
+    OTHER = auto()
 
     def __repr__(self):
         return f"<{self.__class__.__name__}.{self.name}>"

--- a/src/build123d/build_enums.py
+++ b/src/build123d/build_enums.py
@@ -103,25 +103,25 @@ class FrameMethod(Enum):
         return f"<{self.__class__.__name__}.{self.name}>"
 
 
-class GeomType(Enum):
+class GeomType(str, Enum):
     """CAD geometry object type"""
 
-    PLANE = auto()
-    CYLINDER = auto()
-    CONE = auto()
-    SPHERE = auto()
-    TORUS = auto()
-    BEZIER = auto()
-    BSPLINE = auto()
-    REVOLUTION = auto()
-    EXTRUSION = auto()
-    OFFSET = auto()
-    LINE = auto()
-    CIRCLE = auto()
-    ELLIPSE = auto()
-    HYPERBOLA = auto()
-    PARABOLA = auto()
-    OTHER = auto()
+    PLANE = 'PLANE'
+    CYLINDER = 'CYLINDER'
+    CONE = 'CONE'
+    SPHERE = 'SPHERE'
+    TORUS = 'TORUS'
+    BEZIER = 'BEZIER'
+    BSPLINE = 'BSPLINE'
+    REVOLUTION = 'REVOLUTION'
+    EXTRUSION = 'EXTRUSION'
+    OFFSET = 'OFFSET'
+    LINE = 'LINE'
+    CIRCLE = 'CIRCLE'
+    ELLIPSE = 'ELLIPSE'
+    HYPERBOLA = 'HYPERBOLA'
+    PARABOLA = 'PARABOLA'
+    OTHER = 'OTHER'
 
     def __repr__(self):
         return f"<{self.__class__.__name__}.{self.name}>"

--- a/src/build123d/exporters.py
+++ b/src/build123d/exporters.py
@@ -807,7 +807,7 @@ class ExportDXF(Export2D):
     }
 
     def _convert_edge(self, edge: Edge, attribs: dict):
-        geom_type = edge.geom_type()
+        geom_type = edge.geom_type
         convert = self._CONVERTER_LOOKUP.get(geom_type, ExportDXF._convert_other)
         convert(self, edge, attribs)
 
@@ -1353,7 +1353,7 @@ class ExportSVG(Export2D):
 
     def _edge_segments(self, edge: Edge, reverse: bool) -> list[PathSegment]:
         edge_reversed = edge.wrapped.Orientation() == TopAbs_Orientation.TopAbs_REVERSED
-        geom_type = edge.geom_type()
+        geom_type = edge.geom_type
         segments = self._SEGMENT_LOOKUP.get(geom_type, ExportSVG._other_segments)
         result = segments(self, edge, reverse ^ edge_reversed)
         return result
@@ -1366,7 +1366,7 @@ class ExportSVG(Export2D):
     }
 
     def _edge_element(self, edge: Edge) -> ET.Element:
-        geom_type = edge.geom_type()
+        geom_type = edge.geom_type
         element = self._ELEMENT_LOOKUP.get(geom_type, ExportSVG._other_element)
         result = element(self, edge)
         return result

--- a/src/build123d/operations_generic.py
+++ b/src/build123d/operations_generic.py
@@ -38,7 +38,7 @@ from build123d.build_common import (
     flatten_sequence,
     validate_inputs,
 )
-from build123d.build_enums import Keep, Kind, Mode, Side, Transition
+from build123d.build_enums import Keep, Kind, Mode, Side, Transition, GeomType
 from build123d.build_line import BuildLine
 from build123d.build_part import BuildPart
 from build123d.build_sketch import BuildSketch
@@ -619,7 +619,7 @@ def offset(
                 pass
         new_faces.append(Face(outer_wire, inner_wires))
     if edges:
-        if len(edges) == 1 and edges[0].geom_type() == "LINE":
+        if len(edges) == 1 and edges[0].geom_type() == GeomType.LINE:
             new_wires = [
                 Wire(
                     [

--- a/src/build123d/operations_generic.py
+++ b/src/build123d/operations_generic.py
@@ -619,7 +619,7 @@ def offset(
                 pass
         new_faces.append(Face(outer_wire, inner_wires))
     if edges:
-        if len(edges) == 1 and edges[0].geom_type() == GeomType.LINE:
+        if len(edges) == 1 and edges[0].geom_type == GeomType.LINE:
             new_wires = [
                 Wire(
                     [

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -3304,7 +3304,7 @@ class ShapeList(list[T]):
         elif isinstance(filter_by, GeomType):
 
             def predicate(obj):
-                return obj.geom_type == filter_by.name
+                return obj.geom_type == filter_by
 
         else:
             raise ValueError(f"Unsupported filter_by predicate: {filter_by}")

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -341,29 +341,29 @@ geom_LUT = {
 
 
 geom_LUT_FACE = {
-    ga.GeomAbs_Plane: "PLANE",
-    ga.GeomAbs_Cylinder: "CYLINDER",
-    ga.GeomAbs_Cone: "CONE",
-    ga.GeomAbs_Sphere: "SPHERE",
-    ga.GeomAbs_Torus: "TORUS",
-    ga.GeomAbs_BezierSurface: "BEZIER",
-    ga.GeomAbs_BSplineSurface: "BSPLINE",
-    ga.GeomAbs_SurfaceOfRevolution: "REVOLUTION",
-    ga.GeomAbs_SurfaceOfExtrusion: "EXTRUSION",
-    ga.GeomAbs_OffsetSurface: "OFFSET",
-    ga.GeomAbs_OtherSurface: "OTHER",
+    ga.GeomAbs_Plane: GeomType.PLANE,
+    ga.GeomAbs_Cylinder: GeomType.CYLINDER,
+    ga.GeomAbs_Cone: GeomType.CONE,
+    ga.GeomAbs_Sphere: GeomType.SPHERE,
+    ga.GeomAbs_Torus: GeomType.TORUS,
+    ga.GeomAbs_BezierSurface: GeomType.BEZIER,
+    ga.GeomAbs_BSplineSurface: GeomType.BSPLINE,
+    ga.GeomAbs_SurfaceOfRevolution: GeomType.REVOLUTION,
+    ga.GeomAbs_SurfaceOfExtrusion: GeomType.EXTRUSION,
+    ga.GeomAbs_OffsetSurface: GeomType.OFFSET,
+    ga.GeomAbs_OtherSurface: GeomType.OTHER,
 }
 
 geom_LUT_EDGE = {
-    ga.GeomAbs_Line: "LINE",
-    ga.GeomAbs_Circle: "CIRCLE",
-    ga.GeomAbs_Ellipse: "ELLIPSE",
-    ga.GeomAbs_Hyperbola: "HYPERBOLA",
-    ga.GeomAbs_Parabola: "PARABOLA",
-    ga.GeomAbs_BezierCurve: "BEZIER",
-    ga.GeomAbs_BSplineCurve: "BSPLINE",
-    ga.GeomAbs_OffsetCurve: "OFFSET",
-    ga.GeomAbs_OtherCurve: "OTHER",
+    ga.GeomAbs_Line: GeomType.LINE,
+    ga.GeomAbs_Circle: GeomType.CIRCLE,
+    ga.GeomAbs_Ellipse: GeomType.ELLIPSE,
+    ga.GeomAbs_Hyperbola: GeomType.HYPERBOLA,
+    ga.GeomAbs_Parabola: GeomType.PARABOLA,
+    ga.GeomAbs_BezierCurve: GeomType.BEZIER,
+    ga.GeomAbs_BSplineCurve: GeomType.BSPLINE,
+    ga.GeomAbs_OffsetCurve: GeomType.OFFSET,
+    ga.GeomAbs_OtherCurve: GeomType.OTHER,
 }
 
 Shapes = Literal["Vertex", "Edge", "Wire", "Face", "Shell", "Solid", "Compound"]
@@ -373,22 +373,22 @@ Geoms = Literal[
     "Shell",
     "Solid",
     "Compound",
-    "PLANE",
-    "CYLINDER",
-    "CONE",
-    "SPHERE",
-    "TORUS",
-    "BEZIER",
-    "BSPLINE",
-    "REVOLUTION",
-    "EXTRUSION",
-    "OFFSET",
-    "OTHER",
-    "LINE",
-    "CIRCLE",
-    "ELLIPSE",
-    "HYPERBOLA",
-    "PARABOLA",
+    GeomType.PLANE,
+    GeomType.CYLINDER,
+    GeomType.CONE,
+    GeomType.SPHERE,
+    GeomType.TORUS,
+    GeomType.BEZIER,
+    GeomType.BSPLINE,
+    GeomType.REVOLUTION,
+    GeomType.EXTRUSION,
+    GeomType.OFFSET,
+    GeomType.OTHER,
+    GeomType.LINE,
+    GeomType.CIRCLE,
+    GeomType.ELLIPSE,
+    GeomType.HYPERBOLA,
+    GeomType.PARABOLA,
 ]
 
 
@@ -2084,9 +2084,9 @@ class Shape(NodeMixin):
 
         while explorer.More():
             item = explorer.Current()
-            out[item.HashCode(HASH_CODE_MAX)] = (
-                item  # needed to avoid pseudo-duplicate entities
-            )
+            out[
+                item.HashCode(HASH_CODE_MAX)
+            ] = item  # needed to avoid pseudo-duplicate entities
             explorer.Next()
 
         return list(out.values())
@@ -3246,10 +3246,12 @@ class Comparable(metaclass=ABCMeta):
     """Abstract base class that requires comparison methods"""
 
     @abstractmethod
-    def __lt__(self, other: Any) -> bool: ...
+    def __lt__(self, other: Any) -> bool:
+        ...
 
     @abstractmethod
-    def __eq__(self, other: Any) -> bool: ...
+    def __eq__(self, other: Any) -> bool:
+        ...
 
 
 # This TypeVar allows IDEs to see the type of objects within the ShapeList
@@ -3260,7 +3262,8 @@ K = TypeVar("K", bound=Comparable)
 class ShapePredicate(Protocol):
     """Predicate for shape filters"""
 
-    def __call__(self, shape: Shape) -> bool: ...
+    def __call__(self, shape: Shape) -> bool:
+        ...
 
 
 class ShapeList(list[T]):
@@ -3706,10 +3709,12 @@ class ShapeList(list[T]):
         return ShapeList(set(self) & set(other))
 
     @overload
-    def __getitem__(self, key: int) -> T: ...
+    def __getitem__(self, key: int) -> T:
+        ...
 
     @overload
-    def __getitem__(self, key: slice) -> ShapeList[T]: ...
+    def __getitem__(self, key: slice) -> ShapeList[T]:
+        ...
 
     def __getitem__(self, key: Union[int, slice]) -> Union[T, ShapeList[T]]:
         """Return slices of ShapeList as ShapeList"""

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -1853,9 +1853,9 @@ class Shape(NodeMixin):
 
         shape: TopAbs_ShapeEnum = shapetype(self.wrapped)
 
-        if shape is ta.TopAbs_EDGE:
+        if shape == ta.TopAbs_EDGE:
             geom = geom_LUT_EDGE[BRepAdaptor_Curve(self.wrapped).GetType()]
-        elif shape is ta.TopAbs_FACE:
+        elif shape == ta.TopAbs_FACE:
             geom = geom_LUT_FACE[BRepAdaptor_Surface(self.wrapped).GetType()]
         else:
             geom = GeomType.OTHER
@@ -5083,7 +5083,9 @@ class Edge(Mixin1D, Shape):
     def to_axis(self) -> Axis:
         """Translate a linear Edge to an Axis"""
         if self.geom_type() != GeomType.LINE:
-            raise ValueError("to_axis is only valid for linear Edges")
+            raise ValueError(
+                "to_axis is only valid for linear Edges not " + self.geom_type()
+            )
         return Axis(self.position_at(0), self.position_at(1) - self.position_at(0))
 
 

--- a/tests/test_build_generic.py
+++ b/tests/test_build_generic.py
@@ -486,7 +486,7 @@ class MirrorTests(unittest.TestCase):
             revolve(axis=Axis.Z)
             mirror(about=Plane.XY)
             construction_face = p.faces().sort_by(Axis.Z)[0]
-            self.assertEqual(construction_face.geom_type(), "PLANE")
+            self.assertEqual(construction_face.geom_type(), GeomType.PLANE)
 
 
 class OffsetTests(unittest.TestCase):

--- a/tests/test_build_generic.py
+++ b/tests/test_build_generic.py
@@ -486,7 +486,7 @@ class MirrorTests(unittest.TestCase):
             revolve(axis=Axis.Z)
             mirror(about=Plane.XY)
             construction_face = p.faces().sort_by(Axis.Z)[0]
-            self.assertEqual(construction_face.geom_type(), GeomType.PLANE)
+            self.assertEqual(construction_face.geom_type, GeomType.PLANE)
 
 
 class OffsetTests(unittest.TestCase):

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -1269,7 +1269,7 @@ class TestFace(DirectApiTestCase):
             interior_wires=[hole],
         )
         self.assertTrue(surface.is_valid())
-        self.assertEqual(surface.geom_type(), "BSPLINE")
+        self.assertEqual(surface.geom_type(), GeomType.BSPLINE)
         bbox = surface.bounding_box()
         self.assertVectorAlmostEquals(bbox.min, (-50.5, -24.5, -5.113393280136395), 5)
         self.assertVectorAlmostEquals(bbox.max, (50.5, 24.5, 0), 5)
@@ -1961,12 +1961,12 @@ class TestMixin1D(DirectApiTestCase):
         # base_edge = Edge.make_circle(10, start_angle=40, end_angle=50)
         # self.assertTrue(isinstance(offset_edge, Edge))
         # offset_edge = base_edge.offset_2d(2, side=Side.RIGHT, closed=False)
-        # self.assertTrue(offset_edge.geom_type() == "CIRCLE")
+        # self.assertTrue(offset_edge.geom_type() == GeomType.CIRCLE)
         # self.assertAlmostEqual(offset_edge.radius, 12, 5)
         # base_edge = Edge.make_line((0, 1), (1, 10))
         # offset_edge = base_edge.offset_2d(2, side=Side.RIGHT, closed=False)
         # self.assertTrue(isinstance(offset_edge, Edge))
-        # self.assertTrue(offset_edge.geom_type() == "LINE")
+        # self.assertTrue(offset_edge.geom_type() == GeomType.LINE)
         # self.assertAlmostEqual(offset_edge.position_at(0).X, 3)
 
     def test_common_plane(self):

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -1269,7 +1269,7 @@ class TestFace(DirectApiTestCase):
             interior_wires=[hole],
         )
         self.assertTrue(surface.is_valid())
-        self.assertEqual(surface.geom_type(), GeomType.BSPLINE)
+        self.assertEqual(surface.geom_type, GeomType.BSPLINE)
         bbox = surface.bounding_box()
         self.assertVectorAlmostEquals(bbox.min, (-50.5, -24.5, -5.113393280136395), 5)
         self.assertVectorAlmostEquals(bbox.max, (50.5, 24.5, 0), 5)
@@ -1961,12 +1961,12 @@ class TestMixin1D(DirectApiTestCase):
         # base_edge = Edge.make_circle(10, start_angle=40, end_angle=50)
         # self.assertTrue(isinstance(offset_edge, Edge))
         # offset_edge = base_edge.offset_2d(2, side=Side.RIGHT, closed=False)
-        # self.assertTrue(offset_edge.geom_type() == GeomType.CIRCLE)
+        # self.assertTrue(offset_edge.geom_type == GeomType.CIRCLE)
         # self.assertAlmostEqual(offset_edge.radius, 12, 5)
         # base_edge = Edge.make_line((0, 1), (1, 10))
         # offset_edge = base_edge.offset_2d(2, side=Side.RIGHT, closed=False)
         # self.assertTrue(isinstance(offset_edge, Edge))
-        # self.assertTrue(offset_edge.geom_type() == GeomType.LINE)
+        # self.assertTrue(offset_edge.geom_type == GeomType.LINE)
         # self.assertAlmostEqual(offset_edge.position_at(0).X, 3)
 
     def test_common_plane(self):

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -35,7 +35,7 @@ class ImportSVG(unittest.TestCase):
         test_obj: BuildLine = ex_locals[builder_name]
         found = 0
         for edge in test_obj.edges():
-            if edge.geom_type() == GeomType.ELLIPSE:
+            if edge.geom_type() == GeomType.BEZIER:
                 found += 1
             elif edge.geom_type() == GeomType.LINE:
                 found += 1

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -10,6 +10,7 @@ from build123d import (
 )
 from build123d.importers import import_svg_as_buildline_code, import_brep, import_svg
 from build123d.exporters import ExportSVG
+from build123d.build_enums import GeomType
 from pathlib import Path
 
 
@@ -34,11 +35,11 @@ class ImportSVG(unittest.TestCase):
         test_obj: BuildLine = ex_locals[builder_name]
         found = 0
         for edge in test_obj.edges():
-            if edge.geom_type() == "BEZIER":
+            if edge.geom_type() == GeomType.ELLIPSE:
                 found += 1
-            elif edge.geom_type() == "LINE":
+            elif edge.geom_type() == GeomType.LINE:
                 found += 1
-            elif edge.geom_type() == "ELLIPSE":
+            elif edge.geom_type() == GeomType.ELLIPSE:
                 found += 1
         self.assertEqual(found, 4)
         os.remove("test.svg")

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -35,11 +35,11 @@ class ImportSVG(unittest.TestCase):
         test_obj: BuildLine = ex_locals[builder_name]
         found = 0
         for edge in test_obj.edges():
-            if edge.geom_type() == GeomType.BEZIER:
+            if edge.geom_type == GeomType.BEZIER:
                 found += 1
-            elif edge.geom_type() == GeomType.LINE:
+            elif edge.geom_type == GeomType.LINE:
                 found += 1
-            elif edge.geom_type() == GeomType.ELLIPSE:
+            elif edge.geom_type == GeomType.ELLIPSE:
                 found += 1
         self.assertEqual(found, 4)
         os.remove("test.svg")


### PR DESCRIPTION
Fixes: #321 and #466

Solution:
Return GeomType directly. Add type hints to LUTs

Compromises:
Cannot return arbitrary strings or Shapes from GeomType (Eg. Vertex, Component, Face etc.)
GeomType is now a str enum to maintain compatibility

Breaking changes:
 - geom_type is now a property by popular demand