### PR TITLE
Add `align_z` argument to pack() Method. 

### DIFF
--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -172,6 +172,14 @@ padding (right):
   :align: right
 
 
+By default, the original Z value of all objects packed using the :meth:`pack.pack` function is preserved. 
+If you want to align all objects so that they are "placed" on the zero Z coordinate, the :meth:`pack` 
+function has an `align_z` argument. When set to `True`, this will align all objects. 
+
+This can be useful, for example, when preparing print setups for 3D printing, giving you full control 
+over this alignment so you don't have to leave it to the slicer.
+
+
 .. _are_glob_imports_bad_practice:
 
 ***********************************************

--- a/src/build123d/pack.py
+++ b/src/build123d/pack.py
@@ -120,7 +120,17 @@ def _pack2d(
 
 
 def pack(objects: Collection[Shape], padding: float, align_z: bool = False) -> Collection[Shape]:
-    """Pack objects in a squarish area in Plane.XY."""
+    """Pack objects in a squarish area in Plane.XY.
+
+    Args:
+        objects (Collection[Shape]): objects to arrange
+        padding (float): space between objects
+        align_z (bool, optional): align shape bottoms to Plane.XY. Defaults to False.
+
+    Returns:
+        Collection[Shape]: rearranged objects
+    """
+
     bounding_boxes = {o: o.bounding_box().size + (padding, padding) for o in objects}
     translations = _pack2d(
         objects,

--- a/src/build123d/pack.py
+++ b/src/build123d/pack.py
@@ -132,12 +132,6 @@ def pack(objects: Collection[Shape], padding: float, align_z: bool = True) -> Co
         for (o, t) in zip(objects, translations)
     ]
 
-    for o in objects:
-        print(o.bounding_box() )
-
-    for o in translated:
-        print(o.bounding_box() )
-
     # Assert the packing didn't cause any overlaps.
     def _overlapping(bb1, bb2):
         # Boundaries of the intersection of the two bounding boxes.

--- a/src/build123d/pack.py
+++ b/src/build123d/pack.py
@@ -119,7 +119,7 @@ def _pack2d(
     return [(t[1], t[2]) for t in sorted(translations, key=lambda t: t[0])]
 
 
-def pack(objects: Collection[Shape], padding: float, align_z: bool = True) -> Collection[Shape]:
+def pack(objects: Collection[Shape], padding: float, align_z: bool = False) -> Collection[Shape]:
     """Pack objects in a squarish area in Plane.XY."""
     bounding_boxes = {o: o.bounding_box().size + (padding, padding) for o in objects}
     translations = _pack2d(

--- a/src/build123d/pack.py
+++ b/src/build123d/pack.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable, Collection, Optional, cast
 
-from build123d import Location, Shape
+from build123d import Location, Shape, Pos
 
 
 def _pack2d(
@@ -119,7 +119,7 @@ def _pack2d(
     return [(t[1], t[2]) for t in sorted(translations, key=lambda t: t[0])]
 
 
-def pack(objects: Collection[Shape], padding: float) -> Collection[Shape]:
+def pack(objects: Collection[Shape], padding: float, align_z: bool = True) -> Collection[Shape]:
     """Pack objects in a squarish area in Plane.XY."""
     bounding_boxes = {o: o.bounding_box().size + (padding, padding) for o in objects}
     translations = _pack2d(
@@ -128,9 +128,15 @@ def pack(objects: Collection[Shape], padding: float) -> Collection[Shape]:
         length_fn=lambda o: bounding_boxes[cast(Shape, o)].Y,
     )
     translated = [
-        Location((t[0] - o.bounding_box().min.X, t[1] - o.bounding_box().min.Y, 0)) * o
+        Location((t[0] - o.bounding_box().min.X, t[1] - o.bounding_box().min.Y, 0)) * Pos((0, 0, -o.bounding_box().min.Z if align_z else 0)) * o
         for (o, t) in zip(objects, translations)
     ]
+
+    for o in objects:
+        print(o.bounding_box() )
+
+    for o in translated:
+        print(o.bounding_box() )
 
     # Assert the packing didn't cause any overlaps.
     def _overlapping(bb1, bb2):


### PR DESCRIPTION
Hi, 

I've added a new argument `align_z` to the `pack()` method. When you enable this, it aligns all objects to the same Z axis.

#### Motivation and Context

I made this change to help with preparing print plates for 3D printing (set of multiple 3D bodies). The current `pack()` method only arranges objects in the X and Y coordinates. With the new `align_z` option, it becomes much easier to prepare objects for printing without needing to adjust them by a slicer.

#### How Has This Been Tested?

I did some manual testing to make sure the objects align correctly in the Z axis. See following images:

##### Without `z_align` (default)
```
parts = [box, lid]
p = pack(parts, padding=5, align_z=False)
show(p, reset_camera=Camera.KEEP)
```
![obrazek](https://github.com/gumyr/build123d/assets/5196729/443b5047-3a88-4ba8-b32c-aacd55d0b05e)
![obrazek](https://github.com/gumyr/build123d/assets/5196729/9b342406-3c5d-44b3-bc36-16abd3470384)


##### With `z_align`
```
parts = [box, lid]
p = pack(parts, padding=5, align_z=True)
show(p, reset_camera=Camera.KEEP)
```
![obrazek](https://github.com/gumyr/build123d/assets/5196729/1fe8971f-fae7-4681-bb43-c7ca791c2041)


Thank you! 