### PR TITLE
context aware shapes: fix to generic typevar to pass-through return types of those affected by functools.wraps correctly

### DIFF
--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -1283,11 +1283,12 @@ class WorkplaneList:
 
 
 P = ParamSpec("P")
+T2 = TypeSpec("T2")
 
 
 def __gen_context_component_getter(
-    func: Callable[Concatenate[Builder, P], T]
-) -> Callable[P, T]:
+    func: Callable[Concatenate[Builder, P], T2]
+) -> Callable[P, T2]:
     @functools.wraps(func)
     def getter(select: Select = Select.ALL):
         context = Builder._get_context(func.__name__)

--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -1283,7 +1283,7 @@ class WorkplaneList:
 
 
 P = ParamSpec("P")
-T2 = TypeSpec("T2")
+T2 = TypeVar("T2")
 
 
 def __gen_context_component_getter(


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/854ea6b7-79a1-4f9e-a9bb-2f35741f7c12)
The existing context-aware `shapes()` do not properly pass through their return types (current returns as `list[Any]` instead of `ShapeList[Shape]`) which means that the docstrings for their applicable methods do not show up in e.g. VSCode. This PR fixes this behavior by introducing a more generic TypeVar `T2`

new behavior:
![image](https://github.com/user-attachments/assets/2ec21052-4aad-41b2-8996-41516de4a41a)
