### PR TITLE
Change Empty Builders RuntimeError to a UserWarning

### DIFF
--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -280,9 +280,7 @@ class Builder(ABC):
                 "Transferring object(s) to %s", type(self.builder_parent).__name__
             )
             if self._obj is None and not sys.exc_info()[1]:
-                raise RuntimeError(
-                    f"{self._obj_name} is None - {self._tag} didn't create anything"
-                )
+                warnings.warn(f"{self._obj_name} is None - {self._tag} didn't create anything")
             self.builder_parent._add_to_context(self._obj, mode=self.mode)
 
         self.exit_workplanes = WorkplaneList._get_context().workplanes
@@ -361,7 +359,8 @@ class Builder(ABC):
             # Generate an exception if not processing exceptions
             if len(objects) != num_stored and not sys.exc_info()[1]:
                 unsupported = set(objects) - set(v for l in typed.values() for v in l)
-                raise ValueError(f"{self._tag} doesn't accept {unsupported}")
+                if unsupported != {None}:
+                    raise ValueError(f"{self._tag} doesn't accept {unsupported}")
 
             # Extract base objects from Compounds
             compound: Compound

--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -280,7 +280,7 @@ class Builder(ABC):
                 "Transferring object(s) to %s", type(self.builder_parent).__name__
             )
             if self._obj is None and not sys.exc_info()[1]:
-                warnings.warn(f"{self._obj_name} is None - {self._tag} didn't create anything")
+                warnings.warn(f"{self._obj_name} is None - {self._tag} didn't create anything", stacklevel=2)
             self.builder_parent._add_to_context(self._obj, mode=self.mode)
 
         self.exit_workplanes = WorkplaneList._get_context().workplanes


### PR DESCRIPTION
Currently builder patterns like:
```py
with BuildPart() as p:
    with BuildSketch() as s:
        pass
    pass
```
result in `RuntimeError: sketch is None - BuildSketch didn't create anything`

I propose that this behavior is changed to a UserWarning instead of a RuntimeError, as this can be quite annoying to work around while developing a part that is only partially finished. I often resort to adding "dummy objects" like boxes and rectangles to ensure that the builders are not empty.