### PR TITLE
Update docs to remove obsolete advice for Apple Silicon installation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ cd build123d
 python3 -m pip install -e .
 ```
 
-Further installation instructions are available (e.g. Poetry, Apple Silicon) see the [installation section on readthedocs](https://build123d.readthedocs.io/en/latest/installation.html).
+Further installation instructions are available (e.g. Poetry) see the [installation section on readthedocs](https://build123d.readthedocs.io/en/latest/installation.html).

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -2,7 +2,7 @@
 Installation
 ############
 
-The recommended method for most users is to install **build123d** is:
+The recommended method for most users to install **build123d** is:
 
 .. doctest::
 
@@ -109,35 +109,6 @@ Which should return something similar to:
 			├── Face at 0x165e8821570, Center(0.5, 2.0, 1.5)
 			├── Face at 0x165e88218f0, Center(0.5, 1.0, 0.0)
 			└── Face at 0x165eb21ee70, Center(0.5, 1.0, 3.0)
-
-Special notes on Apple Silicon installs
-----------------------------------------------
-
-Due to some dependencies not being available via pip, there is a bit of a hacky work around for Apple Silicon installs (M1 or M2 ARM64 architecture machines - if you aren't sure, try `uname -p` in a terminal and see if it returns arm).  Specifically the cadquery-ocp dependency fails to resolve at install time.  The error looks something like this:
-
-.. doctest::
-
-	└[~]> python3 -m pip install build123d
-	Collecting build123d
-	...
-	INFO: pip is looking at multiple versions of build123d to determine which version is compatible with other requirements. This could take a while.
-	ERROR: Could not find a version that satisfies the requirement cadquery-ocp~=7.7.1 (from build123d) (from versions: none)
-	ERROR: No matching distribution found for cadquery-ocp~=7.7.1
-
-A procedure for avoiding this issue is to install in a conda environment, which does have the missing dependency (substituting <YOUR ENVIRONMENT NAME> for the environment name you want to use for this install):
-
-.. doctest::
-
-	conda create -n <YOUR ENVIRONMENT NAME> python=3.10
-	conda activate <YOUR ENVIRONMENT NAME>
-	conda install -c cadquery -c conda-forge cadquery=master
-	pip install svgwrite svgpathtools anytree scipy ipython trianglesolver \
-	    ocp_tessellate webcolors==1.12 "numpy>=2,<3" cachetools==5.2.0 \
-	    ocp_vscode requests orjson urllib3 certifi py-lib3mf \
-	    "svgpathtools>=1.5.1,<2" "svgelements>=1.9.1,<2" "ezdxf>=1.1.0,<2"
-	pip install --no-deps build123d ocpsvg
-
-`You can track the issue here <https://github.com/CadQuery/ocp-build-system/issues/11#issuecomment-1407769681>`_
 
 Adding a nicer GUI
 ----------------------------------------------


### PR DESCRIPTION
Earlier today cadquery-ocp released packages on PyPI for macos-arm64 for cadquery-ocp==7.7.2 for python versions 3.9 through 3.12.

This PR closes https://github.com/gumyr/build123d/issues/646 and closes https://github.com/gumyr/build123d/issues/439 and fixes the docs to remove the obsolete Apple Silicon workaround installation instructions.