### PR TITLE
Refactored topology.py ready to split into multiple modules

### DIFF
--- a/docs/direct_api_reference.rst
+++ b/docs/direct_api_reference.rst
@@ -84,18 +84,6 @@ Import/Export
 *************
 Methods and functions specific to exporting and importing build123d objects are defined below.
 
-.. py:module:: topology
-   :noindex:
-
-.. automethod:: Shape.export_brep
-   :noindex:
-.. automethod:: Shape.export_stl
-   :noindex:
-.. automethod:: Shape.export_step
-   :noindex:
-.. automethod:: Shape.export_stl
-   :noindex:
-
 .. py:module:: importers
    :noindex:
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,9 @@
 # Global options:
 
 [mypy]
-no_implicit_optional=False
+
+[mypy-OCP.*]
+ignore_missing_imports = True
 
 [mypy-anytree.*]
 ignore_missing_imports = True
@@ -12,3 +14,11 @@ ignore_missing_imports = True
 [mypy-vtkmodules.*]
 ignore_missing_imports = True
 
+[mypy-build123d.topology.jupyter_tools.*]
+ignore_missing_imports = True
+
+[mypy-IPython.lib.pretty.*]
+ignore_missing_imports = True
+
+[mypy-svgpathtools.*]
+ignore_missing_imports = True

--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -429,23 +429,30 @@ class Builder(ABC):
                 if mode == Mode.ADD:
                     if self._obj is None:
                         if len(typed[self._shape]) == 1:
-                            self._obj = typed[self._shape][0]
+                            combined = typed[self._shape][0]
                         else:
-                            self._obj = (
+                            combined = (
                                 typed[self._shape].pop().fuse(*typed[self._shape])
                             )
                     else:
-                        self._obj = self._obj.fuse(*typed[self._shape])
+                        combined = self._obj.fuse(*typed[self._shape])
                 elif mode == Mode.SUBTRACT:
                     if self._obj is None:
                         raise RuntimeError("Nothing to subtract from")
-                    self._obj = self._obj.cut(*typed[self._shape])
+                    combined = self._obj.cut(*typed[self._shape])
                 elif mode == Mode.INTERSECT:
                     if self._obj is None:
                         raise RuntimeError("Nothing to intersect with")
-                    self._obj = self._obj.intersect(*typed[self._shape])
+                    combined = self._obj.intersect(*typed[self._shape])
                 elif mode == Mode.REPLACE:
-                    self._obj = Compound(list(typed[self._shape]))
+                    combined = self._sub_class(list(typed[self._shape]))
+
+                # If the boolean operation created a list, convert back
+                self._obj = (
+                    self._sub_class(combined)
+                    if isinstance(combined, list)
+                    else combined
+                )
 
                 if self._obj is not None and clean:
                     self._obj = self._obj.clean()

--- a/src/build123d/drafting.py
+++ b/src/build123d/drafting.py
@@ -439,23 +439,25 @@ class DimensionLine(BaseSketchObject):
         overage = shaft_length + draft.pad_around_text + label_length / 2
         label_u_values = [0.5, -overage / path_length, 1 + overage / path_length]
 
-        # d_lines = Sketch(children=arrows[0])
         d_lines = {}
-        # for arrow_pair in arrow_shapes:
         for u_value in label_u_values:
-            d_line = Sketch()
-            for add_arrow, arrow_shape in zip(arrows, arrow_shapes):
-                if add_arrow:
-                    d_line += arrow_shape
+            select_arrow_shapes = [
+                arrow_shape
+                for add_arrow, arrow_shape in zip(arrows, arrow_shapes)
+                if add_arrow
+            ]
+            d_line = Sketch(select_arrow_shapes)
             flip_label = path_obj.tangent_at(u_value).get_angle(Vector(1, 0, 0)) >= 180
             loc = Draft._sketch_location(path_obj, u_value, flip_label)
             placed_label = label_shape.located(loc)
-            self_intersection = d_line.intersect(placed_label).area
+            self_intersection = Sketch.intersect(d_line, placed_label).area
             d_line += placed_label
             bbox_size = d_line.bounding_box().size
 
             # Minimize size while avoiding intersections
-            common_area = 0.0 if sketch is None else d_line.intersect(sketch).area
+            common_area = (
+                0.0 if sketch is None else Sketch.intersect(d_line, sketch).area
+            )
             common_area += self_intersection
             score = (d_line.area - 10 * common_area) / bbox_size.X
             d_lines[d_line] = score

--- a/src/build123d/drafting.py
+++ b/src/build123d/drafting.py
@@ -50,7 +50,7 @@ from build123d.objects_curve import Line, TangentArc
 from build123d.objects_sketch import BaseSketchObject, Polygon, Text
 from build123d.operations_generic import fillet, mirror, sweep
 from build123d.operations_sketch import make_face, trace
-from build123d.topology import Compound, Edge, Sketch, Vertex, Wire
+from build123d.topology import Compound, Curve, Edge, Sketch, Vertex, Wire
 
 
 class ArrowHead(BaseSketchObject):
@@ -704,7 +704,10 @@ class TechnicalDrawing(BaseSketchObject):
         )
         bf_pnt3 = box_frame_curve.edges().sort_by(Axis.X)[0] @ (1 / 3)
         bf_pnt4 = box_frame_curve.edges().sort_by(Axis.X)[0] @ (2 / 3)
-        box_frame_curve += Edge.make_line(bf_pnt3, (bf_pnt2.X, bf_pnt3.Y))
+        box_frame_curve = Curve() + [
+            box_frame_curve,
+            Edge.make_line(bf_pnt3, (bf_pnt2.X, bf_pnt3.Y)),
+        ]
         box_frame_curve += Edge.make_line(bf_pnt4, (bf_pnt2.X, bf_pnt4.Y))
         bf_pnt5 = box_frame_curve.edges().sort_by(Axis.Y)[-1] @ (1 / 3)
         bf_pnt6 = box_frame_curve.edges().sort_by(Axis.Y)[-1] @ (2 / 3)

--- a/src/build123d/exporters.py
+++ b/src/build123d/exporters.py
@@ -55,17 +55,14 @@ from OCP.TopAbs import TopAbs_Orientation, TopAbs_ShapeEnum  # type: ignore
 from OCP.TopExp import TopExp_Explorer  # type: ignore
 from typing_extensions import Self
 
-from build123d.build_enums import Unit
-from build123d.geometry import TOLERANCE, Color
+from build123d.build_enums import Unit, GeomType
+from build123d.geometry import TOLERANCE, Color, Vector, VectorLike
 from build123d.topology import (
     BoundBox,
     Compound,
     Edge,
     Wire,
-    GeomType,
     Shape,
-    Vector,
-    VectorLike,
 )
 from build123d.build_common import UNITS_PER_METER
 
@@ -682,7 +679,7 @@ class ExportDXF(Export2D):
 
     def _convert_circle(self, edge: Edge, attribs: dict):
         """Converts a Circle object into a DXF circle entity."""
-        curve = edge._geom_adaptor()
+        curve = edge.geom_adaptor()
         circle = curve.Circle()
         center = self._convert_point(circle.Location())
         radius = circle.Radius()
@@ -710,7 +707,7 @@ class ExportDXF(Export2D):
 
     def _convert_ellipse(self, edge: Edge, attribs: dict):
         """Converts an Ellipse object into a DXF ellipse entity."""
-        geom = edge._geom_adaptor()
+        geom = edge.geom_adaptor()
         ellipse = geom.Ellipse()
         minor_radius = ellipse.MinorRadius()
         major_radius = ellipse.MajorRadius()
@@ -743,7 +740,7 @@ class ExportDXF(Export2D):
 
         # This pulls the underlying Geom_BSplineCurve out of the Edge.
         # The adaptor also supplies a parameter range for the curve.
-        adaptor = edge._geom_adaptor()
+        adaptor = edge.geom_adaptor()
         curve = adaptor.Curve().Curve()
         u1 = adaptor.FirstParameter()
         u2 = adaptor.LastParameter()
@@ -1157,7 +1154,7 @@ class ExportSVG(Export2D):
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     def _line_segment(self, edge: Edge, reverse: bool) -> PT.Line:
-        curve = edge._geom_adaptor()
+        curve = edge.geom_adaptor()
         fp = curve.FirstParameter()
         lp = curve.LastParameter()
         (u0, u1) = (lp, fp) if reverse else (fp, lp)
@@ -1187,7 +1184,7 @@ class ExportSVG(Export2D):
 
     def _circle_segments(self, edge: Edge, reverse: bool) -> list[PathSegment]:
         # pylint: disable=too-many-locals
-        curve = edge._geom_adaptor()
+        curve = edge.geom_adaptor()
         circle = curve.Circle()
         radius = circle.Radius()
         x_axis = circle.XAxis().Direction()
@@ -1215,7 +1212,7 @@ class ExportSVG(Export2D):
     def _circle_element(self, edge: Edge) -> ET.Element:
         """Converts a Circle object into an SVG circle element."""
         if edge.is_closed:
-            curve = edge._geom_adaptor()
+            curve = edge.geom_adaptor()
             circle = curve.Circle()
             radius = circle.Radius()
             center = circle.Location()
@@ -1233,7 +1230,7 @@ class ExportSVG(Export2D):
 
     def _ellipse_segments(self, edge: Edge, reverse: bool) -> list[PathSegment]:
         # pylint: disable=too-many-locals
-        curve = edge._geom_adaptor()
+        curve = edge.geom_adaptor()
         ellipse = curve.Ellipse()
         minor_radius = ellipse.MinorRadius()
         major_radius = ellipse.MajorRadius()
@@ -1276,7 +1273,7 @@ class ExportSVG(Export2D):
 
         # This pulls the underlying Geom_BSplineCurve out of the Edge.
         # The adaptor also supplies a parameter range for the curve.
-        adaptor = edge._geom_adaptor()
+        adaptor = edge.geom_adaptor()
         spline = adaptor.Curve().Curve()
         u1 = adaptor.FirstParameter()
         u2 = adaptor.LastParameter()

--- a/src/build123d/exporters.py
+++ b/src/build123d/exporters.py
@@ -53,6 +53,7 @@ from OCP.HLRAlgo import HLRAlgo_Projector  # type: ignore
 from OCP.HLRBRep import HLRBRep_Algo, HLRBRep_HLRToShape  # type: ignore
 from OCP.TopAbs import TopAbs_Orientation, TopAbs_ShapeEnum  # type: ignore
 from OCP.TopExp import TopExp_Explorer  # type: ignore
+from OCP.TopoDS import TopoDS
 from typing_extensions import Self
 
 from build123d.build_enums import Unit, GeomType
@@ -1060,7 +1061,7 @@ class ExportSVG(Export2D):
         )
         while explorer.More():
             topo_wire = explorer.Current()
-            loose_wires.append(Wire(topo_wire))
+            loose_wires.append(Wire(TopoDS.Wire_s(topo_wire)))
             explorer.Next()
         # print(f"{len(loose_wires)} loose wires")
         for wire in loose_wires:
@@ -1097,12 +1098,13 @@ class ExportSVG(Export2D):
 
     @staticmethod
     def _wire_edges(wire: Wire, reverse: bool) -> List[Edge]:
-        edges = []
-        explorer = BRepTools_WireExplorer(wire.wrapped)
-        while explorer.More():
-            topo_edge = explorer.Current()
-            edges.append(Edge(topo_edge))
-            explorer.Next()
+        # edges = []
+        # explorer = BRepTools_WireExplorer(wire.wrapped)
+        # while explorer.More():
+        #     topo_edge = explorer.Current()
+        #     edges.append(Edge(topo_edge))
+        #     explorer.Next()
+        edges = wire.edges()
         if reverse:
             edges.reverse()
         return edges

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -450,7 +450,7 @@ class Vector:
 
     def __hash__(self) -> int:
         """Hash of Vector"""
-        return hash(self.X) + hash(self.Y) + hash(self.Z)
+        return hash(round(self.X, 6)) + hash(round(self.Y, 6)) + hash(round(self.Z, 6))
 
     def __copy__(self) -> Vector:
         """Return copy of self"""

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -861,8 +861,12 @@ class BoundBox:
     """A BoundingBox for a Shape"""
 
     def __init__(self, bounding_box: Bnd_Box) -> None:
-        self.wrapped: Bnd_Box = bounding_box
-        x_min, y_min, z_min, x_max, y_max, z_max = bounding_box.Get()
+        if bounding_box.IsVoid():
+            self.wrapped = None
+            x_min, y_min, z_min, x_max, y_max, z_max = (0,) * 6
+        else:
+            self.wrapped: Bnd_Box = bounding_box
+            x_min, y_min, z_min, x_max, y_max, z_max = bounding_box.Get()
         self.min = Vector(x_min, y_min, z_min)  #: location of minimum corner
         self.max = Vector(x_max, y_max, z_max)  #: location of maximum corner
         self.size = Vector(x_max - x_min, y_max - y_min, z_max - z_min)  #: overall size
@@ -870,6 +874,8 @@ class BoundBox:
     @property
     def diagonal(self) -> float:
         """body diagonal length (i.e. object maximum size)"""
+        if self.wrapped is None:
+            return 0.0
         return self.wrapped.SquareExtent() ** 0.5
 
     def __repr__(self):
@@ -914,13 +920,14 @@ class BoundBox:
 
         tmp = Bnd_Box()
         tmp.SetGap(tol)
-        tmp.Add(self.wrapped)
+        if self.wrapped is not None:
+            tmp.Add(self.wrapped)
 
         if isinstance(obj, tuple):
             tmp.Update(*obj)
         elif isinstance(obj, Vector):
             tmp.Update(*obj.to_tuple())
-        elif isinstance(obj, BoundBox):
+        elif isinstance(obj, BoundBox) and obj.wrapped is not None:
             tmp.Add(obj.wrapped)
 
         return BoundBox(tmp)

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -963,7 +963,7 @@ class BoundBox:
         return result
 
     @classmethod
-    def _from_topo_ds(
+    def from_topo_ds(
         cls,
         shape: TopoDS_Shape,
         tolerance: float = None,

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -450,7 +450,7 @@ class Vector:
 
     def __hash__(self) -> int:
         """Hash of Vector"""
-        return hash(round(self.X, 6)) + hash(round(self.Y, 6)) + hash(round(self.Z, 6))
+        return hash((round(self.X, 6), round(self.Y, 6), round(self.Z, 6)))
 
     def __copy__(self) -> Vector:
         """Return copy of self"""

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -542,7 +542,7 @@ class Vector:
 
 #:TypeVar("VectorLike"): Tuple of float or Vector defining a position in space
 VectorLike = Union[
-    Vector, tuple[float, float], tuple[float, float, float], Iterable[float]
+    Vector, tuple[float, float], tuple[float, float, float], Sequence[float]
 ]
 
 

--- a/src/build123d/importers.py
+++ b/src/build123d/importers.py
@@ -113,7 +113,7 @@ def import_brep(file_name: Union[PathLike, str, bytes]) -> Shape:
     if shape.IsNull():
         raise ValueError(f"Could not import {file_name}")
 
-    return Shape.cast(shape)
+    return Compound.cast(shape)
 
 
 def import_step(filename: Union[PathLike, str, bytes]) -> Compound:

--- a/src/build123d/objects_sketch.py
+++ b/src/build123d/objects_sketch.py
@@ -43,6 +43,7 @@ from build123d.geometry import (
     Vector,
     VectorLike,
     to_align_offset,
+    TOLERANCE,
 )
 from build123d.topology import (
     Compound,
@@ -52,7 +53,6 @@ from build123d.topology import (
     Sketch,
     Wire,
     tuplify,
-    TOLERANCE,
     topo_explore_common_vertex,
 )
 

--- a/src/build123d/operations_generic.py
+++ b/src/build123d/operations_generic.py
@@ -904,7 +904,7 @@ SplitType = Union[Edge, Wire, Face, Solid]
 
 def split(
     objects: Union[SplitType, Iterable[SplitType]] = None,
-    bisect_by: Union[Plane, Face] = Plane.XZ,
+    bisect_by: Union[Plane, Face, Shell] = Plane.XZ,
     keep: Keep = Keep.TOP,
     mode: Mode = Mode.REPLACE,
 ):
@@ -937,7 +937,16 @@ def split(
 
     new_objects = []
     for obj in object_list:
-        new_objects.append(obj.split(bisect_by, keep))
+        bottom = None
+        if keep == Keep.BOTH:
+            top, bottom = obj.split(bisect_by, keep)
+        else:
+            top = obj.split(bisect_by, keep)
+        for subpart in [top, bottom]:
+            if isinstance(subpart, Iterable):
+                new_objects.extend(subpart)
+            elif subpart is not None:
+                new_objects.append(subpart)
 
     if context is not None:
         context._add_to_context(*new_objects, mode=mode)

--- a/src/build123d/operations_part.py
+++ b/src/build123d/operations_part.py
@@ -173,7 +173,10 @@ def extrude(
         context._add_to_context(*new_solids, clean=clean, mode=mode)
     else:
         if len(new_solids) > 1:
-            new_solids = [new_solids.pop().fuse(*new_solids)]
+            fused_solids = new_solids.pop().fuse(*new_solids)
+            new_solids = (
+                fused_solids if isinstance(fused_solids, list) else [fused_solids]
+            )
         if clean:
             new_solids = [solid.clean() for solid in new_solids]
 
@@ -597,7 +600,9 @@ def thicken(
         )
         for direction in [1, -1] if both else [1]:
             new_solids.append(
-                face.thicken(depth=amount, normal_override=face_normal * direction)
+                Solid.thicken(
+                    face, depth=amount, normal_override=face_normal * direction
+                )
             )
 
     if context is not None:

--- a/src/build123d/operations_sketch.py
+++ b/src/build123d/operations_sketch.py
@@ -305,4 +305,9 @@ def trace(
         context.pending_edges = ShapeList()
 
     combined_faces = Face.fuse(*new_faces) if len(new_faces) > 1 else new_faces[0]
-    return Sketch(combined_faces.wrapped)
+    result = (
+        Sketch(combined_faces)
+        if isinstance(combined_faces, list)
+        else Sketch(combined_faces.wrapped)
+    )
+    return result

--- a/src/build123d/operations_sketch.py
+++ b/src/build123d/operations_sketch.py
@@ -40,9 +40,8 @@ from build123d.topology import (
     Sketch,
     topo_explore_connected_edges,
     topo_explore_common_vertex,
-    TOLERANCE,
 )
-from build123d.geometry import Vector
+from build123d.geometry import Vector, TOLERANCE
 from build123d.build_common import flatten_sequence, validate_inputs
 from build123d.build_sketch import BuildSketch
 from scipy.spatial import Voronoi

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -2393,7 +2393,9 @@ class ShapeList(list[T]):
         def axis_parallel_predicate(axis: Axis, tolerance: float):
             def pred(shape: Shape):
                 if shape.is_planar_face:
-                    assert shape.wrapped is not None and isinstance(shape, Face)
+                    assert shape.wrapped is not None and isinstance(
+                        shape.wrapped, TopoDS_Face
+                    )
                     gp_pnt = gp_Pnt()
                     surface_normal = gp_Vec()
                     u_val, _, v_val, _ = BRepTools.UVBounds_s(shape.wrapped)
@@ -2428,7 +2430,9 @@ class ShapeList(list[T]):
 
             def pred(shape: Shape):
                 if shape.is_planar_face:
-                    assert shape.wrapped is not None and isinstance(shape, Face)
+                    assert shape.wrapped is not None and isinstance(
+                        shape.wrapped, TopoDS_Face
+                    )
                     gp_pnt: gp_Pnt = gp_Pnt()
                     surface_normal: gp_Vec = gp_Vec()
                     u_val, _, v_val, _ = BRepTools.UVBounds_s(shape.wrapped)

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -4266,7 +4266,8 @@ class ShapeList(list[T]):
 
     def __add__(self, other: ShapeList) -> ShapeList[T]:  # type: ignore
         """Combine two ShapeLists together operator +"""
-        return ShapeList(itertools.chain(self, other))
+        # return ShapeList(itertools.chain(self, other))
+        return ShapeList(list(self) + list(other))
 
     def __sub__(self, other: ShapeList) -> ShapeList[T]:
         """Differences between two ShapeLists operator -"""

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -468,18 +468,18 @@ class Mixin1D:
     @overload
     def split(
         self, tool: TrimmingTool, keep: Literal[Keep.TOP, Keep.BOTTOM]
-    ) -> Optional[Self] | Optional[list[Self]]:
+    ) -> Self | list[Self] | None:
         """split and keep inside or outside"""
 
     @overload
     def split(self, tool: TrimmingTool, keep: Literal[Keep.BOTH]) -> tuple[
-        Optional[Self] | Optional[list[Self]],
-        Optional[Self] | Optional[list[Self]],
+        Self | list[Self] | None,
+        Self | list[Self] | None,
     ]:
         """split and keep inside and outside"""
 
     @overload
-    def split(self, tool: TrimmingTool) -> Optional[Self] | Optional[list[Self]]:
+    def split(self, tool: TrimmingTool) -> Self | list[Self] | None:
         """split and keep inside (default)"""
 
     def split(self, tool: TrimmingTool, keep: Keep = Keep.TOP):
@@ -494,8 +494,8 @@ class Mixin1D:
         Returns:
             Shape: result of split
         Returns:
-            Optional[Self] | Optional[list[Self]],
-            Tuple[Optional[Self] | Optional[list[Self]]]: The result of the split operation.
+            Self | list[Self] | None,
+            Tuple[Self | list[Self] | None]: The result of the split operation.
 
             - **Keep.TOP**: Returns the top as a `Self` or `list[Self]`, or `None`
               if no top is found.
@@ -3204,22 +3204,22 @@ class Shape(NodeMixin):
     @overload
     def split_by_perimeter(
         self, perimeter: Union[Edge, Wire], keep: Literal[Keep.INSIDE, Keep.OUTSIDE]
-    ) -> Optional[Face] | Optional[Shell] | Optional[ShapeList[Face]]:
+    ) -> Face | Shell | ShapeList[Face] | None:
         """split_by_perimeter and keep inside or outside"""
 
     @overload
     def split_by_perimeter(
         self, perimeter: Union[Edge, Wire], keep: Literal[Keep.BOTH]
     ) -> tuple[
-        Optional[Face] | Optional[Shell] | Optional[ShapeList[Face]],
-        Optional[Face] | Optional[Shell] | Optional[ShapeList[Face]],
+        Face | Shell | ShapeList[Face] | None,
+        Face | Shell | ShapeList[Face] | None,
     ]:
         """split_by_perimeter and keep inside and outside"""
 
     @overload
     def split_by_perimeter(
         self, perimeter: Union[Edge, Wire]
-    ) -> Optional[Face] | Optional[Shell] | Optional[ShapeList[Face]]:
+    ) -> Face | Shell | ShapeList[Face] | None:
         """split_by_perimeter and keep inside (default)"""
 
     def split_by_perimeter(
@@ -3241,8 +3241,8 @@ class Shape(NodeMixin):
             ValueError: keep must be one of Keep.INSIDE|OUTSIDE|BOTH
 
         Returns:
-            Union[Optional[Shell], Optional[Face],
-            Tuple[Optional[Shell], Optional[Face]]]: The result of the split operation.
+            Union[Face | Shell | ShapeList[Face] | None,
+            Tuple[Face | Shell | ShapeList[Face] | None]: The result of the split operation.
 
             - **Keep.INSIDE**: Returns the inside part as a `Shell` or `Face`, or `None`
               if no inside part is found.

--- a/src/build123d/topology.py
+++ b/src/build123d/topology.py
@@ -2930,8 +2930,20 @@ class GroupBy(Generic[T, K]):
         return self.group(self.key_f(shape))
 
 
-class Mixin1D(Shape, ABC):
+class Mixin1D(Shape):
     """Methods to add to the Edge and Wire classes"""
+
+    @classmethod
+    def extrude(
+        cls, obj: Shape, direction: VectorLike
+    ) -> Edge | Face | Shell | Solid | Compound:
+        """Unused - only here because Mixin1D is a subclass of Shape"""
+        return NotImplemented
+
+    @property
+    def _dim(self) -> int:
+        """Dimension of Edges and Wires"""
+        return 1
 
     def __add__(
         self, other: None | Shape | Iterable[Shape]
@@ -3819,8 +3831,20 @@ class Mixin1D(Shape, ABC):
         return (visible_edges, hidden_edges)
 
 
-class Mixin2D(Shape, ABC):
+class Mixin2D(Shape):
     """Additional methods to add to Face and Shell class"""
+
+    @classmethod
+    def extrude(
+        cls, obj: Shape, direction: VectorLike
+    ) -> Edge | Face | Shell | Solid | Compound:
+        """Unused - only here because Mixin1D is a subclass of Shape"""
+        return NotImplemented
+
+    @property
+    def _dim(self) -> int:
+        """Dimension of Faces and Shells"""
+        return 2
 
     project_to_viewport = Mixin1D.project_to_viewport
     split = Mixin1D.split
@@ -3925,8 +3949,20 @@ class Mixin2D(Shape, ABC):
         return result
 
 
-class Mixin3D(Shape, ABC):
+class Mixin3D(Shape):
     """Additional methods to add to 3D Shape classes"""
+
+    @classmethod
+    def extrude(
+        cls, obj: Shape, direction: VectorLike
+    ) -> Edge | Face | Shell | Solid | Compound:
+        """Unused - only here because Mixin1D is a subclass of Shape"""
+        return NotImplemented
+
+    @property
+    def _dim(self) -> int | None:
+        """Dimension of Solids"""
+        return 3
 
     project_to_viewport = Mixin1D.project_to_viewport
     split = Mixin1D.split
@@ -5040,10 +5076,6 @@ class Edge(Mixin1D, Shape[TopoDS_Edge]):
 
     order = 1.0
 
-    @property
-    def _dim(self) -> int:
-        return 1
-
     def __init__(
         self,
         obj: Optional[TopoDS_Edge | Axis | None] = None,
@@ -6000,10 +6032,6 @@ class Face(Mixin2D, Shape[TopoDS_Face]):
     # pylint: disable=too-many-public-methods
 
     order = 2.0
-
-    @property
-    def _dim(self) -> int:
-        return 2
 
     @overload
     def __init__(
@@ -6969,10 +6997,6 @@ class Shell(Mixin2D, Shape[TopoDS_Shell]):
 
     order = 2.5
 
-    @property
-    def _dim(self) -> int:
-        return 2
-
     def __init__(
         self,
         obj: Optional[TopoDS_Shell | Face | Iterable[Face]] = None,
@@ -7106,10 +7130,6 @@ class Solid(Mixin3D, Shape[TopoDS_Solid]):
     Solid objects to create or modify complex geometries."""
 
     order = 3.0
-
-    @property
-    def _dim(self) -> int:
-        return 3
 
     def __init__(
         self,
@@ -8125,10 +8145,6 @@ class Wire(Mixin1D, Shape[TopoDS_Wire]):
     allowing precise definition of paths within a 3D model."""
 
     order = 1.5
-
-    @property
-    def _dim(self) -> int:
-        return 1
 
     @overload
     def __init__(

--- a/tests/test_algebra.py
+++ b/tests/test_algebra.py
@@ -1,6 +1,5 @@
 import math
 import unittest
-import pytest
 from build123d import *
 from build123d.topology import Shape
 
@@ -553,7 +552,7 @@ class AlgebraTests(unittest.TestCase):
         self.assertAlmostEqual(l.length, 3, 5)
 
         l2 = e1 + e3
-        self.assertTrue(isinstance(l2, Compound))
+        self.assertTrue(isinstance(l2, list))
 
     def test_curve_plus_nothing(self):
         e1 = Edge.make_line((0, 1), (1, 1))
@@ -626,7 +625,8 @@ class AlgebraTests(unittest.TestCase):
     def test_part_minus_empty(self):
         b = Box(1, 2, 3)
         r = b - Part()
-        self.assertEqual(b.wrapped, r.wrapped)
+        self.assertAlmostEqual(b.volume, r.volume, 5)
+        self.assertEqual(r._dim, 3)
 
     def test_empty_and_part(self):
         b = Box(1, 2, 3)
@@ -660,7 +660,8 @@ class AlgebraTests(unittest.TestCase):
     def test_sketch_minus_empty(self):
         b = Rectangle(1, 2)
         r = b - Sketch()
-        self.assertEqual(b.wrapped, r.wrapped)
+        self.assertAlmostEqual(b.area, r.area, 5)
+        self.assertEqual(r._dim, 2)
 
     def test_empty_and_sketch(self):
         b = Rectangle(1, 3)
@@ -823,6 +824,7 @@ class LocationTests(unittest.TestCase):
             # on plane, located to grid position, and finally rotated
             c_plane = plane * outer_loc * rotations[i]
             s += c_plane * Circle(1)
+            s = Sketch(s.faces())
 
             for loc in PolarLocations(0.8, (i + 3) * 2):
                 # Use polar locations on c_plane

--- a/tests/test_build_sketch.py
+++ b/tests/test_build_sketch.py
@@ -480,8 +480,6 @@ class TestBuildSketchObjects(unittest.TestCase):
 
         line = Polyline((0, 0), (10, 10), (20, 10))
         test = trace(line, 4)
-        self.assertEqual(len(test.faces()), 3)
-        test = trace(line, 4).clean()
         self.assertEqual(len(test.faces()), 1)
 
     def test_full_round(self):

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -3211,10 +3211,6 @@ class TestShape(DirectApiTestCase):
         self.assertVectorAlmostEquals(box.position, (1, 2, 3), 5)
         self.assertVectorAlmostEquals(box.orientation, (10, 20, 30), 5)
 
-    def test_copy(self):
-        with self.assertWarns(DeprecationWarning):
-            Solid.make_box(1, 1, 1).copy()
-
     def test_distance_to_with_closest_points(self):
         s0 = Solid.make_sphere(1).locate(Location((0, 2.1, 0)))
         s1 = Solid.make_sphere(1)

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -4205,9 +4205,7 @@ class TestVector(DirectApiTestCase):
         self.assertVectorAlmostEquals(
             (v1 & Solid.make_box(2, 4, 5)).vertex(), (1, 2, 3), 5
         )
-        self.assertTrue(
-            len(v1.intersect(Solid.make_box(0.5, 0.5, 0.5)).vertices()) == 0
-        )
+        self.assertIsNone(v1.intersect(Solid.make_box(0.5, 0.5, 0.5)))
 
 
 class TestVectorLike(DirectApiTestCase):

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -32,8 +32,6 @@ from build123d import (
 )
 from build123d.exporters import ExportSVG, ExportDXF, Drawing, LineType
 
-from ocp_vscode import show
-
 
 class ExportersTestCase(unittest.TestCase):
     @staticmethod

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -32,6 +32,8 @@ from build123d import (
 )
 from build123d.exporters import ExportSVG, ExportDXF, Drawing, LineType
 
+from ocp_vscode import show
+
 
 class ExportersTestCase(unittest.TestCase):
     @staticmethod

--- a/tests/test_joints.py
+++ b/tests/test_joints.py
@@ -34,7 +34,7 @@ from build123d.build_enums import Align, CenterOf, GeomType
 from build123d.build_common import Mode
 from build123d.build_part import BuildPart
 from build123d.build_sketch import BuildSketch
-from build123d.geometry import Axis, Location, Rotation, Vector, VectorLike
+from build123d.geometry import Axis, Location, Plane, Rotation, Vector, VectorLike
 from build123d.joints import (
     BallJoint,
     CylindricalJoint,
@@ -45,7 +45,7 @@ from build123d.joints import (
 from build123d.objects_part import Box, Cone, Cylinder, Sphere
 from build123d.objects_sketch import Circle
 from build123d.operations_part import extrude
-from build123d.topology import Edge, Plane, Solid
+from build123d.topology import Edge, Solid
 
 
 class DirectApiTestCase(unittest.TestCase):

--- a/tools/refactor_topo.py
+++ b/tools/refactor_topo.py
@@ -87,9 +87,6 @@ Key Features:
   - `_topods_bool_op`: Generic Boolean operations for TopoDS_Shapes.
   - `new_edges`: Identifies newly created edges from combined shapes.
 
-- **Utility Classes**:
-  - `_ClassMethodProxy`: Dynamically binds methods across classes.
-
 - **Enhanced Math**:
   - `isclose_b`: Overrides `math.isclose` with a stricter absolute tolerance.
 
@@ -354,7 +351,7 @@ def write_topo_class_files(
             "get_top_level_topods_shapes",
             "_sew_topods_faces",
             "shapetype",
-            "_topods_compound_dim",
+            "topods_dim",
             "_topods_entities",
             "_topods_face_normal_at",
             "apply_ocp_monkey_patches",
@@ -386,7 +383,6 @@ def write_topo_class_files(
 
     # Define class groupings based on layers
     class_groups = {
-        "utils": ["_ClassMethodProxy"],
         "shape_core": [
             "Shape",
             "Comparable",
@@ -456,7 +452,6 @@ license:
             additional_imports.append(
                 "from .shape_core import Shape, ShapeList, BoundBox, SkipClean, TrimmingTool, Joint"
             )
-            additional_imports.append("from .utils import _ClassMethodProxy")
         if group_name not in ["shape_core", "vertex"]:
             for sub_group_name in function_source.keys():
                 additional_imports.append(
@@ -508,26 +503,6 @@ license:
         # if group_name in ["shape_core", "utils"]:
         if group_name in function_source.keys():
             body = [*cst.parse_module(all_imports_code).body]
-            for func in function_collector.functions:
-                if group_name == "shape_core" and func.name.value in [
-                    "_topods_compound_dim",
-                    "_topods_face_normal_at",
-                    "apply_ocp_monkey_patches",
-                ]:
-                    body.append(func)
-
-                # If this is the "apply_ocp_monkey_patches" function, add a call to it
-                if (
-                    group_name == "shape_core"
-                    and func.name.value == "apply_ocp_monkey_patches"
-                ):
-                    apply_patches_call = cst.Expr(
-                        value=cst.Call(func=cst.Name("apply_ocp_monkey_patches"))
-                    )
-                    body.append(apply_patches_call)
-                    body.append(cst.EmptyLine(indent=False))
-                    body.append(cst.EmptyLine(indent=False))
-
             if group_name == "shape_core":
                 for var in variable_collector.global_variables:
                     # Check the name of the assigned variable(s)
@@ -562,13 +537,7 @@ license:
                                     body.append(cst.EmptyLine(indent=False))
 
             for func in function_collector.functions:
-                if func.name.value in function_source[
-                    group_name
-                ] and func.name.value not in [
-                    "_topods_compound_dim",
-                    "_topods_face_normal_at",
-                    "apply_ocp_monkey_patches",
-                ]:
+                if func.name.value in function_source[group_name]:
                     body.append(func)
             class_module = cst.Module(body=body, header=header)
         else:
@@ -756,7 +725,6 @@ def main():
 
     # Define classes to extract
     class_names = [
-        "_ClassMethodProxy",
         "BoundBox",
         "Shape",
         "Compound",

--- a/tools/refactor_topo.py
+++ b/tools/refactor_topo.py
@@ -233,6 +233,188 @@ interface for efficient and extensible CAD modeling workflows.
 }
 
 
+def sort_class_methods_by_convention(class_def: cst.ClassDef) -> cst.ClassDef:
+    """Sort methods and properties in a class according to Python conventions."""
+    methods, properties = extract_methods_and_properties(class_def)
+    sorted_body = order_methods_by_convention(methods, properties)
+
+    other_statements = [
+        stmt for stmt in class_def.body.body if not isinstance(stmt, cst.FunctionDef)
+    ]
+    final_body = cst.IndentedBlock(body=other_statements + sorted_body)
+    return class_def.with_changes(body=final_body)
+
+
+def extract_methods_and_properties(
+    class_def: cst.ClassDef,
+) -> tuple[List[cst.FunctionDef], List[List[cst.FunctionDef]]]:
+    """
+    Extract methods and properties (with setters grouped together) from a class.
+
+    Returns:
+        - methods: Regular methods in the class.
+        - properties: List of grouped properties, where each group contains a getter
+          and its associated setter, if present.
+    """
+    methods = []
+    properties = {}
+
+    for stmt in class_def.body.body:
+        if isinstance(stmt, cst.FunctionDef):
+            for decorator in stmt.decorators:
+                # Handle @property
+                if (
+                    isinstance(decorator.decorator, cst.Name)
+                    and decorator.decorator.value == "property"
+                ):
+                    properties[stmt.name.value] = [stmt]  # Initialize with getter
+                # Handle @property.setter
+                elif (
+                    isinstance(decorator.decorator, cst.Attribute)
+                    and decorator.decorator.attr.value == "setter"
+                ):
+                    base_name = decorator.decorator.value.value  # Extract base name
+                    if base_name in properties:
+                        properties[base_name].append(
+                            stmt
+                        )  # Add setter to the property group
+                    else:
+                        # Setter appears before the getter
+                        properties[base_name] = [None, stmt]
+
+            # Add non-property methods
+            if not any(
+                isinstance(decorator.decorator, cst.Name)
+                and decorator.decorator.value == "property"
+                or isinstance(decorator.decorator, cst.Attribute)
+                and decorator.decorator.attr.value == "setter"
+                for decorator in stmt.decorators
+            ):
+                methods.append(stmt)
+
+    # Convert property dictionary into a sorted list of grouped properties
+    sorted_properties = [group for _, group in sorted(properties.items())]
+
+    return methods, sorted_properties
+
+
+def order_methods_by_convention(
+    methods: List[cst.FunctionDef], properties: List[List[cst.FunctionDef]]
+) -> List[cst.BaseStatement]:
+    """
+    Order methods and properties in a class by Python's conventional order with section headers.
+
+    Sections:
+    - Constructor
+    - Properties (grouped by getter and setter)
+    - Class Methods
+    - Static Methods
+    - Public and Private Instance Methods
+    """
+
+    def method_key(method: cst.FunctionDef) -> tuple[int, str]:
+        name = method.name.value
+        decorators = {
+            decorator.decorator.value
+            for decorator in method.decorators
+            if isinstance(decorator.decorator, cst.Name)
+        }
+
+        if name == "__init__":
+            return (0, name)  # Constructor always comes first
+        elif name.startswith("__") and name.endswith("__"):
+            return (1, name)  # Dunder methods follow
+        elif any(
+            decorator == "property" or decorator.endswith(".setter")
+            for decorator in decorators
+        ):
+            return (2, name)  # Properties and setters follow dunder methods
+        elif "classmethod" in decorators:
+            return (3, name)  # Class methods follow properties
+        elif "staticmethod" in decorators:
+            return (4, name)  # Static methods follow class methods
+        elif not name.startswith("_"):
+            return (5, name)  # Public instance methods
+        else:
+            return (6, name)  # Private methods last
+
+    # Flatten properties into a single sorted list
+    flattened_properties = [
+        prop for group in properties for prop in group if prop is not None
+    ]
+
+    # Separate __init__, class methods, static methods, and instance methods
+    init_methods = [m for m in methods if m.name.value == "__init__"]
+    class_methods = [
+        m
+        for m in methods
+        if any(decorator.decorator.value == "classmethod" for decorator in m.decorators)
+    ]
+    static_methods = [
+        m
+        for m in methods
+        if any(
+            decorator.decorator.value == "staticmethod" for decorator in m.decorators
+        )
+    ]
+    instance_methods = [
+        m
+        for m in methods
+        if m.name.value != "__init__"
+        and not any(
+            decorator.decorator.value in {"classmethod", "staticmethod"}
+            for decorator in m.decorators
+        )
+    ]
+
+    # Sort properties and each method group alphabetically
+    sorted_properties = sorted(flattened_properties, key=lambda prop: prop.name.value)
+    sorted_class_methods = sorted(class_methods, key=lambda m: m.name.value)
+    sorted_static_methods = sorted(static_methods, key=lambda m: m.name.value)
+    sorted_instance_methods = sorted(instance_methods, key=lambda m: method_key(m))
+
+    # Combine all sections with headers
+    ordered_sections: List[cst.BaseStatement] = []
+
+    if init_methods:
+        ordered_sections.append(
+            cst.SimpleStatementLine([cst.Expr(cst.Comment("# ---- Constructor ----"))])
+        )
+        ordered_sections.extend(init_methods)
+
+    if sorted_properties:
+        ordered_sections.append(
+            cst.SimpleStatementLine([cst.Expr(cst.Comment("# ---- Properties ----"))])
+        )
+        ordered_sections.extend(sorted_properties)
+
+    if sorted_class_methods:
+        ordered_sections.append(
+            cst.SimpleStatementLine(
+                [cst.Expr(cst.Comment("# ---- Class Methods ----"))]
+            )
+        )
+        ordered_sections.extend(sorted_class_methods)
+
+    if sorted_static_methods:
+        ordered_sections.append(
+            cst.SimpleStatementLine(
+                [cst.Expr(cst.Comment("# ---- Static Methods ----"))]
+            )
+        )
+        ordered_sections.extend(sorted_static_methods)
+
+    if sorted_instance_methods:
+        ordered_sections.append(
+            cst.SimpleStatementLine(
+                [cst.Expr(cst.Comment("# ---- Instance Methods ----"))]
+            )
+        )
+        ordered_sections.extend(sorted_instance_methods)
+
+    return ordered_sections
+
+
 class ImportCollector(cst.CSTVisitor):
     def __init__(self):
         self.imports: Set[str] = set()
@@ -257,6 +439,22 @@ class ClassExtractor(cst.CSTVisitor):
     def visit_ClassDef(self, node: cst.ClassDef) -> None:
         if node.name.value in self.class_names:
             self.extracted_classes[node.name.value] = node
+
+
+class ClassMethodExtractor(cst.CSTVisitor):
+    def __init__(self):
+        self.class_methods: Dict[str, List[cst.FunctionDef]] = {}
+
+    def visit_ClassDef(self, node: cst.ClassDef) -> None:
+        class_name = node.name.value
+        self.class_methods[class_name] = []
+
+        for statement in node.body.body:
+            if isinstance(statement, cst.FunctionDef):
+                self.class_methods[class_name].append(statement)
+
+        # Sort methods alphabetically by name
+        self.class_methods[class_name].sort(key=lambda method: method.name.value)
 
 
 class MixinClassExtractor(cst.CSTVisitor):
@@ -284,6 +482,9 @@ class StandaloneFunctionAndVariableCollector(cst.CSTVisitor):
     def visit_FunctionDef(self, node: cst.FunctionDef) -> None:
         if self.current_scope_level == 0:
             self.functions.append(node)
+
+    def get_sorted_functions(self) -> List[cst.FunctionDef]:
+        return sorted(self.functions, key=lambda func: func.name.value)
 
 
 class GlobalVariableExtractor(cst.CSTVisitor):
@@ -402,6 +603,7 @@ def write_topo_class_files(
     }
 
     for group_name, class_names in class_groups.items():
+
         module_docstring = f"""
 build123d topology
 
@@ -442,9 +644,10 @@ license:
             source_tree.visit(variable_collector)
 
         group_classes = [
-            extracted_classes[name] for name in class_names if name in extracted_classes
+            sort_class_methods_by_convention(extracted_classes[name])
+            for name in class_names
+            if name in extracted_classes
         ]
-
         # Add imports for base classes based on layer dependencies
         additional_imports = []
         if group_name != "shape_core":
@@ -535,7 +738,7 @@ license:
                                     body.append(var)
                                     body.append(cst.EmptyLine(indent=False))
 
-            for func in function_collector.functions:
+            for func in function_collector.get_sorted_functions():
                 if func.name.value in function_source[group_name]:
                     body.append(func)
             class_module = cst.Module(body=body, header=header)

--- a/tools/refactor_topo.py
+++ b/tools/refactor_topo.py
@@ -398,6 +398,7 @@ def write_topo_class_files(
         "two_d": ["Mixin2D", "Face", "Shell"],
         "three_d": ["Mixin3D", "Solid"],
         "composite": ["Compound", "Curve", "Sketch", "Part"],
+        "utils": [],
     }
 
     for group_name, class_names in class_groups.items():
@@ -443,8 +444,6 @@ license:
         group_classes = [
             extracted_classes[name] for name in class_names if name in extracted_classes
         ]
-        if not group_classes:
-            continue
 
         # Add imports for base classes based on layer dependencies
         additional_imports = []

--- a/tools/refactor_topo.py
+++ b/tools/refactor_topo.py
@@ -333,51 +333,6 @@ class ClassMethodExtractor(cst.CSTVisitor):
             self.extracted_methods.append(renamed_node)
 
 
-class OptionalTransformer(cst.CSTTransformer):
-    def __init__(self):
-        super().__init__()
-        self.requires_optional_import = False  # Tracks if `Optional` import is needed
-
-    def leave_AnnAssign(
-        self, original_node: cst.AnnAssign, updated_node: cst.AnnAssign
-    ) -> cst.AnnAssign:
-        # Check if the annotation has a default value of `None`
-        if (
-            isinstance(updated_node.value, cst.Name)
-            and updated_node.value.value == "None"
-        ):
-            # Wrap the annotation type in `Optional`
-            if updated_node.annotation:
-                self.requires_optional_import = True
-                new_annotation = cst.Subscript(
-                    value=cst.Name("Optional"),
-                    slice=[
-                        cst.SubscriptElement(
-                            slice=cst.Index(updated_node.annotation.annotation)
-                        )
-                    ],
-                )
-                return updated_node.with_changes(
-                    annotation=cst.Annotation(new_annotation)
-                )
-        return updated_node
-
-    def leave_Module(
-        self, original_node: cst.Module, updated_node: cst.Module
-    ) -> cst.Module:
-        # Add the `Optional` import if required
-        if self.requires_optional_import:
-            import_stmt = cst.ImportFrom(
-                module=cst.Name("typing"),
-                names=[cst.ImportAlias(name=cst.Name("Optional"))],
-            )
-            new_body = [cst.SimpleStatementLine([import_stmt])] + list(
-                updated_node.body
-            )
-            return updated_node.with_changes(body=new_body)
-        return updated_node
-
-
 def write_topo_class_files(
     source_tree: cst.Module,
     extracted_classes: Dict[str, cst.ClassDef],
@@ -809,12 +764,10 @@ def main():
 
     # Parse source file and collect imports
     source_tree = cst.parse_module(topo_file.read_text())
+    source_tree = source_tree.visit(UnionToPipeTransformer())
+    # transformed_module = source_tree.visit(UnionToPipeTransformer())
+    # print(transformed_module.code)
 
-    # Apply transformations
-    source_tree = source_tree.visit(UnionToPipeTransformer())  # Existing transformation
-    source_tree = source_tree.visit(OptionalTransformer())  # New Optional conversion
-
-    # Collect imports
     collector = ImportCollector()
     source_tree.visit(collector)
 
@@ -829,6 +782,8 @@ def main():
     # Extract functions
     function_collector = StandaloneFunctionAndVariableCollector()
     source_tree.visit(function_collector)
+    # for f in function_collector.functions:
+    #     print(f.name.value)
 
     # Write the class files
     write_topo_class_files(
@@ -838,8 +793,11 @@ def main():
         output_dir=output_dir,
     )
 
-    # Clean up imports
+    # Create a Rope project instance
+    # project = Project(str(script_dir))
     project = Project(str(output_dir))
+
+    # Clean up imports
     for file in output_dir.glob("*.py"):
         if file.name == "__init__.py":
             continue


### PR DESCRIPTION
Here is the refactor of the `topology.py` module that I've been working on.  The change will occur in two stages:
1) All of these changes are applied against the existing file structure and should pass all of the acceptance criteria as is.
2) The `refactor_topo.py` tool (look in the `build123d/tools/` directory) converts the file `topology_old.py` (just `topology.py` renamed) into the new structure including generation of the` __init__.py` file. Reviewers, it will be useful to run the tool to see what the resulting files look like.  Actually introducing the split files needs to be done carefully to avoid loosing history for the files.

The new structure is (lines file order main_classes):
```
     92 __init__.py
   2831 shape_core.py  Shape, ShapeList
    470 utils.py
    319 zero_d.py      Vertex
   2921 one_d.py       Mixin1D, Edge, Wire
   1265 two_d.py       Mixin2D, Face, Shell
   1337 three_d.py     Mixin3D, Solid
    730 composite.py   Compound (and soon to be Assembly)
  10173 total
```
The core idea is that there is a topology order of these objects - no object shall depend on a higher order module: `shape_core` being the base, `composite` being the highest. As `Edge` and `Wire` are in the same module they can depend on each other.

 Not being able to use a `Compound` in the lower order object results changes to the API - here are all of the API changes:
- boolean operations may generate a list: `Part() + ...` will generate a `Compound` if necessary, while `Solid() + ...` may generate a `ShapeList` of `Solids`.
- `surface.thicken(amount)` -> `Solid.thicken(surface, amount)`: this was an exception to the other class methods and was problematic because a `Face` was generating an object of a higher topological order which isn't possible anymore.  This is a key thing to look for in the future.
- deprecated methods were removed and the vtk ones commented out to see if anyone notices
- `shape.split(Keep.BOTH)` generates a `tuple` of `Shape` instead of a `Compound`
- `Shape.extrude()` is replaced by specific class versions like `Edge.extrude()`, `Face.extrude()`, etc.

Quite a bit of code changed - 14 files changed, 1865 insertions(+), 1777 deletions(-) - as many of the methods needed to rewritten to directly work at the OCCT level and not depend on resources provided by higher order classes.

This change will help with long term support of the project.  The `topology.py` file is almost 10,000 lines long which is kinda crazy and difficult to work with.

Any feedback you can provide on this change is greatly appreciated.
