### PR TITLE
test: check that exporter.library is >= 2.3.1 not == 2.3.1

### DIFF
--- a/tests/test_mesher.py
+++ b/tests/test_mesher.py
@@ -1,4 +1,5 @@
 import unittest, uuid
+from packaging.specifiers import SpecifierSet
 from build123d.build_enums import MeshType, Unit
 from build123d.build_part import BuildPart
 from build123d.build_sketch import BuildSketch
@@ -36,7 +37,7 @@ class DirectApiTestCase(unittest.TestCase):
 class TestProperties(unittest.TestCase):
     def test_version(self):
         exporter = Mesher()
-        self.assertEqual(exporter.library_version, "2.3.1")
+        assert exporter.library_version in SpecifierSet(">= 2.3.1")
 
     def test_units(self):
         for unit in Unit:


### PR DESCRIPTION
Instead of checking that the exporter is version 2.3.1 make sure it is a compatible version with 2.3.1

closes #731