### PR TITLE
In the docs' index, replace e.g. with i.e. in two places

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,14 +39,14 @@ wide variety of popular CAD tools such as FreeCAD and SolidWorks.
 Build123d could be considered as an evolution of
 `CadQuery <https://cadquery.readthedocs.io/en/latest/index.html>`_ where the
 somewhat restrictive Fluent API (method chaining) is replaced with stateful
-context managers - e.g. `with` blocks - thus enabling the full python toolbox:
+context managers - i.e. `with` blocks - thus enabling the full python toolbox:
 for loops, references to objects, object sorting and filtering, etc.
 
 ########
 Overview
 ########
 
-build123d uses the standard python context manager - e.g. the ``with`` statement often used when
+build123d uses the standard python context manager - i.e. the ``with`` statement often used when
 working with files - as a builder of the object under construction. Once the object is complete
 it can be extracted from the builders and used in other ways: for example exported as a STEP
 file or used in an Assembly.  There are three builders available:


### PR DESCRIPTION
Very minor, but it bugs me enough to open a PR.

There are two situations in the index of the docs where as far as I can tell `i.e.` was intended to be used, but instead `e.g.` was written.

