### PR TITLE
Path support

### DIFF
--- a/src/build123d/exporters.py
+++ b/src/build123d/exporters.py
@@ -649,7 +649,7 @@ class ExportDXF(Export2D):
         # https://github.com/gumyr/build123d/issues/382 tracks
         # exposing viewport control to the user.
         zoom.extents(self._modelspace)
-        self._document.saveas(file_name)
+        self._document.saveas(fsdecode(file_name))
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 

--- a/src/build123d/exporters.py
+++ b/src/build123d/exporters.py
@@ -32,9 +32,11 @@ license:
 
 import math
 import xml.etree.ElementTree as ET
-from enum import Enum, auto
-from typing import Callable, Iterable, Optional, Union, List, Tuple
 from copy import copy
+from enum import Enum, auto
+from os import PathLike, fsdecode, fspath
+from pathlib import Path
+from typing import Callable, Iterable, List, Optional, Tuple, Union
 
 import ezdxf
 import svgpathtools as PT
@@ -633,13 +635,13 @@ class ExportDXF(Export2D):
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-    def write(self, file_name: str):
+    def write(self, file_name: Union[PathLike, str, bytes]):
         """write
 
         Writes the DXF data to the specified file name.
 
         Args:
-            file_name (str): The file name (including path) where the DXF data will
+            file_name (Union[PathLike, str, bytes]): The file name (including path) where the DXF data will
                 be written.
         """
         # Reset the main CAD viewport of the model space to the
@@ -647,7 +649,6 @@ class ExportDXF(Export2D):
         # https://github.com/gumyr/build123d/issues/382 tracks
         # exposing viewport control to the user.
         zoom.extents(self._modelspace)
-
         self._document.saveas(file_name)
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -877,7 +878,7 @@ class ExportSVG(Export2D):
             line_type: LineType,
         ):
             def convert_color(
-                c: Union[ColorIndex, RGB, Color, None]
+                c: Union[ColorIndex, RGB, Color, None],
             ) -> Union[Color, None]:
                 if isinstance(c, ColorIndex):
                     # The easydxf color indices BLACK and WHITE have the same
@@ -1390,7 +1391,6 @@ class ExportSVG(Export2D):
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     def _group_for_layer(self, layer: _Layer, attribs: dict = None) -> ET.Element:
-
         def _color_attribs(c: Color) -> Tuple[str, str]:
             if c:
                 (r, g, b, a) = tuple(c)
@@ -1428,13 +1428,13 @@ class ExportSVG(Export2D):
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-    def write(self, path: str):
+    def write(self, path: Union[PathLike, str, bytes]):
         """write
 
         Writes the SVG data to the specified file path.
 
         Args:
-            path (str): The file path where the SVG data will be written.
+            path (Union[PathLike, str, bytes]): The file path where the SVG data will be written.
         """
         # pylint: disable=too-many-locals
         bb = self._bounds

--- a/src/build123d/exporters3d.py
+++ b/src/build123d/exporters3d.py
@@ -29,6 +29,7 @@ license:
 # pylint has trouble with the OCP imports
 # pylint: disable=no-name-in-module, import-error
 
+from io import BytesIO
 import warnings
 from os import PathLike, fsdecode, fspath
 from typing import Union
@@ -155,18 +156,21 @@ def _create_xde(to_export: Shape, unit: Unit = Unit.MM) -> TDocStd_Document:
 
 def export_brep(
     to_export: Shape,
-    file_path: Union[PathLike, str, bytes],
+    file_path: Union[PathLike, str, bytes, BytesIO],
 ) -> bool:
     """Export this shape to a BREP file
 
     Args:
         to_export (Shape): object or assembly
-        file_path: Union[PathLike, str, bytes]: brep file path or memory buffer
+        file_path: Union[PathLike, str, bytes, BytesIO]: brep file path or memory buffer
 
     Returns:
         bool: write status
     """
-    return_value = BRepTools.Write_s(to_export.wrapped, fsdecode(file_path))
+    if not isinstance(file_path, BytesIO):
+        file_path = fsdecode(file_path)
+
+    return_value = BRepTools.Write_s(to_export.wrapped, file_path)
 
     return True if return_value is None else return_value
 

--- a/src/build123d/mesher.py
+++ b/src/build123d/mesher.py
@@ -88,8 +88,10 @@ import os
 import sys
 import uuid
 import warnings
+from os import PathLike, fsdecode
 from typing import Iterable, Union
 
+import OCP.TopAbs as ta
 from OCP.BRep import BRep_Tool
 from OCP.BRepBuilderAPI import (
     BRepBuilderAPI_MakeFace,
@@ -100,16 +102,15 @@ from OCP.BRepBuilderAPI import (
 from OCP.BRepGProp import BRepGProp
 from OCP.BRepMesh import BRepMesh_IncrementalMesh
 from OCP.gp import gp_Pnt
-import OCP.TopAbs as ta
 from OCP.GProp import GProp_GProps
 from OCP.TopAbs import TopAbs_ShapeEnum
 from OCP.TopExp import TopExp_Explorer
-from OCP.TopoDS import TopoDS_Compound
 from OCP.TopLoc import TopLoc_Location
-
+from OCP.TopoDS import TopoDS_Compound
 from py_lib3mf import Lib3MF
+
 from build123d.build_enums import MeshType, Unit
-from build123d.geometry import Color, TOLERANCE
+from build123d.geometry import TOLERANCE, Color
 from build123d.topology import Compound, Shape, Shell, Solid, downcast
 
 
@@ -482,11 +483,11 @@ class Mesher:
 
         return shape_obj
 
-    def read(self, file_name: str) -> list[Shape]:
+    def read(self, file_name: Union[PathLike, str, bytes]) -> list[Shape]:
         """read
 
         Args:
-            file_name (str): file path
+            file_name Union[PathLike, str, bytes]: file path
 
         Raises:
             ValueError: Unknown file format - must be 3mf or stl
@@ -494,10 +495,11 @@ class Mesher:
         Returns:
             list[Shape]: build123d shapes extracted from mesh file
         """
-        input_file_format = file_name.split(".")[-1].lower()
-        if input_file_format not in ["3mf", "stl"]:
-            raise ValueError(f"Unknown file format {input_file_format}")
-        reader = self.model.QueryReader(input_file_format)
+        file_name = fsdecode(file_name)
+        _, input_file_extension = os.path.splitext(file_name)
+        if input_file_extension not in [".3mf", ".stl"]:
+            raise ValueError(f"Unknown file format {input_file_extension}")
+        reader = self.model.QueryReader(input_file_extension[1:])
         reader.ReadFromFile(file_name)
         self.unit = Mesher._map_3mf_to_b3d_unit[self.model.GetUnit()]
 
@@ -525,17 +527,18 @@ class Mesher:
 
         return shapes
 
-    def write(self, file_name: str):
+    def write(self, file_name: Union[PathLike, str, bytes]):
         """write
 
         Args:
-            file_name (str): file path
+            file_name Union[Pathlike, str, bytes]: file path
 
         Raises:
             ValueError: Unknown file format - must be 3mf or stl
         """
-        output_file_format = file_name.split(".")[-1].lower()
-        if output_file_format not in ["3mf", "stl"]:
-            raise ValueError(f"Unknown file format {output_file_format}")
-        writer = self.model.QueryWriter(output_file_format)
+        file_name = fsdecode(file_name)
+        _, output_file_extension = os.path.splitext(file_name)
+        if output_file_extension not in [".3mf", ".stl"]:
+            raise ValueError(f"Unknown file format {output_file_extension}")
+        writer = self.model.QueryWriter(output_file_extension[1:])
         writer.WriteToFile(file_name)

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -1,6 +1,11 @@
-import unittest
-import math
+from os import fsdecode, fsencode
 from typing import Union, Iterable
+import math
+from pathlib import Path
+import unittest
+
+import pytest
+
 from build123d import (
     Color,
     Mode,
@@ -167,6 +172,19 @@ class ExportersTestCase(unittest.TestCase):
         )
         svg.add_shape(sketch)
         svg.write("test-colors.svg")
+
+
+@pytest.mark.parametrize(
+    "format", (Path, fsencode, fsdecode), ids=["path", "bytes", "str"]
+)
+@pytest.mark.parametrize("Exporter", (ExportSVG, ExportDXF))
+def test_pathlike_exporters(tmp_path, format, Exporter):
+    path = format(tmp_path / "file")
+    sketch = ExportersTestCase.create_test_sketch()
+    exporter = Exporter()
+    exporter.add_shape(sketch)
+    exporter.write(path)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_exporters3d.py
+++ b/tests/test_exporters3d.py
@@ -30,12 +30,15 @@ import os
 import re
 import unittest
 from typing import Optional
+from pathlib import Path
+
+import pytest
 
 from build123d.build_common import GridLocations
 from build123d.build_enums import Unit
 from build123d.build_line import BuildLine
 from build123d.build_sketch import BuildSketch
-from build123d.exporters3d import export_gltf, export_step
+from build123d.exporters3d import export_gltf, export_step, export_brep, export_stl
 from build123d.geometry import Color, Pos, Vector, VectorLike
 from build123d.objects_curve import Line
 from build123d.objects_part import Box, Sphere
@@ -163,6 +166,18 @@ class TestExportGltf(DirectApiTestCase):
     #     os.chmod("box.gltf", 0o777)  # Make the file read/write
     #     os.remove("box.gltf")
     #     os.remove("box.bin")
+
+
+@pytest.mark.parametrize(
+    "format", (Path, os.fsencode, os.fsdecode), ids=["path", "bytes", "str"]
+)
+@pytest.mark.parametrize(
+    "exporter", (export_gltf, export_stl, export_step, export_brep)
+)
+def test_pathlike_exporters(tmp_path, format, exporter):
+    path = format(tmp_path / "file")
+    box = Box(1, 1, 1).locate(Pos(-1, -2, -3))
+    exporter(box, path)
 
 
 if __name__ == "__main__":

--- a/tests/test_exporters3d.py
+++ b/tests/test_exporters3d.py
@@ -66,7 +66,6 @@ class DirectApiTestCase(unittest.TestCase):
 
 
 class TestExportStep(DirectApiTestCase):
-
     def test_export_step_solid(self):
         b = Box(1, 1, 1).locate(Pos(-1, -2, -3))
         self.assertTrue(export_step(b, "box.step"))

--- a/tests/test_exporters3d.py
+++ b/tests/test_exporters3d.py
@@ -25,6 +25,7 @@ license:
 
 """
 
+import io
 import json
 import os
 import re
@@ -178,6 +179,12 @@ def test_pathlike_exporters(tmp_path, format, exporter):
     path = format(tmp_path / "file")
     box = Box(1, 1, 1).locate(Pos(-1, -2, -3))
     exporter(box, path)
+
+
+def test_export_brep_in_memory():
+    buffer = io.BytesIO()
+    box = Box(1, 1, 1).locate(Pos(-1, -2, -3))
+    export_brep(box, buffer)
 
 
 if __name__ == "__main__":

--- a/tests/test_mesher.py
+++ b/tests/test_mesher.py
@@ -1,5 +1,10 @@
 import unittest, uuid
 from packaging.specifiers import SpecifierSet
+from pathlib import Path
+from os import fsdecode, fsencode
+
+import pytest
+
 from build123d.build_enums import MeshType, Unit
 from build123d.build_part import BuildPart
 from build123d.build_sketch import BuildSketch
@@ -204,6 +209,17 @@ class TestImportDegenerateTriangles(unittest.TestCase):
         self.assertTrue(stl.is_manifold)
         self.assertTrue(stl.is_valid())
         self.assertEqual(sum(f.area == 0 for f in stl.faces()), 0)
+
+
+@pytest.mark.parametrize(
+    "format", (Path, fsencode, fsdecode), ids=["path", "bytes", "str"]
+)
+def test_pathlike_mesher(tmp_path, format):
+    path = format(tmp_path / "test.3mf")
+    exporter, importer = Mesher(), Mesher()
+    exporter.add_shape(Solid.make_box(1, 1, 1))
+    exporter.write(path)
+    importer.read(path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For all import / export methods make the path a `Union[Pathlike, str, bytes]` argument to follow python conventions as outlined in [pep 519](https://peps.python.org/pep-0519/).

closes: https://github.com/gumyr/build123d/issues/685
closes: https://github.com/gumyr/build123d/issues/774

~~I got carried away big time and this PR is probably unreasonably large. To test the new functionality I changed all the tests to feed in `pathlib.Paths`. In addition any tests which wrote to disk were rewritten to use the pytest `tmp_path` fixture. Which then caused me to rewrite the tests in the pytest style...~~

~~I can revert the test changes and be less invasive with my changes if desired.~~

Edit: I decided to roll those back. I think they're good changes in the long run but they get in the way of reviewing the pr at hand.

Open questions:
- should the deprecated export methods in `topology.py` also be moved over to this scheme? Technically that is what #685 is requesting
- ~~should the tests attempt to verify that all three types: string, paths, and bytes work?~~ I added said tests 
- did I miss any exporting/importing methods