### PR TITLE
Remove unused numpy-stl dependency and update Apple Silicon instructions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -133,8 +133,8 @@ A procedure for avoiding this issue is to install in a conda environment, which 
 	conda install -c cadquery -c conda-forge cadquery=master
 	pip install svgwrite svgpathtools anytree scipy ipython trianglesolver \
 	    ocp_tessellate webcolors==1.12 numpy numpy-quaternion cachetools==5.2.0 \
-	    ocp_vscode requests orjson urllib3 certifi numpy-stl py-lib3mf \
-	    "svgpathtools>=1.5.1,<2" "svgelements>=1.9.1,<2"
+	    ocp_vscode requests orjson urllib3 certifi py-lib3mf \
+	    "svgpathtools>=1.5.1,<2" "svgelements>=1.9.1,<2" "ezdxf>=1.1.0,<2"
 	pip install --no-deps build123d ocpsvg
 
 `You can track the issue here <https://github.com/CadQuery/ocp-build-system/issues/11#issuecomment-1407769681>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ dependencies = [
     "svgpathtools >= 1.5.1, <2",
     "anytree >= 2.8.0, <3",
     "ezdxf >= 1.1.0, < 2",
-    "numpy-stl >= 3.0.0, <4",
     "ipython >= 8.0.0, <9",
     "py-lib3mf >= 2.3.1",
     "ocpsvg",


### PR DESCRIPTION
Fixes issue https://github.com/gumyr/build123d/issues/650 also updated the apple silicon instructions by removing numpy-stl and adding ezdxf with a version range.