### PR TITLE
Use build123d.__version__ for readthedocs page title

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@
 #
 import os
 import sys
+import build123d
 
 build123d_path = os.path.dirname(os.path.abspath(os.getcwd()))
 source_files_path = os.path.join(build123d_path, "src", "build123d")
@@ -27,11 +28,8 @@ copyright = "2022, Gumyr"
 author = "Gumyr"
 
 # The full version, including alpha/beta/rc tags
-with open(os.path.join(build123d_path, "pyproject.toml")) as f:
-    pyproject_toml = f.readlines()
-for line in pyproject_toml:
-    if "version =" in line:
-        release = line.split("=")[1].strip()
+# version = build123d.__version__
+release = build123d.__version__
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
This PR fixes the page title of the readthedocs page to include the correct build123d version that was used to build it. Currently the parser is picking the wrong info from `pyproject.toml`, which makes the page title look like this:

![image](https://github.com/gumyr/build123d/assets/16868537/6c633853-7716-4225-ab20-54555ad8a133)

Page title will now look more like this:
![image](https://github.com/gumyr/build123d/assets/16868537/c56fb1a1-dfda-455f-bcfe-9f5ed8f234c2)
