### PR TITLE
Slots error if width <= height

### DIFF
--- a/src/build123d/objects_sketch.py
+++ b/src/build123d/objects_sketch.py
@@ -425,6 +425,13 @@ class SlotCenterPoint(BaseSketchObject):
         self.slot_height = height
 
         half_line = point_v - center_v
+
+        if half_line.length * 2 <= height:
+            raise ValueError(
+                f"Slots must have width > height. "
+                "Got: {height=} width={half_line.length * 2} (computed)"
+            )
+
         face = Face(
             Wire.combine(
                 [

--- a/src/build123d/objects_sketch.py
+++ b/src/build123d/objects_sketch.py
@@ -499,6 +499,11 @@ class SlotOverall(BaseSketchObject):
         align: Union[Align, tuple[Align, Align]] = (Align.CENTER, Align.CENTER),
         mode: Mode = Mode.ADD,
     ):
+        if width <= height:
+            raise ValueError(
+                f"Slot requires that width > height. Got: {width=}, {height=}"
+            )
+
         context = BuildSketch._get_context(self)
         validate_inputs(context, self)
 

--- a/src/build123d/objects_sketch.py
+++ b/src/build123d/objects_sketch.py
@@ -458,6 +458,11 @@ class SlotCenterToCenter(BaseSketchObject):
         rotation: float = 0,
         mode: Mode = Mode.ADD,
     ):
+        if center_separation <= 0:
+            raise ValueError(
+                f"Requires center_separation > 0. Got: {center_separation=}"
+            )
+
         context = BuildSketch._get_context(self)
         validate_inputs(context, self)
 

--- a/tests/test_build_sketch.py
+++ b/tests/test_build_sketch.py
@@ -29,6 +29,8 @@ license:
 import unittest
 from math import atan2, degrees, pi, sqrt
 
+import pytest
+
 from build123d import *
 
 
@@ -507,6 +509,19 @@ class TestBuildSketchObjects(unittest.TestCase):
         self.assertLess(negative.area, positive.area)
         self.assertAlmostEqual(r1, r2, 2)
         self.assertTupleAlmostEquals(tuple(c1), tuple(c2), 2)
+
+
+@pytest.mark.parametrize(
+    "slot,args",
+    [
+        (SlotOverall, (5, 10)),
+        (SlotCenterToCenter, (-1, 10)),
+        (SlotCenterPoint, ((0, 0, 0), (2, 0, 0), 10)),
+    ],
+)
+def test_invalid_slots(slot, args):
+    with pytest.raises(ValueError):
+        slot(*args)
 
 
 if __name__ == "__main__":

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -8,10 +8,8 @@ date: November 9th 2023
 desc: Unit tests for the build123d pack module
 """
 
-import operator
 import random
 import unittest
-from functools import reduce
 
 from build123d import *
 
@@ -53,15 +51,14 @@ class TestPack(unittest.TestCase):
         random.seed(123456)
         # 50 is an arbitrary number that is large enough to exercise
         # different aspects of the packer while still completing quickly.
-        inputs = [
-            SlotOverall(random.randint(1, 20), random.randint(1, 20)) for _ in range(50)
-        ]
+        widths = [random.randint(2, 20) for _ in range(50)]
+        heights = [random.randint(1, width - 1) for width in widths]
+        inputs = [SlotOverall(width, height) for width, height in zip(widths, heights)]
         # Not raising in this call shows successfull non-overlap.
         packed = pack(inputs, 1)
-        self.assertEqual(
-            "bbox: 0.0 <= x <= 124.0, 0.0 <= y <= 105.0, 0.0 <= z <= 0.0",
-            str((Sketch() + packed).bounding_box()),
-        )
+        bb = (Sketch() + packed).bounding_box()
+        self.assertEqual(bb.min, Vector(0, 0, 0))
+        self.assertEqual(bb.max, Vector(70, 63, 0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
It is invalid to try and construct a slot whose width <= height. This PR adds checks for this in `SlotOverall`, `SlotCenterToCenter`, and `SlotCenterPoint`. `SlotArc` is omitted for now as I believe the only error condition would be an empty arc. 

Closes: #73 
Closes: #415