### PR TITLE
Compound sub dim check

### DIFF
--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -1730,7 +1730,7 @@ class Shape(NodeMixin):
         others = other if isinstance(other, (list, tuple)) else [other]
 
         for _other in others:
-            if type(_other)._dim < type(self)._dim:
+            if not type(_other)._dim == type(self)._dim and type(_other)._dim < type(self)._dim:
                 raise ValueError(
                     f"Only shapes with equal or greater dimension can be subtracted: "
                     f"not {type(self).__name__} ({type(self)._dim}D) and "

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -1696,78 +1696,111 @@ class Shape(NodeMixin):
             result = Shape._show_tree(tree[0], show_center)
         return result
 
-def __add__(self, other: Union[list[Shape], Shape]) -> Self:
-    """fuse shape to self operator +"""
-    if type(self) == Compound:  # Only block generic Compounds
-        raise NotImplementedError(
-            "Addition not supported for generic Compounds. Use Part for 3D objects, "
-            "Sketch for 2D objects, or Curve for 1D objects instead."
-        )
+    def __add__(self, other: Union[list[Shape], Shape]) -> Self:
+        """fuse shape to self operator +"""
+        # if type(self) == Compound:  # Only block generic Compounds
+        #     raise NotImplementedError(
+        #         "Addition not supported for generic Compounds. Use Part for 3D objects, "
+        #         "Sketch for 2D objects, or Curve for 1D objects instead."
+        #     )
 
-    others = other if isinstance(other, (list, tuple)) else [other]
+        others = other if isinstance(other, (list, tuple)) else [other]
 
-    if not all([type(other)._dim == type(self)._dim for other in others]):
-        raise ValueError("Only shapes with the same dimension can be added")
+        if not all([type(other)._dim == type(self)._dim for other in others]):
+            raise ValueError("Only shapes with the same dimension can be added")
 
-    if self.wrapped is None:
-        if len(others) == 1:
-            new_shape = others[0]
+        if self.wrapped is None:
+            if len(others) == 1:
+                new_shape = others[0]
+            else:
+                new_shape = others[0].fuse(*others[1:])
+        elif isinstance(other, Shape) and other.wrapped is None:
+            new_shape = self
         else:
-            new_shape = others[0].fuse(*others[1:])
-    elif isinstance(other, Shape) and other.wrapped is None:
-        new_shape = self
-    else:
-        new_shape = self.fuse(*others)
+            new_shape = self.fuse(*others)
 
-    if SkipClean.clean:
-        new_shape = new_shape.clean()
+        if SkipClean.clean:
+            new_shape = new_shape.clean()
 
-    if self._dim == 3:
-        new_shape = Part(new_shape.wrapped)
-    elif self._dim == 2:
-        new_shape = Sketch(new_shape.wrapped)
-    elif self._dim == 1:
-        new_shape = Curve(Compound(new_shape.edges()).wrapped)
+        if self._dim == 3:
+            new_shape = Part(new_shape.wrapped)
+        elif self._dim == 2:
+            new_shape = Sketch(new_shape.wrapped)
+        elif self._dim == 1:
+            new_shape = Curve(Compound(new_shape.edges()).wrapped)
 
-    return new_shape
+        return new_shape
 
-def __sub__(self, other: Shape) -> Self:
-    """cut shape from self operator -"""
-    if type(self) == Compound:  # Only block generic Compounds
-        raise NotImplementedError(
-            "Subtraction not supported for generic Compounds. Use Part for 3D objects, "
-            "Sketch for 2D objects, or Curve for 1D objects instead."
-        )
+    def __sub__(self, other: Shape) -> Self:
+        """Generalized cut shape from self operator -"""
 
-    others = other if isinstance(other, (list, tuple)) else [other]
+        others = other if isinstance(other, (list, tuple)) else [other]
+        
+        # Only do dimension check for non-Compound shapes
+        # or dimensional Compounds (Part, Sketch, Curve)
+        if self._dim is not None:
+            for _other in others:
+                # Skip check if other is a generic Compound
+                if _other._dim is not None and type(_other)._dim < type(self)._dim:
+                    raise ValueError(
+                        f"Only shapes with equal or greater dimension can be subtracted: "
+                        f"not {type(self).__name__} ({type(self)._dim}D) and "
+                        f"{type(_other).__name__} ({type(_other)._dim}D)"
+                    )
 
-    for _other in others:
-        if type(_other)._dim < type(self)._dim:
-            raise ValueError(
-                f"Only shapes with equal or greater dimension can be subtracted: "
-                f"not {type(self).__name__} ({type(self)._dim}D) and "
-                f"{type(_other).__name__} ({type(_other)._dim}D)"
-            )
+        new_shape = None
+        if self.wrapped is None:
+            raise ValueError("Cannot subtract shape from empty compound")
+        if isinstance(other, Shape) and other.wrapped is None:
+            new_shape = self
+        else:
+            # Do a single boolean operation with all shapes
+            cut_op = BRepAlgoAPI_Cut()
+            
+            args = TopTools_ListOfShape()
+            args.Append(self.wrapped)
+            cut_op.SetArguments(args)
+            
+            tools = TopTools_ListOfShape()
+            for o in others:
+                tools.Append(o.wrapped)
+            cut_op.SetTools(tools)
+            
+            cut_op.SetRunParallel(True)
+            cut_op.Build()
+            
+            if not cut_op.IsDone():
+                new_shape = None
+            else:
+                new_shape = Shape.cast(cut_op.Shape())
 
-    new_shape = None
-    if self.wrapped is None:
-        raise ValueError("Cannot subtract shape from empty compound")
-    if isinstance(other, Shape) and other.wrapped is None:
-        new_shape = self
-    else:
-        new_shape = self.cut(*others)
+        if new_shape is not None and SkipClean.clean:
+            new_shape = new_shape.clean()
 
-    if new_shape is not None and SkipClean.clean:
-        new_shape = new_shape.clean()
+        if new_shape is None:
+            # Return an empty shape of the appropriate dimensional type
+            if hasattr(type(self), '_dim'):
+                if self._dim == 3:
+                    new_shape = Part([])
+                elif self._dim == 2:
+                    new_shape = Sketch([])
+                elif self._dim == 1:
+                    new_shape = Curve([])
+            else:
+                new_shape = Compound([])
+        else:
+            # Convert to appropriate dimensional type
+            if hasattr(type(self), '_dim'):
+                if self._dim == 3:
+                    new_shape = Part(new_shape.wrapped)
+                elif self._dim == 2:
+                    new_shape = Sketch(new_shape.wrapped)
+                elif self._dim == 1:
+                    new_shape = Curve(Compound(new_shape.edges()).wrapped)
+            else:
+                new_shape = Compound(new_shape.wrapped)
 
-    if self._dim == 3:
-        new_shape = Part(new_shape.wrapped)
-    elif self._dim == 2:
-        new_shape = Sketch(new_shape.wrapped)
-    elif self._dim == 1:
-        new_shape = Curve(Compound(new_shape.edges()).wrapped)
-
-    return new_shape
+        return new_shape
 
     def __and__(self, other: Shape) -> Self:
         """intersect shape with self operator &"""

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -1745,32 +1745,19 @@ class Shape(NodeMixin):
         if new_shape is not None and SkipClean.clean:
             new_shape = new_shape.clean()
 
+        dim = self._dim if hasattr(type(self), "_dim") else None
+
         if new_shape is None:
             # Return an empty shape of the appropriate dimensional type
-            if hasattr(type(self), "_dim"):
-                if self._dim == 3:
-                    new_shape = Part([])
-                elif self._dim == 2:
-                    new_shape = Sketch([])
-                elif self._dim == 1:
-                    new_shape = Curve([])
-            else:
-                new_shape = Compound([])
+            new_shape = shapes_by_dim[dim]()
+        elif dim == 1:
+            new_shape = Curve(Compound(new_shape.edges()).wrapped)
         else:
-            # Convert to appropriate dimensional type
-            if hasattr(type(self), "_dim"):
-                if self._dim == 3:
-                    new_shape = Part(new_shape.wrapped)
-                elif self._dim == 2:
-                    new_shape = Sketch(new_shape.wrapped)
-                elif self._dim == 1:
-                    new_shape = Curve(Compound(new_shape.edges()).wrapped)
-            else:
-                new_shape = Compound(new_shape.wrapped)
+            new_shape = shapes_by_dim[dim](new_shape.wrapped)
 
         return new_shape
 
-    def __sub__(self, other: Shape) -> Self:
+    def __sub__(self, other: Shape) -> Union[Compound, Part, Sketch, Curve]:
         """Generalized cut shape from self operator -"""
 
         others = other if isinstance(other, (list, tuple)) else [other]
@@ -1816,28 +1803,15 @@ class Shape(NodeMixin):
         if new_shape is not None and SkipClean.clean:
             new_shape = new_shape.clean()
 
+        dim = self._dim if hasattr(type(self), "_dim") else None
+
         if new_shape is None:
             # Return an empty shape of the appropriate dimensional type
-            if hasattr(type(self), "_dim"):
-                if self._dim == 3:
-                    new_shape = Part([])
-                elif self._dim == 2:
-                    new_shape = Sketch([])
-                elif self._dim == 1:
-                    new_shape = Curve([])
-            else:
-                new_shape = Compound([])
+            new_shape = shapes_by_dim[dim]()
+        elif dim == 1:
+            new_shape = Curve(Compound(new_shape.edges()).wrapped)
         else:
-            # Convert to appropriate dimensional type
-            if hasattr(type(self), "_dim"):
-                if self._dim == 3:
-                    new_shape = Part(new_shape.wrapped)
-                elif self._dim == 2:
-                    new_shape = Sketch(new_shape.wrapped)
-                elif self._dim == 1:
-                    new_shape = Curve(Compound(new_shape.edges()).wrapped)
-            else:
-                new_shape = Compound(new_shape.wrapped)
+            new_shape = shapes_by_dim[dim](new_shape.wrapped)
 
         return new_shape
 
@@ -4657,6 +4631,9 @@ class Curve(Compound):
     def wires(self) -> list[Wire]:
         """A list of wires created from the edges"""
         return Wire.combine(self.edges())
+
+
+shapes_by_dim = {1: Curve, 2: Sketch, 3: Part, None: Compound}
 
 
 class Edge(Mixin1D, Shape):

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -1735,7 +1735,7 @@ class Shape(NodeMixin):
         """Generalized cut shape from self operator -"""
 
         others = other if isinstance(other, (list, tuple)) else [other]
-        
+
         # Only do dimension check for non-Compound shapes
         # or dimensional Compounds (Part, Sketch, Curve)
         if self._dim is not None:
@@ -1756,19 +1756,19 @@ class Shape(NodeMixin):
         else:
             # Do a single boolean operation with all shapes
             cut_op = BRepAlgoAPI_Cut()
-            
+
             args = TopTools_ListOfShape()
             args.Append(self.wrapped)
             cut_op.SetArguments(args)
-            
+
             tools = TopTools_ListOfShape()
             for o in others:
                 tools.Append(o.wrapped)
             cut_op.SetTools(tools)
-            
+
             cut_op.SetRunParallel(True)
             cut_op.Build()
-            
+
             if not cut_op.IsDone():
                 new_shape = None
             else:
@@ -1779,7 +1779,7 @@ class Shape(NodeMixin):
 
         if new_shape is None:
             # Return an empty shape of the appropriate dimensional type
-            if hasattr(type(self), '_dim'):
+            if hasattr(type(self), "_dim"):
                 if self._dim == 3:
                     new_shape = Part([])
                 elif self._dim == 2:
@@ -1790,7 +1790,7 @@ class Shape(NodeMixin):
                 new_shape = Compound([])
         else:
             # Convert to appropriate dimensional type
-            if hasattr(type(self), '_dim'):
+            if hasattr(type(self), "_dim"):
                 if self._dim == 3:
                     new_shape = Part(new_shape.wrapped)
                 elif self._dim == 2:

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -1705,7 +1705,7 @@ class Shape(NodeMixin):
         # or dimensional Compounds (Part, Sketch, Curve)
         if self._dim is not None:
             for _other in others:
-                # Skip check if other is a generic Compound 
+                # Skip check if other is a generic Compound
                 if _other._dim is not None and type(_other)._dim != type(self)._dim:
                     raise ValueError(
                         f"Only shapes with the same dimension can be added: "
@@ -1718,7 +1718,7 @@ class Shape(NodeMixin):
             if len(others) == 1:
                 new_shape = others[0]
             else:
-                new_shape = others[0].fuse(*others[1:]) 
+                new_shape = others[0].fuse(*others[1:])
         elif isinstance(other, Shape) and other.wrapped is None:
             new_shape = self
         else:
@@ -1732,7 +1732,7 @@ class Shape(NodeMixin):
             tools = TopTools_ListOfShape()
             for o in others:
                 tools.Append(o.wrapped)
-            fuse_op.SetTools(tools) 
+            fuse_op.SetTools(tools)
 
             fuse_op.SetRunParallel(True)
             fuse_op.Build()
@@ -1757,12 +1757,12 @@ class Shape(NodeMixin):
             else:
                 new_shape = Compound([])
         else:
-            # Convert to appropriate dimensional type  
+            # Convert to appropriate dimensional type
             if hasattr(type(self), "_dim"):
                 if self._dim == 3:
                     new_shape = Part(new_shape.wrapped)
                 elif self._dim == 2:
-                    new_shape = Sketch(new_shape.wrapped) 
+                    new_shape = Sketch(new_shape.wrapped)
                 elif self._dim == 1:
                     new_shape = Curve(Compound(new_shape.edges()).wrapped)
             else:

--- a/tests/test_algebra.py
+++ b/tests/test_algebra.py
@@ -660,30 +660,19 @@ class AlgebraTests(unittest.TestCase):
             _ = rectangle - line
 
     # Compound
-    def test_compound_minus(self):
+    def test_compound_plus(self):
+        """Test that addition of generic Compounds raises NotImplementedError"""
         box = Box(1, 2, 3)
         cylinder = Cylinder(0.2, 5)
-        last_edges = box.edges()
-        result = Compound(box) - Compound(cylinder)
-        self.assertEqual(len(result.edges() - last_edges), 3)
-        self.assertTupleAlmostEquals(
-            result.edges()
-            .sort_by()
-            .filter_by(GeomType.CIRCLE)
-            .first.center(CenterOf.MASS),
-            (0, 0, -1.5),
-            6,
-        )
-        self.assertTupleAlmostEquals(
-            result.edges()
-            .sort_by()
-            .filter_by(GeomType.CIRCLE)
-            .last.center(CenterOf.MASS),
-            (0, 0, 1.5),
-            6,
-        )
-        self.assertTupleAlmostEquals(result.bounding_box().min, (-0.5, -1.0, -1.5), 6)
-        self.assertTupleAlmostEquals(result.bounding_box().max, (0.5, 1.0, 1.5), 6)
+        with self.assertRaises(NotImplementedError):
+            result = Compound(box) + Compound(cylinder)
+
+    def test_compound_minus(self):
+        """Test that subtraction of generic Compounds raises NotImplementedError"""
+        box = Box(1, 2, 3)
+        cylinder = Cylinder(0.2, 5)
+        with self.assertRaises(NotImplementedError):
+            result = Compound(box) - Compound(cylinder)
 
 class LocationTests(unittest.TestCase):
     def test_wheel(self):

--- a/tests/test_algebra.py
+++ b/tests/test_algebra.py
@@ -672,6 +672,7 @@ class AlgebraTests(unittest.TestCase):
         cylinder = Cylinder(0.2, 5)
         _ = Compound(box) - Compound(cylinder)
 
+
 class LocationTests(unittest.TestCase):
     def test_wheel(self):
         plane = Plane.ZX

--- a/tests/test_algebra.py
+++ b/tests/test_algebra.py
@@ -661,18 +661,16 @@ class AlgebraTests(unittest.TestCase):
 
     # Compound
     def test_compound_plus(self):
-        """Test that addition of generic Compounds raises NotImplementedError"""
+        """Test that addition of generic Compounds works"""
         box = Box(1, 2, 3)
         cylinder = Cylinder(0.2, 5)
-        with self.assertRaises(NotImplementedError):
-            result = Compound(box) + Compound(cylinder)
+        _ = Compound(box) + Compound(cylinder)
 
     def test_compound_minus(self):
-        """Test that subtraction of generic Compounds raises NotImplementedError"""
+        """Test that subtraction of generic Compounds works"""
         box = Box(1, 2, 3)
         cylinder = Cylinder(0.2, 5)
-        with self.assertRaises(NotImplementedError):
-            result = Compound(box) - Compound(cylinder)
+        _ = Compound(box) - Compound(cylinder)
 
 class LocationTests(unittest.TestCase):
     def test_wheel(self):

--- a/tests/test_algebra.py
+++ b/tests/test_algebra.py
@@ -672,6 +672,24 @@ class AlgebraTests(unittest.TestCase):
         cylinder = Cylinder(0.2, 5)
         _ = Compound(box) - Compound(cylinder)
 
+    def test_dimension_mismatch(self):
+        """Test that operations between different dimensional shapes fail"""
+        test_face = Face.make_rect(1, 2)  # 2D
+        test_solid = Solid.make_box(1, 2, 3)  # 3D
+
+        with self.assertRaises(ValueError) as cm:
+            _ = test_face + test_solid
+        self.assertIn(
+            "Only shapes with the same dimension can be added", str(cm.exception)
+        )
+
+        with self.assertRaises(ValueError) as cm:
+            _ = test_solid - test_face
+        self.assertIn(
+            "Only shapes with equal or greater dimension can be subtracted: not Solid (3D) and Face (2D)",
+            str(cm.exception),
+        )
+
 
 class LocationTests(unittest.TestCase):
     def test_wheel(self):

--- a/tests/test_algebra.py
+++ b/tests/test_algebra.py
@@ -666,11 +666,21 @@ class AlgebraTests(unittest.TestCase):
         cylinder = Cylinder(0.2, 5)
         _ = Compound(box) + Compound(cylinder)
 
+        # Single-dimensional edge case in code path
+        curve1 = Curve(Edge.make_line((1, 2), (4, 4)))
+        curve2 = Curve(Edge.make_circle(2))
+        _ = curve1 + curve2
+
     def test_compound_minus(self):
         """Test that subtraction of generic Compounds works"""
         box = Box(1, 2, 3)
         cylinder = Cylinder(0.2, 5)
         _ = Compound(box) - Compound(cylinder)
+
+        # Single-dimensional edge case in code path
+        curve1 = Curve(Edge.make_line((1, 2), (4, 4)))
+        curve2 = Curve(Edge.make_circle(2))
+        _ = curve1 - curve2
 
     def test_dimension_mismatch(self):
         """Test that operations between different dimensional shapes fail"""

--- a/tests/test_algebra.py
+++ b/tests/test_algebra.py
@@ -659,6 +659,31 @@ class AlgebraTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             _ = rectangle - line
 
+    # Compound
+    def test_compound_minus(self):
+        box = Box(1, 2, 3)
+        cylinder = Cylinder(0.2, 5)
+        last_edges = box.edges()
+        result = Compound(box) - Compound(cylinder)
+        self.assertEqual(len(result.edges() - last_edges), 3)
+        self.assertTupleAlmostEquals(
+            result.edges()
+            .sort_by()
+            .filter_by(GeomType.CIRCLE)
+            .first.center(CenterOf.MASS),
+            (0, 0, -1.5),
+            6,
+        )
+        self.assertTupleAlmostEquals(
+            result.edges()
+            .sort_by()
+            .filter_by(GeomType.CIRCLE)
+            .last.center(CenterOf.MASS),
+            (0, 0, 1.5),
+            6,
+        )
+        self.assertTupleAlmostEquals(result.bounding_box().min, (-0.5, -1.0, -1.5), 6)
+        self.assertTupleAlmostEquals(result.bounding_box().max, (0.5, 1.0, 1.5), 6)
 
 class LocationTests(unittest.TestCase):
     def test_wheel(self):

--- a/tests/test_algebra.py
+++ b/tests/test_algebra.py
@@ -667,9 +667,9 @@ class AlgebraTests(unittest.TestCase):
         _ = Compound(box) + Compound(cylinder)
 
         # Single-dimensional edge case in code path
-        curve1 = Curve(Edge.make_line((1, 2), (4, 4)))
-        curve2 = Curve(Edge.make_circle(2))
-        _ = curve1 + curve2
+        l1 = Curve() + CenterArc((0, 0), 1, 0, 180)
+        l2 = Curve() + CenterArc((2, 0), 1, 0, -180)
+        _ = l1 + l2
 
     def test_compound_minus(self):
         """Test that subtraction of generic Compounds works"""
@@ -678,9 +678,9 @@ class AlgebraTests(unittest.TestCase):
         _ = Compound(box) - Compound(cylinder)
 
         # Single-dimensional edge case in code path
-        curve1 = Curve(Edge.make_line((1, 2), (4, 4)))
-        curve2 = Curve(Edge.make_circle(2))
-        _ = curve1 - curve2
+        l1 = Curve() + CenterArc((0, 0), 1, 0, 180)
+        l2 = Curve() + CenterArc((0, 0), 1, 0, 90)
+        _ = l1 - l2
 
     def test_dimension_mismatch(self):
         """Test that operations between different dimensional shapes fail"""


### PR DESCRIPTION
This addresses the immediate problem in #752 , and adds a narrow test of the behavior.

It does not address the fact that `Compound`s have `._dim = None`.

----
Update after better understanding the intention of the codebase: `Compound` is not meant to support add/subtract, it's an awkward part of the inheritance hierarchy. So this PR instead raises an informative error if add/subtract are attempted on Compound objects, to save others confusion. 

-----
Update after understanding longer-term roadmap of supporting these operations with `Assembly` objects: `Compound` must support add/subtract, and in case it contains many objects, for performant execution the operation should be consolidated into a single call to OpenCASCADE and not a naive nested for loop over every pair of shape primitives in `self` and `other`.