### PR TITLE
Remove use of deprecated `Compound.make_compound()` in `tutorial_joints.py` and fix intro ex. 23 for algebra mode 

### DIFF
--- a/docs/general_examples_algebra.py
+++ b/docs/general_examples_algebra.py
@@ -386,7 +386,7 @@ pts = [
 
 l1 = Polyline(pts)
 l2 = Line(l1 @ 1, l1 @ 0)
-sk23 = make_face(l1, l2)
+sk23 = make_face([l1, l2])
 
 sk23 += Pos(0, 35) * Circle(25)
 sk23 = Plane.XZ * split(sk23, bisect_by=Plane.ZY)

--- a/docs/tutorial_joints.py
+++ b/docs/tutorial_joints.py
@@ -239,11 +239,11 @@ def write_svg(part, filename: str, view_port_origin=(-100, 100, 150)):
 #
 # SVG Export options
 write_svg(
-    Compound.make_compound([box, box.joints["hinge_attachment"].symbol]),
+    Compound([box, box.joints["hinge_attachment"].symbol]),
     "tutorial_joint_box",
 )
 write_svg(
-    Compound.make_compound(
+    Compound(
         [
             hinge_inner,
             hinge_inner.joints["leaf"].symbol,
@@ -257,7 +257,7 @@ write_svg(
     (100, 100, -50),
 )
 write_svg(
-    Compound.make_compound(
+    Compound(
         [
             hinge_outer,
             hinge_outer.joints["leaf"].symbol,
@@ -271,17 +271,17 @@ write_svg(
     (100, 100, -50),
 )
 write_svg(
-    Compound.make_compound([box, hinge_outer]),
+    Compound([box, hinge_outer]),
     "tutorial_joint_box_outer",
     (-100, -100, 50),
 )
 write_svg(
-    Compound.make_compound([lid, lid.joints["hinge_attachment"].symbol]),
+    Compound([lid, lid.joints["hinge_attachment"].symbol]),
     "tutorial_joint_lid",
     (-100, 100, 150),
 )
 write_svg(
-    Compound.make_compound([m6_screw, m6_joint.symbol]),
+    Compound([m6_screw, m6_joint.symbol]),
     "tutorial_joint_m6_screw",
     (-100, 100, 150),
 )
@@ -290,7 +290,7 @@ write_svg(
 box.joints["hinge_attachment"].connect_to(hinge_outer.joints["leaf"])
 # [Connect Box to Outer Hinge]
 write_svg(
-    Compound.make_compound([box, hinge_outer]),
+    Compound([box, hinge_outer]),
     "tutorial_joint_box_outer",
     (-100, -100, 50),
 )
@@ -298,7 +298,7 @@ write_svg(
 hinge_outer.joints["hinge_axis"].connect_to(hinge_inner.joints["hinge_axis"], angle=120)
 # [Connect Hinge Leaves]
 write_svg(
-    Compound.make_compound([box, hinge_outer, hinge_inner]),
+    Compound([box, hinge_outer, hinge_inner]),
     "tutorial_joint_box_outer_inner",
     (-100, -100, 50),
 )
@@ -306,7 +306,7 @@ write_svg(
 hinge_inner.joints["leaf"].connect_to(lid.joints["hinge_attachment"])
 # [Connect Hinge to Lid]
 write_svg(
-    Compound.make_compound([box, hinge_outer, hinge_inner, lid]),
+    Compound([box, hinge_outer, hinge_inner, lid]),
     "tutorial_joint_box_outer_inner_lid",
     (-100, -100, 50),
 )


### PR DESCRIPTION
Fixes https://github.com/gumyr/build123d/issues/639 and https://github.com/gumyr/build123d/issues/714