### PR TITLE
fix location_at, position_at and tangent_at with PositionMode.LENGTH for Wire

### DIFF
--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -444,7 +444,7 @@ class Mixin1D:
             if position_mode == PositionMode.PARAMETER:
                 parameter = self.param_at(position)
             else:
-                parameter = position
+                parameter = self.param_at(position / self.length)
         else:
             try:
                 pnt = Vector(position)
@@ -682,7 +682,7 @@ class Mixin1D:
         if position_mode == PositionMode.PARAMETER:
             param = self.param_at(distance)
         else:
-            param = distance
+            param = self.param_at(distance / self.length)
 
         return Vector(curve.Value(param))
 
@@ -733,7 +733,7 @@ class Mixin1D:
         if position_mode == PositionMode.PARAMETER:
             param = self.param_at(distance)
         else:
-            param = distance
+            param = self.param_at(distance / self.length)
 
         law: GeomFill_TrihedronLaw
         if frame_method == FrameMethod.FRENET:

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -1989,6 +1989,33 @@ class TestMixin1D(DirectApiTestCase):
         )
         self.assertTrue(all([0.0 < v < 1.0 for v in point]))
 
+        wire = Wire([Edge.make_line((0, 0, 0), (10, 0, 0))])
+        self.assertVectorAlmostEquals(wire.position_at(0.3), (3, 0, 0), 5)
+        self.assertVectorAlmostEquals(
+            wire.position_at(3, position_mode=PositionMode.LENGTH), (3, 0, 0), 5
+        )
+        self.assertVectorAlmostEquals(wire.edge().position_at(0.3), (3, 0, 0), 5)
+        self.assertVectorAlmostEquals(
+            wire.edge().position_at(3, position_mode=PositionMode.LENGTH), (3, 0, 0), 5
+        )
+
+        circle = Wire(
+            [
+                Edge.make_circle(2, start_angle=0, end_angle=180),
+                Edge.make_circle(2, start_angle=180, end_angle=360),
+            ]
+        )
+        self.assertVectorAlmostEquals(
+            circle.position_at(0.5),
+            (-2, 0, 0),
+            5,
+        )
+        self.assertVectorAlmostEquals(
+            circle.position_at(2 * math.pi, position_mode=PositionMode.LENGTH),
+            (-2, 0, 0),
+            5,
+        )
+
     def test_positions(self):
         e = Edge.make_line((0, 0, 0), (1, 1, 1))
         distances = [i / 4 for i in range(3)]
@@ -2008,6 +2035,14 @@ class TestMixin1D(DirectApiTestCase):
             .to_tuple()
         )
         self.assertTrue(all([0.0 <= v <= 1.0 for v in tangent]))
+
+        self.assertVectorAlmostEquals(
+            Edge.make_circle(1, start_angle=0, end_angle=180).tangent_at(
+                math.pi / 2, position_mode=PositionMode.LENGTH
+            ),
+            (-1, 0, 0),
+            5,
+        )
 
     def test_tangent_at_point(self):
         circle = Wire(
@@ -2075,6 +2110,12 @@ class TestMixin1D(DirectApiTestCase):
 
     def test_location_at(self):
         loc = Edge.make_circle(1).location_at(0.25)
+        self.assertVectorAlmostEquals(loc.position, (0, 1, 0), 5)
+        self.assertVectorAlmostEquals(loc.orientation, (0, -90, -90), 5)
+
+        loc = Edge.make_circle(1).location_at(
+            math.pi / 2, position_mode=PositionMode.LENGTH
+        )
         self.assertVectorAlmostEquals(loc.position, (0, 1, 0), 5)
         self.assertVectorAlmostEquals(loc.orientation, (0, -90, -90), 5)
 

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -1999,6 +1999,25 @@ class TestMixin1D(DirectApiTestCase):
             wire.edge().position_at(3, position_mode=PositionMode.LENGTH), (3, 0, 0), 5
         )
 
+        circle_wire = Wire(
+            [
+                Edge.make_circle(1, start_angle=0, end_angle=180),
+                Edge.make_circle(1, start_angle=180, end_angle=360),
+            ]
+        )
+        p1 = circle_wire.position_at(math.pi, position_mode=PositionMode.LENGTH)
+        p2 = circle_wire.position_at(math.pi / circle_wire.length)
+        self.assertVectorAlmostEquals(p1, (-1, 0, 0), 14)
+        self.assertVectorAlmostEquals(p2, (-1, 0, 0), 14)
+        self.assertVectorAlmostEquals(p1, p2, 14)
+
+        circle_edge = Edge.make_circle(1)
+        p3 = circle_edge.position_at(math.pi, position_mode=PositionMode.LENGTH)
+        p4 = circle_edge.position_at(math.pi / circle_edge.length)
+        self.assertVectorAlmostEquals(p3, (-1, 0, 0), 14)
+        self.assertVectorAlmostEquals(p4, (-1, 0, 0), 14)
+        self.assertVectorAlmostEquals(p3, p4, 14)
+
         circle = Wire(
             [
                 Edge.make_circle(2, start_angle=0, end_angle=180),


### PR DESCRIPTION
Apparently Wire use a different parametrization than `Edge` because `Edge` has its `LastParameter` being the length of the Edge while `Wire`has `LastParameter` being the numer of `Edges` with the fractional part being the parameter inside the edge.

The way the patch works is to always divide the distance provided by the user by the real length of the Wire/Edge so that we get a parameter in [0..1] which we can then pass straight to `param_at` to get the real parameter. 


Fixes https://github.com/gumyr/build123d/issues/572