### PR TITLE
Fix thicken normal calculation when no override is provided

### DIFF
--- a/src/build123d/operations_part.py
+++ b/src/build123d/operations_part.py
@@ -592,12 +592,12 @@ def thicken(
     logger.info("%d face(s) to thicken", len(to_thicken_faces))
 
     for face in to_thicken_faces:
-        normal_override = (
+        face_normal = (
             normal_override if normal_override is not None else face.normal_at()
         )
         for direction in [1, -1] if both else [1]:
             new_solids.append(
-                face.thicken(depth=amount, normal_override=normal_override * direction)
+                face.thicken(depth=amount, normal_override=face_normal * direction)
             )
 
     if context is not None:

--- a/tests/test_build_part.py
+++ b/tests/test_build_part.py
@@ -475,6 +475,17 @@ class TestThicken(unittest.TestCase):
         outer_sphere = thicken(non_planar, amount=0.1)
         self.assertAlmostEqual(outer_sphere.volume, (4 / 3) * pi * (1.1**3 - 1**3), 5)
 
+        wire = JernArc((0, 0), (-1, 0), 1, 180).edge().reversed() + JernArc(
+            (0, 0), (1, 0), 2, -90
+        )
+        part = thicken(sweep((wire ^ 0) * RadiusArc((0, 0), (0, -1), 1), wire), 0.4)
+        self.assertAlmostEqual(part.volume, 2.241583787221904, 5)
+
+        part = thicken(
+            sweep((wire ^ 0) * RadiusArc((0, 0), (0, -1), 1), wire), 0.4, both=True
+        )
+        self.assertAlmostEqual(part.volume, 4.711747154435256, 5)
+
 
 class TestTorus(unittest.TestCase):
     def test_simple_torus(self):


### PR DESCRIPTION
Do not calculate normals if the user did not provide any override, it makes the calculation coherent with what OCCT does.

Fixes https://github.com/gumyr/build123d/issues/623.