### PR TITLE
import_step: do not assign labels to Compound.for_construction

### DIFF
--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -2312,7 +2312,8 @@ class Shape(NodeMixin):
         cls = self.__class__
         result = cls.__new__(cls)
         memo[id(self)] = result
-        memo[id(self.wrapped)] = downcast(BRepBuilderAPI_Copy(self.wrapped).Shape())
+        if self.wrapped is not None:
+            memo[id(self.wrapped)] = downcast(BRepBuilderAPI_Copy(self.wrapped).Shape())
         for key, value in self.__dict__.items():
             setattr(result, key, copy.deepcopy(value, memo))
             if key == "joints":

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -108,6 +108,12 @@ class ImportSTEP(unittest.TestCase):
         box = import_step("test.step")
         self.assertTrue(isinstance(box, Solid))
 
+    def test_move_single_object(self):
+        export_step(Solid.make_box(1, 1, 1), "test.step")
+        box = import_step("test.step")
+        box_moved = Pos(X=1) * box
+        self.assertEqual(tuple(box_moved.location.position), (1, 0, 0))
+
     def test_single_label_color(self):
         box_to_export = Solid.make_box(1, 1, 1)
         box_to_export.label = "box"


### PR DESCRIPTION
This is a proposed fix for #662.

After importing a STEP file, the `for_construction` attribute of `Compound`s contain an `OCP.TDF.TDF_Label`. This will make `Shape.__deepcopy__` fail because the label is not pickleable.
I removed the assignment of `TDF_Label`s to `for_construction` in the STEP import, and pass the label as a function argument to `build_assembly` instead.
I tried importing a few STEP files and it appears to work. WDYT?