### PR TITLE
Drop support for python 3.9

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -8,7 +8,8 @@ jobs:
       matrix:
         python-version: [
           "3.10",
-          "3.11"
+          # "3.11",
+          "3.12"
           ]
 
     runs-on: ubuntu-latest

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -7,9 +7,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [
-          "3.9",
           "3.10",
-          #"3.11"
+          "3.11"
           ]
 
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
         run: |
           pwd
           ls -lR
+          python3 -V
           python3 -m pip install --upgrade pip
           python3 -m pip -V
           python3 -m pip install build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [
-          "3.9",
           "3.10",
-          #"3.11"
+          "3.11"
           ]
         os: [macos-13, ubuntu-latest, windows-latest]
 
@@ -29,7 +28,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [
-          #"3.9",
           "3.10",
           #"3.11"
           ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,8 @@ jobs:
       matrix:
         python-version: [
           "3.10",
-          "3.11"
+          # "3.11",
+          "3.12",
           ]
         os: [macos-13, ubuntu-latest, windows-latest]
 
@@ -29,7 +30,8 @@ jobs:
       matrix:
         python-version: [
           "3.10",
-          #"3.11"
+          #"3.11",
+          #"3.12"
           ]
         os: [macos-14]
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ formats:
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.9"
+    python: "3.10"
   apt_packages:
     - graphviz
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
 ]
 description = "A python CAD programming library"
 readme = "README.md"
-requires-python = ">= 3.9, < 3.13"
+requires-python = ">= 3.10, < 3.13"
 keywords = [
     "3d models",
     "3d printing",
@@ -61,5 +61,5 @@ exclude = ["build123d._dev"]
 write_to = "src/build123d/_version.py"
 
 [tool.black]
-target-version = ["py39", "py310", "py311", "py312"]
+target-version = ["py310", "py311", "py312"]
 line-length = 88


### PR DESCRIPTION
This PR drops support for python 3.9 in all places I am aware of (CI / pyproject.toml). Please merge when ready.