### PR TITLE
Complete JernArc relocates vertex

### DIFF
--- a/src/build123d/objects_curve.py
+++ b/src/build123d/objects_curve.py
@@ -596,6 +596,7 @@ class JernArc(BaseLineObject):
         if abs(arc_size) >= 360:
             circle_plane = copy.copy(jern_workplane)
             circle_plane.origin = self.center_point
+            circle_plane.x_dir = self.start - circle_plane.origin
             arc = Edge.make_circle(radius, circle_plane)
         else:
             arc = Edge.make_tangent_arc(start, start_tangent, self.end_of_arc)

--- a/tests/test_build_line.py
+++ b/tests/test_build_line.py
@@ -224,12 +224,15 @@ class BuildLineTests(unittest.TestCase):
         self.assertAlmostEqual(iso1.radius, 1)
         self.assertAlmostEqual(iso1.length, pi)
         
-        with BuildLine() as l:
+        with BuildLine() as full_l:
             l1 = JernArc(start=(0, 0, 0), tangent=(1, 0, 0), radius=1, arc_size=360)
+            l2 = JernArc(start=(0, 0, 0), tangent=(1, 0, 0), radius=1, arc_size=300)
         self.assertTrue(l1.is_closed)
+        self.assertFalse(l2.is_closed)
         circle_face = Face(l1)
         self.assertAlmostEqual(circle_face.area, pi, 5)
         self.assertTupleAlmostEquals(circle_face.center().to_tuple(), (0, 1, 0), 5)
+        self.assertTupleAlmostEquals(l1.vertex().to_tuple(), l2.start.to_tuple(), 5)
 
         l1 = JernArc((0, 0), (1, 0), 1, 90)
         self.assertTupleAlmostEquals((l1 @ 1).to_tuple(), (1, 1, 0), 5)


### PR DESCRIPTION
This PR fixes https://github.com/gumyr/build123d/issues/621 by altering the `x_dir` of the `Plane` used to construct a closed (>= 360 degree) `JernArc`.