### PR TITLE
Better GroupBy dunder str/repr/ipython methods

### DIFF
--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -3750,6 +3750,12 @@ class GroupBy(Generic[T, K]):
     def __getitem__(self, key: int):
         return self.groups[key]
 
+    def __str__(self):
+        return "[" + "\n".join("".join(str(x)) for x in self) + "]"
+
+    def __repr__(self):
+        return self.__str__()
+
     def group(self, key: K):
         """Select group by key"""
         for k, i in self.key_to_group_index:

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -64,6 +64,7 @@ from typing import cast as tcast
 from typing_extensions import Self, Literal
 
 from anytree import NodeMixin, PreOrderIter, RenderTree
+from IPython.lib.pretty import pretty
 from scipy.spatial import ConvexHull
 from vtkmodules.vtkCommonDataModel import vtkPolyData
 from vtkmodules.vtkFiltersCore import vtkPolyDataNormals, vtkTriangleFilter
@@ -3751,13 +3752,21 @@ class GroupBy(Generic[T, K]):
         return self.groups[key]
 
     def __str__(self):
-        body = ",\n".join(str(x) for x in self)
-        return "[" + body + "]"
-    
+        return pretty(self)
+
     def __repr__(self):
-        # TODO:replace in the future with a version using
-        # implied line continuations
-        return self.__str__()
+        return repr(ShapeList(self))
+
+    def _repr_pretty_(self, p, cycle = False):
+        if cycle:
+            p.text('(...)')
+        else:
+            with p.group(1, '[', ']'):
+                for idx, item in enumerate(self):
+                    if idx:
+                        p.text(',')
+                        p.breakable()
+                    p.pretty(item)
 
     def group(self, key: K):
         """Select group by key"""

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -3751,9 +3751,12 @@ class GroupBy(Generic[T, K]):
         return self.groups[key]
 
     def __str__(self):
-        return "[" + "\n".join("".join(str(x) + ",") for x in self) + "]"
-
+        body = ",\n".join(str(x) for x in self)
+        return "[" + body + "]"
+    
     def __repr__(self):
+        # TODO:replace in the future with a version using
+        # implied line continuations
         return self.__str__()
 
     def group(self, key: K):

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -3751,7 +3751,7 @@ class GroupBy(Generic[T, K]):
         return self.groups[key]
 
     def __str__(self):
-        return "[" + "\n".join("".join(str(x)) for x in self) + "]"
+        return "[" + "\n".join("".join(str(x) + ",") for x in self) + "]"
 
     def __repr__(self):
         return self.__str__()

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -1,5 +1,6 @@
 # system modules
 import copy
+import io
 import json
 import math
 import os
@@ -9,6 +10,7 @@ import re
 from typing import Optional
 import unittest
 from random import uniform
+from IPython.lib import pretty
 
 from OCP.BRepBuilderAPI import BRepBuilderAPI_MakeEdge
 from OCP.gp import (
@@ -3007,6 +3009,11 @@ class TestShapeList(DirectApiTestCase):
             " <build123d.topology.Edge object at 0x000001277F6E1CD0>]]"
         )
         self.assertDunderReprEqual(repr(nonagon.edges().group_by(Axis.X)),expected_repr)
+        
+        f = io.StringIO()
+        p = pretty.PrettyPrinter(f)
+        nonagon.edges().group_by(Axis.X)._repr_pretty_(p, cycle=True)
+        self.assertEqual(f.getvalue(), "(...)")
 
     def test_distance(self):
         with BuildPart() as box:

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -2993,7 +2993,7 @@ class TestShapeList(DirectApiTestCase):
             "  <build123d.topology.Edge at 0x1277fec6d90>]]",
         ]
 
-        self.assertDunderStrEqual(nonagon.edges().group_by(Axis.X), expected)
+        self.assertDunderStrEqual(str(nonagon.edges().group_by(Axis.X)), expected)
 
         expected_repr = (
             "[[<build123d.topology.Edge object at 0x000001277FEC6D90>],"

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -2963,6 +2963,11 @@ class TestShapeList(DirectApiTestCase):
         with self.assertRaises(KeyError):
             result.group("C")
 
+    def test_group_by_str_repr(self):
+        nonagon = RegularPolygon(5,9)
+        # placeholder for future tests
+        self.assertTrue(True)
+    
     def test_distance(self):
         with BuildPart() as box:
             Box(1, 2, 3)

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -2857,7 +2857,7 @@ class TestShapeList(DirectApiTestCase):
         actual_lines = actual.splitlines()
         self.assertEqual(len(actual_lines), len(expected_lines))
         for actual_line, expected_line in zip(actual_lines, expected_lines):
-            start, end = re.split(r"at 0x[0-9a-f]+,", expected_line, 2, re.I)
+            start, end = re.split(r"at 0x[0-9a-f]+", expected_line, 2, re.I)
             self.assertTrue(actual_line.startswith(start))
             self.assertTrue(actual_line.endswith(end))
 

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -2982,18 +2982,18 @@ class TestShapeList(DirectApiTestCase):
         nonagon = RegularPolygon(5,9)
 
         expected = [
-            "[[<build123d.topology.Edge at 0x1277f6e1cd0>],"
-            " [<build123d.topology.Edge at 0x1277f6e1c10>,"
-            "  <build123d.topology.Edge at 0x1277fd8a090>],"
-            " [<build123d.topology.Edge at 0x1277f75d690>,"
-            "  <build123d.topology.Edge at 0x127760d9310>],"
-            " [<build123d.topology.Edge at 0x12777261f90>,"
-            "  <build123d.topology.Edge at 0x1277f6bd2d0>],"
-            " [<build123d.topology.Edge at 0x1276fbb0590>,"
-            "  <build123d.topology.Edge at 0x1277fec6d90>]]"
+            "[[<build123d.topology.Edge at 0x1277f6e1cd0>],",
+            " [<build123d.topology.Edge at 0x1277f6e1c10>,",
+            "  <build123d.topology.Edge at 0x1277fd8a090>],",
+            " [<build123d.topology.Edge at 0x1277f75d690>,",
+            "  <build123d.topology.Edge at 0x127760d9310>],",
+            " [<build123d.topology.Edge at 0x12777261f90>,",
+            "  <build123d.topology.Edge at 0x1277f6bd2d0>],",
+            " [<build123d.topology.Edge at 0x1276fbb0590>,",
+            "  <build123d.topology.Edge at 0x1277fec6d90>]]",
         ]
 
-        assertDunderStrEqual(nonagon.edges().group_by(Axis.X), expected)
+        self.assertDunderStrEqual(nonagon.edges().group_by(Axis.X), expected)
 
         expected_repr = (
             "[[<build123d.topology.Edge object at 0x000001277FEC6D90>],"
@@ -3006,7 +3006,7 @@ class TestShapeList(DirectApiTestCase):
             " [<build123d.topology.Edge object at 0x000001277FC86F90>,"
             " <build123d.topology.Edge object at 0x000001277F6E1CD0>]]"
         )
-        assertDunderReprEqual(repr(nonagon.edges().group_by(Axis.X)),expected_repr)
+        self.assertDunderReprEqual(repr(nonagon.edges().group_by(Axis.X)),expected_repr)
 
     def test_distance(self):
         with BuildPart() as box:

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -2853,6 +2853,21 @@ class TestShape(DirectApiTestCase):
 class TestShapeList(DirectApiTestCase):
     """Test ShapeList functionality"""
 
+    def assertDunderStrEqual(self, actual: str, expected_lines: list[str]):
+        actual_lines = actual.splitlines()
+        self.assertEqual(len(actual_lines), len(expected_lines))
+        for actual_line, expected_line in zip(actual_lines, expected_lines):
+            start, end = re.split(r"at 0x[0-9a-f]+,", expected_line, 2, re.I)
+            self.assertTrue(actual_line.startswith(start))
+            self.assertTrue(actual_line.endswith(end))
+
+    def assertDunderReprEqual(self, actual: str, expected: str):
+        splitter = r"at 0x[0-9a-f]+"
+        actual_split_list = re.split(splitter, actual, 0, re.I)
+        expected_split_list = re.split(splitter, expected, 0, re.I)
+        for actual_split, expected_split in zip(actual_split_list, expected_split_list):
+            self.assertEqual(actual_split, expected_split)
+    
     def test_sort_by(self):
         faces = Solid.make_box(1, 2, 3).faces() < SortBy.AREA
         self.assertAlmostEqual(faces[-1].area, 2, 5)
@@ -2965,9 +2980,34 @@ class TestShapeList(DirectApiTestCase):
 
     def test_group_by_str_repr(self):
         nonagon = RegularPolygon(5,9)
-        # placeholder for future tests
-        self.assertTrue(True)
-    
+
+        expected = [
+            "[[<build123d.topology.Edge at 0x1277f6e1cd0>],"
+            " [<build123d.topology.Edge at 0x1277f6e1c10>,"
+            "  <build123d.topology.Edge at 0x1277fd8a090>],"
+            " [<build123d.topology.Edge at 0x1277f75d690>,"
+            "  <build123d.topology.Edge at 0x127760d9310>],"
+            " [<build123d.topology.Edge at 0x12777261f90>,"
+            "  <build123d.topology.Edge at 0x1277f6bd2d0>],"
+            " [<build123d.topology.Edge at 0x1276fbb0590>,"
+            "  <build123d.topology.Edge at 0x1277fec6d90>]]"
+        ]
+
+        assertDunderStrEqual(nonagon.edges().group_by(Axis.X), expected)
+
+        expected_repr = (
+            "[[<build123d.topology.Edge object at 0x000001277FEC6D90>],"
+            " [<build123d.topology.Edge object at 0x000001277F6BCC10>,"
+            " <build123d.topology.Edge object at 0x000001277EC3D5D0>],"
+            " [<build123d.topology.Edge object at 0x000001277F6BEA90>,"
+            " <build123d.topology.Edge object at 0x000001276FCB2310>],"
+            " [<build123d.topology.Edge object at 0x000001277F6D10D0>,"
+            " <build123d.topology.Edge object at 0x000001276FBAAD10>],"
+            " [<build123d.topology.Edge object at 0x000001277FC86F90>,"
+            " <build123d.topology.Edge object at 0x000001277F6E1CD0>]]"
+        )
+        assertDunderReprEqual(repr(nonagon.edges().group_by(Axis.X)),expected_repr)
+
     def test_distance(self):
         with BuildPart() as box:
             Box(1, 2, 3)


### PR DESCRIPTION
Currently when running in an ipython console:
```py
from build123d import *
nonagon = RegularPolygon(5, 9)
print(str(nonagon.edges().group_by(Axis.X)))
print(repr(nonagon.edges().group_by(Axis.X)))
nonagon.edges().group_by(Axis.X)
```
Returns a not-so-useful result that doesn't give an idea of the structure of the objects inside:
```py
<build123d.topology.GroupBy object at 0x000002AE7995C850>
<build123d.topology.GroupBy object at 0x000002AE79E3D6D0>
Out[1]: <build123d.topology.GroupBy at 0x2ae77a2c0d0>
```
This PR changes the behavior to the following by using ipython pretty printing:
```py
[[<build123d.topology.Edge at 0x1e32f0c9c50>],
 [<build123d.topology.Edge at 0x1e32f0cae90>,
  <build123d.topology.Edge at 0x1e32febbb50>],
 [<build123d.topology.Edge at 0x1e32fe00050>,
  <build123d.topology.Edge at 0x1e32febbed0>],
 [<build123d.topology.Edge at 0x1e316c2b310>,
  <build123d.topology.Edge at 0x1e32f101410>],
 [<build123d.topology.Edge at 0x1e32f8612d0>,
  <build123d.topology.Edge at 0x1e315962650>]]
[[<build123d.topology.Edge object at 0x000001E3158BDED0>], [<build123d.topology.Edge object at 0x000001E32F891110>, <build123d.topology.Edge object at 0x000001E32F74BE10>], [<build123d.topology.Edge object at 0x000001E32F101410>, <build123d.topology.Edge object at 0x000001E32F08FED0>], [<build123d.topology.Edge object at 0x000001E316C2B310>, <build123d.topology.Edge object at 0x000001E316B55390>], [<build123d.topology.Edge object at 0x000001E32EC0DC50>, <build123d.topology.Edge object at 0x000001E32F0F0610>]]
Out[1]:
[[<build123d.topology.Edge at 0x1e316b544d0>],
 [<build123d.topology.Edge at 0x1e316c2b310>,
  <build123d.topology.Edge at 0x1e32ec0dc50>],
 [<build123d.topology.Edge at 0x1e30f5aaed0>,
  <build123d.topology.Edge at 0x1e32f0f0610>],
 [<build123d.topology.Edge at 0x1e32f08f550>,
  <build123d.topology.Edge at 0x1e30f610c10>],
 [<build123d.topology.Edge at 0x1e3175e4e90>,
  <build123d.topology.Edge at 0x1e32f0dc050>]]
  ```
  N.B. in a standard python REPL the return value of the last statement will be equivalent to the second print statement.