### PR TITLE
Fix calculation of projection direction in project()

### DIFF
--- a/src/build123d/operations_generic.py
+++ b/src/build123d/operations_generic.py
@@ -772,7 +772,7 @@ def project(
     obj: Shape
     for obj in face_list + line_list:
         obj_to_screen = (target.center() - obj.center()).normalized()
-        if workplane.from_local_coords(obj_to_screen).Z < 0:
+        if workplane.to_local_coords(obj_to_screen).Z < 0:
             projection_direction = -workplane.z_dir * projection_flip
         else:
             projection_direction = workplane.z_dir * projection_flip
@@ -790,7 +790,7 @@ def project(
     projected_points = []
     for pnt in point_list:
         pnt_to_target = (workplane.origin - pnt).normalized()
-        if workplane.from_local_coords(pnt_to_target).Z < 0:
+        if workplane.to_local_coords(pnt_to_target).Z < 0:
             projection_axis = -Axis(pnt, workplane.z_dir * projection_flip)
         else:
             projection_axis = Axis(pnt, workplane.z_dir * projection_flip)

--- a/src/build123d/operations_generic.py
+++ b/src/build123d/operations_generic.py
@@ -771,8 +771,7 @@ def project(
     projected_shapes = []
     obj: Shape
     for obj in face_list + line_list:
-        obj_to_screen = (target.center() - obj.center()).normalized()
-        if workplane.to_local_coords(obj_to_screen).Z < 0:
+        if workplane.to_local_coords(obj.center()).Z > 0:
             projection_direction = -workplane.z_dir * projection_flip
         else:
             projection_direction = workplane.z_dir * projection_flip

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -6043,6 +6043,9 @@ class Face(Shape):
         for target_face in target_object.faces():
             intersected_faces.extend(face_extruded.intersect(target_face).faces())
 
+        if len(intersected_faces) == 0:
+            return ShapeList()
+
         # intersected faces may be fragmented so we'll put them back together
         sewed_face_list = Face.sew_faces(intersected_faces)
         sewed_faces = ShapeList()

--- a/tests/test_build_generic.py
+++ b/tests/test_build_generic.py
@@ -665,7 +665,7 @@ class ProjectionTests(unittest.TestCase):
     def test_project_to_sketch2(self):
         with BuildPart() as test2:
             Box(4, 4, 1)
-            with BuildSketch(Plane.XY.offset(0.1)) as c:
+            with BuildSketch(Plane.XY.offset(2)) as c:
                 Rectangle(1, 1)
             project()
             extrude(amount=1)


### PR DESCRIPTION
This fixes the fix in 1d3de5ca693a345adef5affa320b8c877e79b5f9, which contained the following diff.

The diff changed `>0` to `<0`, which is indeed fixing a problem with the code.
However, it also changed `to_local_coords` to `from_local_coords`, which is wrong and breaks the code, e.g. when projecting against the `XY` plane. In this case, some objects are extended _away from_ the projection target, leading to an empty intersection and thus, a crash.

```diff
diff --git a/src/build123d/operations_generic.py b/src/build123d/operations_generic.py
index 4589742..6600153 100644
--- a/src/build123d/operations_generic.py
+++ b/src/build123d/operations_generic.py
@@ -766,15 +766,13 @@ def project(
     projected_shapes = []
     obj: Shape
     for obj in face_list + line_list:
-        # obj_to_screen = (workplane.origin - obj.center()).normalized()
         obj_to_screen = (target.center() - obj.center()).normalized()
-        if workplane.to_local_coords(obj_to_screen).Z > 0:
+        if workplane.from_local_coords(obj_to_screen).Z < 0:
             projection_direction = -workplane.z_dir * projection_flip
         else:
             projection_direction = workplane.z_dir * projection_flip
@@ -792,7 +790,7 @@ def project(
     projected_points = []
     for pnt in point_list:
         pnt_to_target = (workplane.origin - pnt).normalized()
-        if workplane.to_local_coords(pnt_to_target).Z > 0:
+        if workplane.from_local_coords(pnt_to_target).Z < 0:
             projection_axis = -Axis(pnt, workplane.z_dir * projection_flip)
         else:
             projection_axis = Axis(pnt, workplane.z_dir * projection_flip)
```