### PR TITLE
Fix 3MF color export and partial support for color import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "ezdxf >= 1.0.0, < 2",
     "numpy-stl >= 3.0.0, <4",
     "ipython >= 8.0.0, <9",
-    "py-lib3mf",
+    "py-lib3mf >= 2.3.1",
     "ocpsvg",
     "trianglesolver"
 ]

--- a/src/build123d/mesher.py
+++ b/src/build123d/mesher.py
@@ -153,7 +153,6 @@ class Mesher:
         self.model = self.wrapper.CreateModel()
         self.model.SetUnit(Mesher._map_b3d_to_3mf_unit[unit])
         self.meshes: list[Lib3MF.MeshObject] = []
-        self.base_material_group = self.model.AddBaseMaterialGroup()
 
     @property
     def model_unit(self) -> Unit:
@@ -345,13 +344,12 @@ class Mesher:
     def _add_color(self, b3d_shape: Shape, mesh_3mf: Lib3MF.MeshObject):
         """Transfer color info from shape to mesh"""
         if b3d_shape.color:
+            base_material_group = self.model.AddBaseMaterialGroup()
             color_lib3mf = self.wrapper.FloatRGBAToColor(*b3d_shape.color.to_tuple())
-            base_material_id = self.base_material_group.AddMaterial(
+            base_material_id = base_material_group.AddMaterial(
                 Name=str(b3d_shape.color), DisplayColor=color_lib3mf
             )
-            mesh_3mf.SetObjectLevelProperty(
-                self.base_material_group.GetResourceID(), base_material_id
-            )
+            mesh_3mf.SetObjectLevelProperty(base_material_group.GetResourceID(), base_material_id)
 
     def add_shape(
         self,

--- a/src/build123d/mesher.py
+++ b/src/build123d/mesher.py
@@ -509,26 +509,13 @@ class Mesher:
             shape = self._get_shape(mesh)
             shape.label = mesh.GetName()
             # Extract color
-            color_indices = []
-            for triangle_property in mesh.GetAllTriangleProperties():
-                color_indices.extend(
-                    [
-                        (triangle_property.ResourceID, triangle_property.PropertyIDs[i])
-                        for i in range(3)
-                    ]
-                )
-            unique_color_indices = list(set(color_indices))
-            try:
-                color_group = self.model.GetColorGroupByID(unique_color_indices[0][0])
-            except:
-                shapes.append(shape)  # There are no colors
-                continue
-            if len(unique_color_indices) > 1:
-                warnings.warn("Warning multiple colors found on mesh - only one used")
-            color_3mf = color_group.GetColor(unique_color_indices[0][1])
-            color = (color_3mf.Red, color_3mf.Green, color_3mf.Blue, color_3mf.Alpha)
-            color = (c / 255.0 for c in color)
-            shape.color = Color(*color)
+            # TODO: check tuple 3rd value means material found
+            base_mat_id, color_index, material_enabled = mesh.GetObjectLevelProperty()
+            if material_enabled:
+                base_mat = self.model.GetBaseMaterialGroupByID(base_mat_id)
+                base_mat_color: Lib3MF.Color = base_mat.GetDisplayColor(color_index)
+                color: tuple = self.wrapper.ColorToFloatRGBA(base_mat_color)  # RGBA float
+                shape.color = Color(*color)
             shapes.append(shape)
 
         return shapes

--- a/tests/test_mesher.py
+++ b/tests/test_mesher.py
@@ -35,7 +35,7 @@ class DirectApiTestCase(unittest.TestCase):
 class TestProperties(unittest.TestCase):
     def test_version(self):
         exporter = Mesher()
-        self.assertEqual(exporter.library_version, "2.2.0")
+        self.assertEqual(exporter.library_version, "2.3.1")
 
     def test_units(self):
         for unit in Unit:


### PR DESCRIPTION
This PR reworks the current 3MF color export and color import to use material groups rather than the current approach of vertex specific colors. This PR allows for one to export objects from build123d with a color to a 3MF and then re-import that 3MF file with color preserved.

Known Limitations:
- Removes vertex coloring from current implementation
- Does not currently support 3MF color groups, which may be possible to support
- One color per object
```py
from build123d import *
a=Solid.make_box(1,2,3)
b=Solid.make_box(3,3,1)
a.color = Color(0.137, 0.306, 0.439)  # Tealish
b.color = Color(0.980, 0.973, 0.749)  # Goldish
exporter = Mesher(unit=Unit.CM)
exporter.add_shape([a,b])
exporter.write("ab_dual_color.3mf")
```
And importing:
```py
importer = Mesher()
objects = importer.read("ab_dual_color.3mf")
```
Which can then be shown e.g. `show(objects)`
![image](https://github.com/gumyr/build123d/assets/16868537/5d621f7a-144d-40e1-93f3-385624aaf6ac)
