### PR TITLE
isclose on all platforms to attempt to fix MacOS / arm64 test failure for new `Wire.trim` feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: test
         run: |
-          python -m pytest -rA
+          python -m pytest
 
   tests_arm64:
     strategy:
@@ -43,4 +43,4 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: test
         run: |
-          python -m pytest -rA
+          python -m pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: test
         run: |
-          python -m pytest
+          python -m pytest -rA
 
   tests_arm64:
     strategy:
@@ -43,4 +43,4 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: test
         run: |
-          python -m pytest
+          python -m pytest -rA

--- a/src/build123d/operations_generic.py
+++ b/src/build123d/operations_generic.py
@@ -29,7 +29,7 @@ license:
 
 import copy
 import logging
-from math import radians, tan, isclose
+from math import radians, tan
 from typing import Union, Iterable
 
 from build123d.build_common import (
@@ -69,6 +69,7 @@ from build123d.topology import (
     Solid,
     Vertex,
     Wire,
+    isclose_b,
 )
 
 logging.getLogger("build123d").addHandler(logging.NullHandler())
@@ -361,15 +362,13 @@ def chamfer(
         if not target.is_closed:
             object_list = filter(
                 lambda v: not (
-                    isclose(
+                    isclose_b(
                         (Vector(*v.to_tuple()) - target.position_at(0)).length,
                         0.0,
-                        abs_tol=1e-14,
                     )
-                    or isclose(
+                    or isclose_b(
                         (Vector(*v.to_tuple()) - target.position_at(1)).length,
                         0.0,
-                        abs_tol=1e-14,
                     )
                 ),
                 object_list,
@@ -462,15 +461,13 @@ def fillet(
         if not target.is_closed:
             object_list = filter(
                 lambda v: not (
-                    isclose(
+                    isclose_b(
                         (Vector(*v.to_tuple()) - target.position_at(0)).length,
                         0.0,
-                        abs_tol=1e-14,
                     )
-                    or isclose(
+                    or isclose_b(
                         (Vector(*v.to_tuple()) - target.position_at(1)).length,
                         0.0,
-                        abs_tol=1e-14,
                     )
                 ),
                 object_list,

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -4785,8 +4785,8 @@ class Edge(Mixin1D, Shape):
             return parameter
 
         point = Vector(point)
-        distance_to_point = self.distance_to(point)
-        if not isclose(distance_to_point, 0.0, abs_tol=TOLERANCE):
+
+        if not isclose_b(self.distance_to(point), 0):
             raise ValueError(f"point ({point}) is not on edge")
 
         # Get the extreme of the parameter values for this Edge/Wire

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -4743,7 +4743,7 @@ class Edge(Mixin1D, Shape):
         new_edge = BRepBuilderAPI_MakeEdge(trimmed_curve).Edge()
         return Edge(new_edge)
 
-    _to_length(self, start: float, length: float) -> Edge:
+    def trim_to_length(self, start: float, length: float) -> Edge:
         """trim_to_length
 
         Create a new edge starting at the given normalized parameter of a

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -44,7 +44,7 @@ import warnings
 from abc import ABC, ABCMeta, abstractmethod
 from io import BytesIO
 from itertools import combinations
-from math import radians, inf, pi, sin, cos, tan, copysign, ceil, floor
+from math import radians, inf, pi, sin, cos, tan, copysign, ceil, floor, isclose
 from typing import (
     Any,
     Callable,
@@ -4786,7 +4786,7 @@ class Edge(Mixin1D, Shape):
 
         point = Vector(point)
 
-        if self.distance_to(point) > TOLERANCE:
+        if isclose(self.distance_to(point), 0.0, 1e-14):
             raise ValueError(f"point ({point}) is not on edge")
 
         # Get the extreme of the parameter values for this Edge/Wire

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -4786,7 +4786,7 @@ class Edge(Mixin1D, Shape):
 
         point = Vector(point)
 
-        if isclose(self.distance_to(point), 0.0, abs_tol=TOLERANCE):
+        if not isclose(self.distance_to(point), 0.0, abs_tol=TOLERANCE):
             raise ValueError(f"point ({point}) is not on edge")
 
         # Get the extreme of the parameter values for this Edge/Wire

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -4786,7 +4786,7 @@ class Edge(Mixin1D, Shape):
 
         point = Vector(point)
 
-        if isclose(self.distance_to(point), 0.0, abs_tol=1e-14):
+        if isclose(self.distance_to(point), 0.0, abs_tol=TOLERANCE):
             raise ValueError(f"point ({point}) is not on edge")
 
         # Get the extreme of the parameter values for this Edge/Wire

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -4786,7 +4786,7 @@ class Edge(Mixin1D, Shape):
 
         point = Vector(point)
 
-        if isclose(self.distance_to(point), 0.0, 1e-14):
+        if isclose(self.distance_to(point), 0.0, abs_tol=1e-14):
             raise ValueError(f"point ({point}) is not on edge")
 
         # Get the extreme of the parameter values for this Edge/Wire

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -4786,7 +4786,7 @@ class Edge(Mixin1D, Shape):
 
         point = Vector(point)
 
-        if not isclose_b(self.distance_to(point), 0):
+        if not isclose_b(self.distance_to(point), 0, abs_tol=TOLERANCE):
             raise ValueError(f"point ({point}) is not on edge")
 
         # Get the extreme of the parameter values for this Edge/Wire

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -2489,6 +2489,9 @@ class Shape(NodeMixin):
 
     def distance_to(self, other: Union[Shape, VectorLike]) -> float:
         """Minimal distance between two shapes"""
+        print(f"{self.distance_to_with_closest_points(other)[0]=}") # TODO: REMOVE PRINT
+        print(f"{self.distance_to_with_closest_points(other)[1]=}") # TODO: REMOVE PRINT
+        print(f"{self.distance_to_with_closest_points(other)[2]=}") # TODO: REMOVE PRINT
         return self.distance_to_with_closest_points(other)[0]
 
     def closest_points(self, other: Union[Shape, VectorLike]) -> tuple[Vector, Vector]:
@@ -4787,6 +4790,8 @@ class Edge(Mixin1D, Shape):
         point = Vector(point)
 
         if not isclose(self.distance_to(point), 0.0, abs_tol=TOLERANCE):
+            print(f"{self.distance_to(point)=}") # TODO: REMOVE PRINTS
+            print(f"{point=}") # TODO: REMOVE PRINTS
             raise ValueError(f"point ({point}) is not on edge")
 
         # Get the extreme of the parameter values for this Edge/Wire

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -4788,10 +4788,10 @@ class Edge(Mixin1D, Shape):
             return parameter
 
         point = Vector(point)
-
-        if not isclose(self.distance_to(point), 0.0, abs_tol=TOLERANCE):
-            print(f"{self.distance_to(point)=}") # TODO: REMOVE PRINTS
-            print(f"{point=}") # TODO: REMOVE PRINTS
+        distance_to_point = self.distance_to(point)
+        print(f"{distance_to_point=}") # TODO: REMOVE PRINTS
+        print(f"{point=}") # TODO: REMOVE PRINTS
+        if not isclose(distance_to_point, 0.0, abs_tol=TOLERANCE):
             raise ValueError(f"point ({point}) is not on edge")
 
         # Get the extreme of the parameter values for this Edge/Wire
@@ -7923,6 +7923,9 @@ class Wire(Mixin1D, Shape):
         Returns:
             Wire: trimmed wire
         """
+        def isclose_b123d(a, b, abs_tol=1e-14):
+            return isclose(a, b, abs_tol=abs_tol)
+
         # pylint: disable=too-many-branches
         if start >= end:
             raise ValueError("start must be less than end")
@@ -7942,10 +7945,10 @@ class Wire(Mixin1D, Shape):
             u = self.param_at_point(e.position_at(0))
             v = self.param_at_point(e.position_at(1))
             if self.is_closed:  # Avoid two beginnings or ends
-                u = 1 - u if found_end_of_wire and (u == 0 or u == 1) else u
-                v = 1 - v if found_end_of_wire and (v == 0 or v == 1) else v
+                u = 1 - u if found_end_of_wire and (isclose_b123d(u,0) or isclose_b123d(u,1)) else u
+                v = 1 - v if found_end_of_wire and (isclose_b123d(v,0) or isclose_b123d(v,1)) else v
                 found_end_of_wire = (
-                    u == 0 or u == 1 or v == 0 or v == 1 or found_end_of_wire
+                    isclose_b123d(u,0) or isclose_b123d(u,1) or isclose_b123d(v,0) or isclose_b123d(v,1) or found_end_of_wire
                 )
 
             # Edge might be reversed and require flipping parms

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -3996,10 +3996,9 @@ class TestWire(DirectApiTestCase):
         t6 = w.trim(0.5, 1)
         self.assertAlmostEqual(t6.length, 4, 5)
 
-        # Doesn't work on arm based Macs
-        # p = RegularPolygon(10, 20).wire()
-        # t7 = p.trim(0.1, 0.2)
-        # self.assertAlmostEqual(p.length * 0.1, t7.length, 5)
+        p = RegularPolygon(10, 20).wire()
+        t7 = p.trim(0.1, 0.2)
+        self.assertAlmostEqual(p.length * 0.1, t7.length, 5)
 
         c = Circle(10).wire()
         t8 = c.trim(0.4, 0.9)


### PR DESCRIPTION
Also defined custom function for build123d that overrides the default abs_tol=0 parameter for math.isclose() -- this is generally useful for comparisons with zero that are stable across CPU types