### PR TITLE
Propose adding `Plane.isometric` to built-in planes

### DIFF
--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -1895,6 +1895,12 @@ class PlaneMeta(type):
         """Bottom Plane"""
         return Plane((0, 0, 0), (1, 0, 0), (0, 0, -1))
 
+    @property
+    def isometric(cls) -> Plane:
+        """Isometric Plane"""
+        return Plane(
+            (0, 0, 0), (1 / 2**0.5, 1 / 2**0.5, 0), (1 / 3**0.5, -1 / 3**0.5, 1 / 3**0.5)
+        )
 
 class Plane(metaclass=PlaneMeta):
     """Plane
@@ -1909,22 +1915,23 @@ class Plane(metaclass=PlaneMeta):
 
     Planes can be created from faces as workplanes for feature creation on objects.
 
-    ======= ====== ====== ======
-    Name    x_dir  y_dir  z_dir
-    ======= ====== ====== ======
-    XY      +x     +y     +z
-    YZ      +y     +z     +x
-    ZX      +z     +x     +y
-    XZ      +x     +z     -y
-    YX      +y     +x     -z
-    ZY      +z     +y     -x
-    front   +x     +z     -y
-    back    -x     +z     +y
-    left    -y     +z     -x
-    right   +y     +z     +x
-    top     +x     +y     +z
-    bottom  +x     -y     -z
-    ======= ====== ====== ======
+    =======   ====== ====== ======
+    Name      x_dir  y_dir  z_dir
+    =======   ====== ====== ======
+    XY         +x     +y     +z
+    YZ         +y     +z     +x
+    ZX         +z     +x     +y
+    XZ         +x     +z     -y
+    YX         +y     +x     -z
+    ZY         +z     +y     -x
+    front      +x     +z     -y
+    back       -x     +z     +y
+    left       -y     +z     -x
+    right      +y     +z     +x
+    top        +x     +y     +z
+    bottom     +x     -y     -z
+    isometric  +x+y   -x+y+z +x+y-z
+    =======  ======  ======  ======
 
     Args:
         gp_pln (gp_Pln): an OCCT plane object

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -1931,7 +1931,7 @@ class Plane(metaclass=PlaneMeta):
     top        +x     +y     +z
     bottom     +x     -y     -z
     isometric  +x+y   -x+y+z +x+y-z
-    =======  ======  ======  ======
+    =======   ====== ====== ======
 
     Args:
         gp_pln (gp_Pln): an OCCT plane object

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -2267,20 +2267,21 @@ class TestPlane(DirectApiTestCase):
 
     def test_class_properties(self):
         """Validate
-        Name    x_dir  y_dir  z_dir
-        ======= ====== ====== ======
-        XY      +x     +y     +z
-        YZ      +y     +z     +x
-        ZX      +z     +x     +y
-        XZ      +x     +z     -y
-        YX      +y     +x     -z
-        ZY      +z     +y     -x
-        front   +x     +z     -y
-        back    -x     +z     +y
-        left    -y     +z     -x
-        right   +y     +z     +x
-        top     +x     +y     +z
-        bottom  +x     -y     -z
+        Name      x_dir  y_dir  z_dir
+        =======   ====== ====== ======
+        XY         +x     +y     +z
+        YZ         +y     +z     +x
+        ZX         +z     +x     +y
+        XZ         +x     +z     -y
+        YX         +y     +x     -z
+        ZY         +z     +y     -x
+        front      +x     +z     -y
+        back       -x     +z     +y
+        left       -y     +z     -x
+        right      +y     +z     +x
+        top        +x     +y     +z
+        bottom     +x     -y     -z
+        isometric  +x+y   -x+y+z +x+y-z
         """
         planes = [
             (Plane.XY, (1, 0, 0), (0, 0, 1)),
@@ -2295,6 +2296,7 @@ class TestPlane(DirectApiTestCase):
             (Plane.right, (0, 1, 0), (1, 0, 0)),
             (Plane.top, (1, 0, 0), (0, 0, 1)),
             (Plane.bottom, (1, 0, 0), (0, 0, -1)),
+            (Plane.isometric, (1 / 2**0.5, 1 / 2**0.5, 0), (1 / 3**0.5, -1 / 3**0.5, 1 / 3**0.5)),
         ]
         for plane, x_dir, z_dir in planes:
             self.assertVectorAlmostEquals(plane.x_dir, x_dir, 5)


### PR DESCRIPTION
Currently there are a number of built-in planes like Plane.XY, YZ, front, top, etc. I propose adding a `Plane.isometric` built-in plane that will (1) allow aligning objects to the viewers isometric view direction (tested against OCP CAD Viewer and CQ-editor) (2) Provide access to a less trivial plane definition that could help improve robustness of unit tests (none of the `Plane.isometric` axes align with the global XYZ axes). There may also be some benefits to the 2D exporters, since providing an easier-to-access isometric view direction could be helpful for e.g. "more intelligible" 2D representations of 3D objects.