### PR TITLE
jupyter_tools: fix out of order display of multiple shapes in static html

### DIFF
--- a/src/build123d/jupyter_tools.py
+++ b/src/build123d/jupyter_tools.py
@@ -26,6 +26,7 @@ license:
 # pylint: disable=no-name-in-module
 from json import dumps
 import os
+import uuid
 from string import Template
 from typing import Any, Dict, List
 from IPython.display import HTML
@@ -92,7 +93,7 @@ def shape_to_html(shape: Any) -> HTML:
     )
 
     # A new div with a unique id, plus the JS code templated with the id
-    div_id = "shape-" + str(id(shape))
+    div_id = 'shape-' + uuid.uuid4().hex[:8]
     code = Template(TEMPLATE_JS).substitute(data=dumps(payload), div_id=div_id, ratio=0.5)
     html = HTML(f"<div id={div_id}></div><script>{code}</script>")
 

--- a/src/build123d/jupyter_tools.py
+++ b/src/build123d/jupyter_tools.py
@@ -25,156 +25,17 @@ license:
 
 # pylint: disable=no-name-in-module
 from json import dumps
+import os
+from string import Template
 from typing import Any, Dict, List
 from IPython.display import Javascript
 from vtkmodules.vtkIOXML import vtkXMLPolyDataWriter
 
 DEFAULT_COLOR = [1, 0.8, 0, 1]
 
-TEMPLATE_RENDER = """
-
-function render(data, parent_element, ratio){{
-
-    // Initial setup
-    const renderWindow = vtk.Rendering.Core.vtkRenderWindow.newInstance();
-    const renderer = vtk.Rendering.Core.vtkRenderer.newInstance({{ background: [1, 1, 1 ] }});
-    renderWindow.addRenderer(renderer);
-
-    // iterate over all children children
-    for (var el of data){{
-        var trans = el.position;
-        var rot = el.orientation;
-        var rgba = el.color;
-        var shape = el.shape;
-
-        // load the inline data
-        var reader = vtk.IO.XML.vtkXMLPolyDataReader.newInstance();
-        const textEncoder = new TextEncoder();
-        reader.parseAsArrayBuffer(textEncoder.encode(shape));
-
-        // setup actor,mapper and add
-        const mapper = vtk.Rendering.Core.vtkMapper.newInstance();
-        mapper.setInputConnection(reader.getOutputPort());
-        mapper.setResolveCoincidentTopologyToPolygonOffset();
-        mapper.setResolveCoincidentTopologyPolygonOffsetParameters(0.5,100);
-
-        const actor = vtk.Rendering.Core.vtkActor.newInstance();
-        actor.setMapper(mapper);
-
-        // set color and position
-        actor.getProperty().setColor(rgba.slice(0,3));
-        actor.getProperty().setOpacity(rgba[3]);
-
-        actor.rotateZ(rot[2]*180/Math.PI);
-        actor.rotateY(rot[1]*180/Math.PI);
-        actor.rotateX(rot[0]*180/Math.PI);
-
-        actor.setPosition(trans);
-
-        renderer.addActor(actor);
-
-    }};
-
-    renderer.resetCamera();
-
-    const openglRenderWindow = vtk.Rendering.OpenGL.vtkRenderWindow.newInstance();
-    renderWindow.addView(openglRenderWindow);
-
-    // Add output to the "parent element"
-    var container;
-    var dims;
-
-    if(typeof(parent_element.appendChild) !== "undefined"){{
-        container = document.createElement("div");
-        parent_element.appendChild(container);
-        dims = parent_element.getBoundingClientRect();
-    }}else{{
-        container = parent_element.append("<div/>").children("div:last-child").get(0);
-        dims = parent_element.get(0).getBoundingClientRect();
-    }};
-
-    openglRenderWindow.setContainer(container);
-
-    // handle size
-    if (ratio){{
-        openglRenderWindow.setSize(dims.width, dims.width*ratio);
-    }}else{{
-        openglRenderWindow.setSize(dims.width, dims.height);
-    }};
-
-    // Interaction setup
-    const interact_style = vtk.Interaction.Style.vtkInteractorStyleManipulator.newInstance();
-
-    const manips = {{
-        rot: vtk.Interaction.Manipulators.vtkMouseCameraTrackballRotateManipulator.newInstance(),
-        pan: vtk.Interaction.Manipulators.vtkMouseCameraTrackballPanManipulator.newInstance(),
-        zoom1: vtk.Interaction.Manipulators.vtkMouseCameraTrackballZoomManipulator.newInstance(),
-        zoom2: vtk.Interaction.Manipulators.vtkMouseCameraTrackballZoomManipulator.newInstance(),
-        roll: vtk.Interaction.Manipulators.vtkMouseCameraTrackballRollManipulator.newInstance(),
-    }};
-
-    manips.zoom1.setControl(true);
-    manips.zoom2.setScrollEnabled(true);
-    manips.roll.setShift(true);
-    manips.pan.setButton(2);
-
-    for (var k in manips){{
-        interact_style.addMouseManipulator(manips[k]);
-    }};
-
-    const interactor = vtk.Rendering.Core.vtkRenderWindowInteractor.newInstance();
-    interactor.setView(openglRenderWindow);
-    interactor.initialize();
-    interactor.bindEvents(container);
-    interactor.setInteractorStyle(interact_style);
-
-    // Orientation marker
-
-    const axes = vtk.Rendering.Core.vtkAnnotatedCubeActor.newInstance();
-    axes.setXPlusFaceProperty({{text: '+X'}});
-    axes.setXMinusFaceProperty({{text: '-X'}});
-    axes.setYPlusFaceProperty({{text: '+Y'}});
-    axes.setYMinusFaceProperty({{text: '-Y'}});
-    axes.setZPlusFaceProperty({{text: '+Z'}});
-    axes.setZMinusFaceProperty({{text: '-Z'}});
-
-    const orientationWidget = vtk.Interaction.Widgets.vtkOrientationMarkerWidget.newInstance({{
-        actor: axes,
-        interactor: interactor }});
-    orientationWidget.setEnabled(true);
-    orientationWidget.setViewportCorner(vtk.Interaction.Widgets.vtkOrientationMarkerWidget.Corners.BOTTOM_LEFT);
-    orientationWidget.setViewportSize(0.2);
-
-}};
-"""
-
-TEMPLATE = (
-    TEMPLATE_RENDER
-    + """
-
-new Promise(
-  function(resolve, reject)
-  {{
-    if (typeof(require) !== "undefined" ){{
-        require.config({{
-         "paths": {{"vtk": "https://unpkg.com/vtk"}},
-        }});
-        require(["vtk"], resolve, reject);
-    }} else if ( typeof(vtk) === "undefined" ){{
-        var script = document.createElement("script");
-    	script.onload = resolve;
-    	script.onerror = reject;
-    	script.src = "https://unpkg.com/vtk.js";
-    	document.head.appendChild(script);
-    }} else {{ resolve() }};
- }}
-).then(() => {{
-    var parent_element = {element};
-    var data = {data};
-    render(data, parent_element, {ratio});
-}});
-"""
-)
+dir_path = os.path.dirname(os.path.realpath(__file__))
+with open(os.path.join(dir_path, "template_render.js"), encoding="utf-8") as f:
+    TEMPLATE_JS = f.read()
 
 
 def to_vtkpoly_string(
@@ -229,6 +90,6 @@ def display(shape: Any) -> Javascript:
             "orientation": [0, 0, 0],
         }
     )
-    code = TEMPLATE.format(data=dumps(payload), element="element", ratio=0.5)
+    code = Template(TEMPLATE_JS).substitute(data=dumps(payload), element="element", ratio=0.5)
 
     return Javascript(code)

--- a/src/build123d/jupyter_tools.py
+++ b/src/build123d/jupyter_tools.py
@@ -28,7 +28,7 @@ from json import dumps
 import os
 from string import Template
 from typing import Any, Dict, List
-from IPython.display import Javascript
+from IPython.display import HTML
 from vtkmodules.vtkIOXML import vtkXMLPolyDataWriter
 
 DEFAULT_COLOR = [1, 0.8, 0, 1]
@@ -65,8 +65,8 @@ def to_vtkpoly_string(
     return writer.GetOutputString()
 
 
-def display(shape: Any) -> Javascript:
-    """display
+def shape_to_html(shape: Any) -> HTML:
+    """shape_to_html
 
     Args:
         shape (Shape): object to display
@@ -75,7 +75,7 @@ def display(shape: Any) -> Javascript:
         ValueError: not a valid Shape
 
     Returns:
-        Javascript: code
+        HTML: html code
     """
     payload: list[dict[str, Any]] = []
 
@@ -90,6 +90,10 @@ def display(shape: Any) -> Javascript:
             "orientation": [0, 0, 0],
         }
     )
-    code = Template(TEMPLATE_JS).substitute(data=dumps(payload), element="element", ratio=0.5)
 
-    return Javascript(code)
+    # A new div with a unique id, plus the JS code templated with the id
+    div_id = "shape-" + str(id(shape))
+    code = Template(TEMPLATE_JS).substitute(data=dumps(payload), div_id=div_id, ratio=0.5)
+    html = HTML(f"<div id={div_id}></div><script>{code}</script>")
+
+    return html

--- a/src/build123d/template_render.js
+++ b/src/build123d/template_render.js
@@ -1,0 +1,137 @@
+function render(data, parent_element, ratio){
+
+    // Initial setup
+    const renderWindow = vtk.Rendering.Core.vtkRenderWindow.newInstance();
+    const renderer = vtk.Rendering.Core.vtkRenderer.newInstance({ background: [1, 1, 1 ] });
+    renderWindow.addRenderer(renderer);
+
+    // iterate over all children children
+    for (var el of data){
+        var trans = el.position;
+        var rot = el.orientation;
+        var rgba = el.color;
+        var shape = el.shape;
+
+        // load the inline data
+        var reader = vtk.IO.XML.vtkXMLPolyDataReader.newInstance();
+        const textEncoder = new TextEncoder();
+        reader.parseAsArrayBuffer(textEncoder.encode(shape));
+
+        // setup actor,mapper and add
+        const mapper = vtk.Rendering.Core.vtkMapper.newInstance();
+        mapper.setInputConnection(reader.getOutputPort());
+        mapper.setResolveCoincidentTopologyToPolygonOffset();
+        mapper.setResolveCoincidentTopologyPolygonOffsetParameters(0.5,100);
+
+        const actor = vtk.Rendering.Core.vtkActor.newInstance();
+        actor.setMapper(mapper);
+
+        // set color and position
+        actor.getProperty().setColor(rgba.slice(0,3));
+        actor.getProperty().setOpacity(rgba[3]);
+
+        actor.rotateZ(rot[2]*180/Math.PI);
+        actor.rotateY(rot[1]*180/Math.PI);
+        actor.rotateX(rot[0]*180/Math.PI);
+
+        actor.setPosition(trans);
+
+        renderer.addActor(actor);
+
+    };
+
+    renderer.resetCamera();
+
+    const openglRenderWindow = vtk.Rendering.OpenGL.vtkRenderWindow.newInstance();
+    renderWindow.addView(openglRenderWindow);
+
+    // Add output to the "parent element"
+    var container;
+    var dims;
+
+    if(typeof(parent_element.appendChild) !== "undefined"){
+        container = document.createElement("div");
+        parent_element.appendChild(container);
+        dims = parent_element.getBoundingClientRect();
+    }else{
+        container = parent_element.append("<div/>").children("div:last-child").get(0);
+        dims = parent_element.get(0).getBoundingClientRect();
+    };
+
+    openglRenderWindow.setContainer(container);
+
+    // handle size
+    if (ratio){
+        openglRenderWindow.setSize(dims.width, dims.width*ratio);
+    }else{
+        openglRenderWindow.setSize(dims.width, dims.height);
+    };
+
+    // Interaction setup
+    const interact_style = vtk.Interaction.Style.vtkInteractorStyleManipulator.newInstance();
+
+    const manips = {
+        rot: vtk.Interaction.Manipulators.vtkMouseCameraTrackballRotateManipulator.newInstance(),
+        pan: vtk.Interaction.Manipulators.vtkMouseCameraTrackballPanManipulator.newInstance(),
+        zoom1: vtk.Interaction.Manipulators.vtkMouseCameraTrackballZoomManipulator.newInstance(),
+        zoom2: vtk.Interaction.Manipulators.vtkMouseCameraTrackballZoomManipulator.newInstance(),
+        roll: vtk.Interaction.Manipulators.vtkMouseCameraTrackballRollManipulator.newInstance(),
+    };
+
+    manips.zoom1.setControl(true);
+    manips.zoom2.setScrollEnabled(true);
+    manips.roll.setShift(true);
+    manips.pan.setButton(2);
+
+    for (var k in manips){
+        interact_style.addMouseManipulator(manips[k]);
+    };
+
+    const interactor = vtk.Rendering.Core.vtkRenderWindowInteractor.newInstance();
+    interactor.setView(openglRenderWindow);
+    interactor.initialize();
+    interactor.bindEvents(container);
+    interactor.setInteractorStyle(interact_style);
+
+    // Orientation marker
+
+    const axes = vtk.Rendering.Core.vtkAnnotatedCubeActor.newInstance();
+    axes.setXPlusFaceProperty({text: '+X'});
+    axes.setXMinusFaceProperty({text: '-X'});
+    axes.setYPlusFaceProperty({text: '+Y'});
+    axes.setYMinusFaceProperty({text: '-Y'});
+    axes.setZPlusFaceProperty({text: '+Z'});
+    axes.setZMinusFaceProperty({text: '-Z'});
+
+    const orientationWidget = vtk.Interaction.Widgets.vtkOrientationMarkerWidget.newInstance({
+        actor: axes,
+        interactor: interactor });
+    orientationWidget.setEnabled(true);
+    orientationWidget.setViewportCorner(vtk.Interaction.Widgets.vtkOrientationMarkerWidget.Corners.BOTTOM_LEFT);
+    orientationWidget.setViewportSize(0.2);
+
+};
+
+
+new Promise(
+  function(resolve, reject)
+  {
+    if (typeof(require) !== "undefined" ){
+        require.config({
+         "paths": {"vtk": "https://unpkg.com/vtk"},
+        });
+        require(["vtk"], resolve, reject);
+    } else if ( typeof(vtk) === "undefined" ){
+        var script = document.createElement("script");
+    	script.onload = resolve;
+    	script.onerror = reject;
+    	script.src = "https://unpkg.com/vtk.js";
+    	document.head.appendChild(script);
+    } else { resolve() };
+ }
+).then(() => {
+    // element, data and ratio are templated by python
+    var parent_element = $element;
+    var data = $data;
+    render(data, parent_element, $ratio);
+});

--- a/src/build123d/template_render.js
+++ b/src/build123d/template_render.js
@@ -1,4 +1,4 @@
-function render(data, parent_element, ratio){
+function render(data, div_id, ratio){
 
     // Initial setup
     const renderWindow = vtk.Rendering.Core.vtkRenderWindow.newInstance();
@@ -45,18 +45,9 @@ function render(data, parent_element, ratio){
     const openglRenderWindow = vtk.Rendering.OpenGL.vtkRenderWindow.newInstance();
     renderWindow.addView(openglRenderWindow);
 
-    // Add output to the "parent element"
-    var container;
-    var dims;
-
-    if(typeof(parent_element.appendChild) !== "undefined"){
-        container = document.createElement("div");
-        parent_element.appendChild(container);
-        dims = parent_element.getBoundingClientRect();
-    }else{
-        container = parent_element.append("<div/>").children("div:last-child").get(0);
-        dims = parent_element.get(0).getBoundingClientRect();
-    };
+    // Get the div container    
+    const container = document.getElementById(div_id);
+    const dims = container.parentElement.getBoundingClientRect();
 
     openglRenderWindow.setContainer(container);
 
@@ -130,8 +121,10 @@ new Promise(
     } else { resolve() };
  }
 ).then(() => {
-    // element, data and ratio are templated by python
-    var parent_element = $element;
-    var data = $data;
-    render(data, parent_element, $ratio);
+    // data, div_id and ratio are templated by python
+    const div_id = "$div_id";
+    const data = $data;
+    const ratio = $ratio;
+
+    render(data, div_id, ratio);
 });

--- a/src/build123d/topology/shape_core.py
+++ b/src/build123d/topology/shape_core.py
@@ -2117,12 +2117,12 @@ class Shape(NodeMixin, Generic[TOPODS]):
 
         return (vertices, edges)
 
-    def _repr_javascript_(self):
+    def _repr_html_(self):
         """Jupyter 3D representation support"""
 
-        from build123d.jupyter_tools import display
+        from build123d.jupyter_tools import shape_to_html
 
-        return display(self)._repr_javascript_()
+        return shape_to_html(self)._repr_html_()
 
 
 class Comparable(ABC):

--- a/tests/test_direct_api/test_jupyter.py
+++ b/tests/test_direct_api/test_jupyter.py
@@ -29,28 +29,28 @@ license:
 import unittest
 
 from build123d.geometry import Vector
-from build123d.jupyter_tools import to_vtkpoly_string, display
+from build123d.jupyter_tools import to_vtkpoly_string, shape_to_html
 from build123d.topology import Solid
 
 
 class TestJupyter(unittest.TestCase):
-    def test_repr_javascript(self):
+    def test_repr_html(self):
         shape = Solid.make_box(1, 1, 1)
 
-        # Test no exception on rendering to js
-        js1 = shape._repr_javascript_()
+        # Test no exception on rendering to html
+        html1 = shape._repr_html_()
 
-        assert "function render" in js1
+        assert "function render" in html1
 
     def test_display_error(self):
         with self.assertRaises(AttributeError):
-            display(Vector())
+            shape_to_html(Vector())
 
         with self.assertRaises(ValueError):
             to_vtkpoly_string("invalid")
 
         with self.assertRaises(ValueError):
-            display("invalid")
+            shape_to_html("invalid")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hello! I know we talked on discord about how you're thinking of removing the jupyter display support, but I found a bug in it and fixed it :grin:

## The problem

When using IPython display from jupyter_tools, there is currently an issue when exporting a notebook to static html. If the notebook contains multiple calls to `display(part)` displaying multiple parts, the parts will be all displayed at the end of the notebook, instead of after the cell that calls the code.

This is because the javascript code that displays the shape is only executed after the full html is loaded, and it dynamically appends a new div to the end of the notebook container when it runs. Therefore, when viewing the static html, all parts 3D models are at the end of the document. This does not happen interactively because the javascript is executed right away.

Here is a jupyter notebook that show the issue: https://gist.github.com/fouronnes/c6bee77d9895003935a83ff5db11d8ca

Interactively, it works fine. But if you convert the notebook to html with:

```
jupyter nbconvert test_notebooks/fix_async_display.ipynb --execute --to html
```
and open the html in firefox, all 3D widgets are at the end, which is not the intended order.

## The fix

First I moved the template JS code to its own `.js` file for lisibility. I also switch to using [`string.Template`](https://docs.python.org/fr/3.8/library/string.html#string.Template) instead for f-strings, because escaping `{` makes the JS code very un-canny. Subsitution with `$` is more suited in this case, I think.

Then in the second commit, I fix the issue by immediately returning a div with a unique ID. This creates a HTML DOM element that the javascript code can them fill with its data later.

Here is a screenshot of a side by side compare of 0.7.0 (the left) and this branch (the right). Each html page is rendered with `jupyter nbconvert ~/Downloads/build123d_fix_async_display.ipynb --execute --to html`

![image](https://github.com/user-attachments/assets/873d602b-de25-44b3-bb5a-ebf126d202ff)


## The unknown

The only thing I'm not sure about is this piece of code (currently in dev branch):

```js
else{
        container = parent_element.append("<div/>").children("div:last-child").get(0);
        dims = parent_element.get(0).getBoundingClientRect();
};
```

I don't understand what this else branch is for. As far as I can tell it should never be executed, and it's producing invalid html anyway. I removed it, but I'm not sure why it was there.