### PR TITLE
Fixing a typo on Update advantages.rst

### DIFF
--- a/docs/advantages.rst
+++ b/docs/advantages.rst
@@ -81,7 +81,7 @@ by the last operation and fillets them. Such a selection would be quite difficul
 otherwise.
 
 .. literalinclude:: ../examples/intersecting_pipes.py
-    :lines: 29, 37-48
+    :lines: 30, 39-49
 
 
 Extensions


### PR DESCRIPTION
Current advantages.rst embeds the wrong lines from examples/intersecting_pipes.py. With these changes, the lines you would see are

```python
from build123d import *

with BuildPart() as pipes:
    box = Box(10, 10, 10, rotation=(10, 20, 30))
    with BuildSketch(*box.faces()) as pipe:
        Circle(4)
    extrude(amount=-5, mode=Mode.SUBTRACT)
    with BuildSketch(*box.faces()) as pipe:
        Circle(4.5)
        Circle(4, mode=Mode.SUBTRACT)
    extrude(amount=10)
    fillet(pipes.edges(Select.LAST), 0.2)
```

If you view the advantages.rst page today, you'll see what I'm talking about:

![image](https://github.com/user-attachments/assets/d30ef30d-7899-46c0-ac40-26971918bd79)


