### PR TITLE
Alignment rework

### DIFF
--- a/src/build123d/build_enums.py
+++ b/src/build123d/build_enums.py
@@ -36,6 +36,7 @@ class Align(Enum):
     MIN = auto()
     CENTER = auto()
     MAX = auto()
+    NONE = None
 
     def __repr__(self):
         return f"<{self.__class__.__name__}.{self.name}>"

--- a/src/build123d/build_enums.py
+++ b/src/build123d/build_enums.py
@@ -27,8 +27,11 @@ license:
 """
 
 from __future__ import annotations
+
 from enum import Enum, auto
-from typing import Union, TypeAlias
+from typing import Union
+
+from typing_extensions import TypeAlias
 
 
 class Align(Enum):

--- a/src/build123d/build_enums.py
+++ b/src/build123d/build_enums.py
@@ -28,6 +28,7 @@ license:
 
 from __future__ import annotations
 from enum import Enum, auto
+from typing import Union, TypeAlias
 
 
 class Align(Enum):
@@ -40,6 +41,17 @@ class Align(Enum):
 
     def __repr__(self):
         return f"<{self.__class__.__name__}.{self.name}>"
+
+
+Align2DType: TypeAlias = Union[
+    Union[Align, None],
+    tuple[Union[Align, None], Union[Align, None]],
+]
+
+Align3DType: TypeAlias = Union[
+    Union[Align, None],
+    tuple[Union[Align, None], Union[Align, None], Union[Align, None]],
+]
 
 
 class ApproxOption(Enum):

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -2530,15 +2530,27 @@ def to_align_offset(
     min_point: Sequence[float],
     max_point: Sequence[float],
     align: Sequence[Align],
+    center: Optional[Sequence[float]] = None,
 ) -> Vector:
     """Amount to move object to achieve the desired alignment"""
     align_offset = []
 
-    for alignment, min_coord, max_coord in zip(align, min_point, max_point):
+    if center is None:
+        center = [
+            (min_coord + max_coord) / 2
+            for min_coord, max_coord in zip(min_point, max_point)
+        ]
+
+    for alignment, min_coord, max_coord, center_coord in zip(
+        align,
+        min_point,
+        max_point,
+        center,
+    ):
         if alignment == Align.MIN:
             align_offset.append(-min_coord)
         elif alignment == Align.CENTER:
-            align_offset.append(-(min_coord + max_coord) / 2)
+            align_offset.append(-center_coord)
         elif alignment == Align.MAX:
             align_offset.append(-max_coord)
         elif alignment == Align.NONE:

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -2541,4 +2541,6 @@ def to_align_offset(
             align_offset.append(-(min_coord + max_coord) / 2)
         elif alignment == Align.MAX:
             align_offset.append(-max_coord)
+        elif alignment == Align.NONE:
+            align_offset.append(0)
     return Vector(*align_offset)

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -2541,11 +2541,11 @@ def to_align_offset(
     if align is None or align is Align.NONE:
         return Vector(0, 0, 0)
     if align is Align.MIN:
-        return Vector(min_point)
+        return -Vector(min_point)
     if align is Align.MAX:
-        return Vector(max_point)
+        return -Vector(max_point)
     if align is Align.CENTER:
-        return Vector(center)
+        return -Vector(center)
 
     for alignment, min_coord, max_coord, center_coord in zip(
         map(Align, align),

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -1019,19 +1019,9 @@ class BoundBox:
             and second_box.max.Z < self.max.Z
         )
 
-    def to_align_offset(self, align: Tuple[Align, Align]) -> List[float]:
+    def to_align_offset(self, align: Sequence[Align]) -> Vector:
         """Amount to move object to achieve the desired alignment"""
-        align_offset = []
-        for i in range(2):
-            if align[i] == Align.MIN:
-                align_offset.append(-self.min.to_tuple()[i])
-            elif align[i] == Align.CENTER:
-                align_offset.append(
-                    -(self.min.to_tuple()[i] + self.max.to_tuple()[i]) / 2
-                )
-            elif align[i] == Align.MAX:
-                align_offset.append(-self.max.to_tuple()[i])
-        return align_offset
+        return to_align_offset(self.min.to_tuple(), self.max.to_tuple(), align)
 
 
 class Color:
@@ -2534,3 +2524,21 @@ class Plane(metaclass=PlaneMeta):
 
         elif shape is not None:
             return shape.intersect(self)
+
+
+def to_align_offset(
+    min_point: Sequence[float],
+    max_point: Sequence[float],
+    align: Sequence[Align],
+) -> Vector:
+    """Amount to move object to achieve the desired alignment"""
+    align_offset = []
+
+    for alignment, min_coord, max_coord in zip(align, min_point, max_point):
+        if alignment == Align.MIN:
+            align_offset.append(-min_coord)
+        elif alignment == Align.CENTER:
+            align_offset.append(-(min_coord + max_coord) / 2)
+        elif alignment == Align.MAX:
+            align_offset.append(-max_coord)
+    return Vector(*align_offset)

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -1019,7 +1019,7 @@ class BoundBox:
             and second_box.max.Z < self.max.Z
         )
 
-    def to_align_offset(self, align: Tuple[float, float]) -> Tuple[float, float]:
+    def to_align_offset(self, align: Tuple[Align, Align]) -> List[float]:
         """Amount to move object to achieve the desired alignment"""
         align_offset = []
         for i in range(2):

--- a/src/build123d/objects_part.py
+++ b/src/build123d/objects_part.py
@@ -63,17 +63,8 @@ class BasePartObject(Part):
         if align is not None:
             align = tuplify(align, 3)
             bbox = part.bounding_box()
-            align_offset = []
-            for i in range(3):
-                if align[i] == Align.MIN:
-                    align_offset.append(-bbox.min.to_tuple()[i])
-                elif align[i] == Align.CENTER:
-                    align_offset.append(
-                        -(bbox.min.to_tuple()[i] + bbox.max.to_tuple()[i]) / 2
-                    )
-                elif align[i] == Align.MAX:
-                    align_offset.append(-bbox.max.to_tuple()[i])
-            part.move(Location(Vector(*align_offset)))
+            offset = bbox.to_align_offset(align)
+            part.move(Location(offset))
 
         context: BuildPart = BuildPart._get_context(self, log=False)
         rotate = Rotation(*rotation) if isinstance(rotation, tuple) else rotation

--- a/src/build123d/objects_sketch.py
+++ b/src/build123d/objects_sketch.py
@@ -36,7 +36,14 @@ from typing import Iterable, Union
 from build123d.build_common import LocationList, flatten_sequence, validate_inputs
 from build123d.build_enums import Align, FontStyle, Mode
 from build123d.build_sketch import BuildSketch
-from build123d.geometry import Axis, Location, Rotation, Vector, VectorLike
+from build123d.geometry import (
+    Axis,
+    Location,
+    Rotation,
+    Vector,
+    VectorLike,
+    to_align_offset,
+)
 from build123d.topology import (
     Compound,
     Edge,
@@ -74,7 +81,7 @@ class BaseSketchObject(Sketch):
     ):
         if align is not None:
             align = tuplify(align, 2)
-            obj.move(Location(Vector(*obj.bounding_box().to_align_offset(align))))
+            obj.move(Location(obj.bounding_box().to_align_offset(align)))
 
         context: BuildSketch = BuildSketch._get_context(self, log=False)
         if context is None:
@@ -346,17 +353,10 @@ class RegularPolygon(BaseSketchObject):
 
         if align is not None:
             align = tuplify(align, 2)
-            align_offset = []
-            for i in range(2):
-                if align[i] == Align.MIN:
-                    align_offset.append(-mins[i])
-                elif align[i] == Align.CENTER:
-                    align_offset.append(0)
-                elif align[i] == Align.MAX:
-                    align_offset.append(-maxs[i])
+            align_offset = to_align_offset(mins, maxs, align)
         else:
-            align_offset = [0, 0]
-        pts = [point + Vector(*align_offset) for point in pts]
+            align_offset = Vector(0, 0)
+        pts = [point + align_offset for point in pts]
 
         face = Face(Wire.make_polygon(pts))
         super().__init__(face, rotation=0, align=None, mode=mode)

--- a/src/build123d/objects_sketch.py
+++ b/src/build123d/objects_sketch.py
@@ -311,7 +311,7 @@ class RegularPolygon(BaseSketchObject):
         side_count: int,
         major_radius: bool = True,
         rotation: float = 0,
-        align: tuple[Align, Align] = (Align.CENTER, Align.CENTER),
+        align: tuple[Align, Align] = (Align.NONE, Align.NONE),
         mode: Mode = Mode.ADD,
     ):
         # pylint: disable=too-many-locals

--- a/src/build123d/objects_sketch.py
+++ b/src/build123d/objects_sketch.py
@@ -311,7 +311,7 @@ class RegularPolygon(BaseSketchObject):
         side_count: int,
         major_radius: bool = True,
         rotation: float = 0,
-        align: tuple[Align, Align] = (Align.NONE, Align.NONE),
+        align: tuple[Align, Align] = (Align.CENTER, Align.CENTER),
         mode: Mode = Mode.ADD,
     ):
         # pylint: disable=too-many-locals
@@ -353,7 +353,7 @@ class RegularPolygon(BaseSketchObject):
 
         if align is not None:
             align = tuplify(align, 2)
-            align_offset = to_align_offset(mins, maxs, align)
+            align_offset = to_align_offset(mins, maxs, align, center=(0, 0))
         else:
             align_offset = Vector(0, 0)
         pts = [point + align_offset for point in pts]

--- a/src/build123d/objects_sketch.py
+++ b/src/build123d/objects_sketch.py
@@ -351,11 +351,7 @@ class RegularPolygon(BaseSketchObject):
         mins = [pts_sorted[0][0].X, pts_sorted[1][0].Y]
         maxs = [pts_sorted[0][-1].X, pts_sorted[1][-1].Y]
 
-        if align is not None:
-            align = tuplify(align, 2)
-            align_offset = to_align_offset(mins, maxs, align, center=(0, 0))
-        else:
-            align_offset = Vector(0, 0)
+        align_offset = to_align_offset(mins, maxs, align, center=(0, 0))
         pts = [point + align_offset for point in pts]
 
         face = Face(Wire.make_polygon(pts))

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -4415,9 +4415,7 @@ class Compound(Mixin3D, Shape):
 
         # Align the text from the bounding box
         align = tuplify(align, 2)
-        text_flat = text_flat.translate(
-            Vector(*text_flat.bounding_box().to_align_offset(align))
-        )
+        text_flat = text_flat.translate(text_flat.bounding_box().to_align_offset(align))
 
         if text_path is not None:
             path_length = text_path.length

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -1,0 +1,79 @@
+import pytest
+
+from build123d.build_enums import Align
+from build123d.geometry import Vector, to_align_offset
+
+
+@pytest.mark.parametrize(
+    "x_align,x_expect",
+    [
+        (Align.MAX, -0.5),
+        (Align.CENTER, 0.25),
+        (Align.MIN, 1),
+        (Align.NONE, 0),
+    ],
+)
+@pytest.mark.parametrize(
+    "y_align,y_expect",
+    [
+        (Align.MAX, -1),
+        (Align.CENTER, 0.25),
+        (Align.MIN, 1.5),
+        (Align.NONE, 0),
+    ],
+)
+@pytest.mark.parametrize(
+    "z_align,z_expect",
+    [
+        (Align.MAX, -1),
+        (Align.CENTER, -0.75),
+        (Align.MIN, -0.5),
+        (Align.NONE, 0),
+    ],
+)
+def test_align(
+    x_align,
+    x_expect,
+    y_align,
+    y_expect,
+    z_align,
+    z_expect,
+):
+    offset = to_align_offset(
+        min_point=(-1, -1.5, 0.5),
+        max_point=(0.5, 1.0, 1.0),
+        align=(x_align, y_align, z_align),
+    )
+    assert offset.X == x_expect
+    assert offset.Y == y_expect
+    assert offset.Z == z_expect
+
+
+@pytest.mark.parametrize("alignment", Align)
+def test_align_single(alignment):
+    min_point = (-1, -1.5, 0.5)
+    max_point = (0.5, 1, 1)
+    expected = to_align_offset(
+        min_point=min_point,
+        max_point=max_point,
+        align=(alignment, alignment, alignment),
+    )
+    offset = to_align_offset(
+        min_point=min_point,
+        max_point=max_point,
+        align=alignment,
+    )
+    assert expected == offset
+
+
+def test_align_center():
+    min_point = (-1, -1.5, 0.5)
+    max_point = (0.5, 1, 1)
+    center = (4, 2, 6)
+    offset = to_align_offset(
+        min_point=min_point,
+        max_point=max_point,
+        center=center,
+        align=Align.CENTER,
+    )
+    assert offset == -Vector(center)

--- a/tests/test_build_sketch.py
+++ b/tests/test_build_sketch.py
@@ -258,7 +258,7 @@ class TestBuildSketchObjects(unittest.TestCase):
         self.assertEqual(r.radius, 2)
         self.assertEqual(r.side_count, 6)
         self.assertEqual(r.rotation, 0)
-        self.assertEqual(r.align, (Align.NONE, Align.NONE))
+        self.assertEqual(r.align, (Align.CENTER, Align.CENTER))
         self.assertEqual(r.mode, Mode.ADD)
         self.assertAlmostEqual(test.sketch.area, (3 * sqrt(3) / 2) * 2**2, 5)
         self.assertTupleAlmostEquals(
@@ -272,7 +272,7 @@ class TestBuildSketchObjects(unittest.TestCase):
         self.assertAlmostEqual(r.radius, 1, 5)
         self.assertEqual(r.side_count, 3)
         self.assertEqual(r.rotation, 0)
-        self.assertEqual(r.align, (Align.NONE, Align.NONE))
+        self.assertEqual(r.align, (Align.CENTER, Align.CENTER))
         self.assertEqual(r.mode, Mode.ADD)
         self.assertAlmostEqual(test.sketch.area, (3 * sqrt(3) / 4) * (0.5 * 2) ** 2, 5)
         self.assertTupleAlmostEquals(

--- a/tests/test_build_sketch.py
+++ b/tests/test_build_sketch.py
@@ -27,7 +27,10 @@ license:
 """
 
 import unittest
-from math import pi, sqrt, atan2, degrees
+from math import atan2, degrees, pi, sqrt
+
+import pytest
+
 from build123d import *
 
 
@@ -278,6 +281,7 @@ class TestBuildSketchObjects(unittest.TestCase):
             test.sketch.faces()[0].normal_at().to_tuple(), (0, 0, 1), 5
         )
 
+    @pytest.mark.skip(reason="Conflicts with test_regular_polygon_matches_polar")
     def test_regular_polygon_align(self):
         with BuildSketch() as align:
             RegularPolygon(2, 5, align=(Align.MIN, Align.MAX))
@@ -293,6 +297,7 @@ class TestBuildSketchObjects(unittest.TestCase):
             Vector(align.vertices().sort_by_distance(other=(0, 0, 0))[-1]).length, 2
         )
 
+    @pytest.mark.skip(reason="Conflicts with test_regular_polygon_align")
     def test_regular_polygon_matches_polar(self):
         for side_count in range(3, 10):
             with BuildSketch():

--- a/tests/test_build_sketch.py
+++ b/tests/test_build_sketch.py
@@ -29,8 +29,6 @@ license:
 import unittest
 from math import atan2, degrees, pi, sqrt
 
-import pytest
-
 from build123d import *
 
 
@@ -260,7 +258,7 @@ class TestBuildSketchObjects(unittest.TestCase):
         self.assertEqual(r.radius, 2)
         self.assertEqual(r.side_count, 6)
         self.assertEqual(r.rotation, 0)
-        self.assertEqual(r.align, (Align.CENTER, Align.CENTER))
+        self.assertEqual(r.align, (Align.NONE, Align.NONE))
         self.assertEqual(r.mode, Mode.ADD)
         self.assertAlmostEqual(test.sketch.area, (3 * sqrt(3) / 2) * 2**2, 5)
         self.assertTupleAlmostEquals(
@@ -274,14 +272,13 @@ class TestBuildSketchObjects(unittest.TestCase):
         self.assertAlmostEqual(r.radius, 1, 5)
         self.assertEqual(r.side_count, 3)
         self.assertEqual(r.rotation, 0)
-        self.assertEqual(r.align, (Align.CENTER, Align.CENTER))
+        self.assertEqual(r.align, (Align.NONE, Align.NONE))
         self.assertEqual(r.mode, Mode.ADD)
         self.assertAlmostEqual(test.sketch.area, (3 * sqrt(3) / 4) * (0.5 * 2) ** 2, 5)
         self.assertTupleAlmostEquals(
             test.sketch.faces()[0].normal_at().to_tuple(), (0, 0, 1), 5
         )
 
-    @pytest.mark.skip(reason="Conflicts with test_regular_polygon_matches_polar")
     def test_regular_polygon_align(self):
         with BuildSketch() as align:
             RegularPolygon(2, 5, align=(Align.MIN, Align.MAX))
@@ -297,7 +294,6 @@ class TestBuildSketchObjects(unittest.TestCase):
             Vector(align.vertices().sort_by_distance(other=(0, 0, 0))[-1]).length, 2
         )
 
-    @pytest.mark.skip(reason="Conflicts with test_regular_polygon_align")
     def test_regular_polygon_matches_polar(self):
         for side_count in range(3, 10):
             with BuildSketch():


### PR DESCRIPTION
While using `build123d` I noticed that the type signature for `BoundBox.to_align_offset` was wrong. While fixing it I noticed that there was a lot of replicated aligning logic. This is an attempt to rectify that.

- add a generic `to_align_offset` function to the `geometry` module to allow for aligning
- add an `Align.NONE` enum member
- change `to_align_offset` to return a `Vector` as every call site immediately constructed a vector anyway

Not sure if there is interest in merging such a pr. If so I can go ahead and make sure the documentation lines up with the changes and make any changes y'all deem appropriate.

Would close:
- #457

Supersedes:
- #734 