### PR TITLE
Add black config section to `pyproject.toml` and `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,11 @@ tests, ensure they build and pass, and ensure that `pylint` and `mypy`
 are happy with your code.
 
 - Install `pip` following their [documentation](https://pip.pypa.io/en/stable/installation/).
-- Install development dependencies: `pip install pylint pytest mypy sphinx`
+- Install development dependencies: `pip install pylint pytest mypy sphinx black`
 - Install docs dependencies: `pip install -r docs/requirements.txt` (might need to comment out the build123d line in that file)
 - Install `build123d` in editable mode from current dir:  `pip install -e .`
 - Run tests with: `python -m pytest`
 - Build docs with: `cd docs && make html`
 - Check added files' style with: `pylint <path/to/file.py>` 
 - Check added files' type annotations with: `mypy <path/to/file.py>`
+- Run black formatter against files' changed: `black --config pyproject.toml <path/to/file.py>` (where the pyproject.toml is from this project's repository)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,31 +64,3 @@ write_to = "src/build123d/_version.py"
 [tool.black]
 target-version = ["py39", "py310", "py311", "py312"]
 line-length = 88
-
-[tool.ruff]
-# Same as Black.
-line-length = 88
-indent-width = 4
-
-[tool.ruff.format]
-# Like Black, use double quotes for strings.
-quote-style = "double"
-
-# Like Black, indent with spaces, rather than tabs.
-indent-style = "space"
-
-# Like Black, respect magic trailing commas.
-skip-magic-trailing-comma = false
-
-# Like Black, automatically detect the appropriate line ending.
-line-ending = "auto"
-
-# Enable auto-formatting of code examples in docstrings. Markdown,
-# reStructuredText code/literal blocks and doctests are all supported.
-#
-# This is currently disabled by default, but it is planned for this
-# to be opt-out in the future.
-docstring-code-format = false
-
-# Keep single-line signatures when body is an Ellipsis
-preview = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,6 @@ line-length = 88
 # Same as Black.
 line-length = 88
 indent-width = 4
-target-version = ["py39", "py310", "py311", "py312"]
 
 [tool.ruff.format]
 # Like Black, use double quotes for strings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,35 @@ exclude = ["build123d._dev"]
 [tool.setuptools_scm]
 write_to = "src/build123d/_version.py"
 
+[tool.black]
+target-version = ["py39", "py310", "py311", "py312"]
+line-length = 88
+
+[tool.ruff]
+# Same as Black.
+line-length = 88
+indent-width = 4
+target-version = ["py39", "py310", "py311", "py312"]
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = false
+
+# Keep single-line signatures when body is an Ellipsis
+preview = true


### PR DESCRIPTION
ruff is currently over 99.9% compatible with black, so I have added both as acceptable formatters to `pyproject.toml` for this PR