### PR TITLE
Enable sdist releases on PyPI starting with build123d v0.7.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,7 @@ jobs:
           ls -lR
           python3 -m pip install --upgrade pip
           python3 -m pip -V
+          python3 -m pip install build
           python3 -m build --outdir wheelhouse
           python3 -m pip freeze
           ls -lR

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,36 +15,23 @@ jobs:
         with:
           fetch-depth: 0 # get all history for setuptools_scm
         
-      - name: Build wheel
+      - name: Build sdist and wheel
         shell: bash
         run: |
           pwd
           ls -lR
           python3 -m pip install --upgrade pip
           python3 -m pip -V
-          python3 -m pip wheel -w wheelhouse .
+          python3 -m build --outdir wheelhouse
           python3 -m pip freeze
+          ls -lR
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          path: ./wheelhouse/build123d*.whl # only store the build123d wheel
-
-  # Do we need sdist wheel?
-  # build_sdist:
-  #   name: Build source distribution
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-
-  #     - name: Build sdist
-  #       run: pipx run build --sdist
-
-  #     - uses: actions/upload-artifact@v3
-  #       with:
-  #         path: dist/*.tar.gz
+          path: ./wheelhouse/build123d*.* # store the build123d wheel and sdist
       
   upload_pypi:
-    needs: [build_wheel] #, build_sdist]
+    needs: [build_wheel]
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -56,7 +43,7 @@ jobs:
     if: needs.build_wheel.result == 'success'
     #if: (github.repository == 'gumyr/build123d' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           # unpacks default artifact into dist/
           # if `name: artifact` is omitted, the action will create extra parent dir


### PR DESCRIPTION
Planning to use with the build123d v0.7.0 release