### PR TITLE
Avoid a crash in Mesher if triangulation fails

### DIFF
--- a/src/build123d/mesher.py
+++ b/src/build123d/mesher.py
@@ -285,6 +285,10 @@ class Mesher:
         for facet in ocp_mesh.faces():
             # Triangulate the face
             poly_triangulation = BRep_Tool.Triangulation_s(facet.wrapped, loc)
+            if poly_triangulation is None:
+                warnings.warn("Face triangulation failed.")
+                # TODO(clairbee): Avoiding a crash. Need to determine a smarter way to handle this.
+                continue
             trsf = loc.Transformation()
             # Store the vertices in the triangulated face
             node_count = poly_triangulation.NbNodes()


### PR DESCRIPTION
Exactly the same problem exists in CadQuery's tessellate() (see [this issue](https://github.com/CadQuery/cadquery/issues/705)).

I don't know how to reproduce it on a small model.
It will be reproducible by the following PartCAD command after the refactoring for OBJ rendering is published (the refactoring is to use build123d instead of CadQuery):

```
pc render -t obj -a /pub/robotics/multimodal/openvmp/robots/don1:robot
```
