### PR TITLE
Workflow cleanup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,7 +10,7 @@ runs:
     - name: python
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ inputs.python-version }}
     - name: install requirements
       shell: bash
       run: |

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -17,5 +17,6 @@ runs:
         pip install wheel
         pip install mypy
         pip install pytest
+        pip install pytest-cov
         pip install pylint
         pip install .

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup/
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - name: Run tests and collect coverage
         run: pytest --cov=build123d
       - name: Upload coverage to Codecov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,14 +6,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+      - name: Setup
+        uses: ./.github/actions/setup/
         with:
           python-version: '3.10'
-      - name: Install dependencies
-        run: pip install -r requirements.txt
       - name: Run tests and collect coverage
         run: pytest --cov=build123d
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-
+        uses: codecov/codecov-action@v5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-pytest-cov
--e .


### PR DESCRIPTION
`coverage.yml` was not set up the same way as other workflows, this PR fixes that and deletes the now unnecessary `requirements.txt` file by moving the `pytest-cov` installation elsewhere.