### PR TITLE
Upgrade to Python 310+ syntax

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,6 +1,6 @@
 name: Run type checker
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 jobs:
   typecheck:
     strategy:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,6 +1,6 @@
 name: Run type checker
 
-on: [push, pull_request, workflow_dispatch]
+on: [push, pull_request]
 jobs:
   typecheck:
     strategy:

--- a/src/build123d/build_enums.py
+++ b/src/build123d/build_enums.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 from enum import Enum, auto
 from typing import Union
 
-from typing_extensions import TypeAlias
+from typing import TypeAlias
 
 
 class Align(Enum):

--- a/src/build123d/build_line.py
+++ b/src/build123d/build_line.py
@@ -79,7 +79,7 @@ class BuildLine(Builder):
 
     def __init__(
         self,
-        workplane: Union[Face, Plane, Location] = Plane.XY,
+        workplane: Face | Plane | Location = Plane.XY,
         mode: Mode = Mode.ADD,
     ):
         self.line: Curve = None
@@ -126,6 +126,6 @@ class BuildLine(Builder):
         """solid() not implemented"""
         raise NotImplementedError("solid() doesn't apply to BuildLine")
 
-    def _add_to_pending(self, *objects: Union[Edge, Face], face_plane: Plane = None):
+    def _add_to_pending(self, *objects: Edge | Face, face_plane: Plane = None):
         """_add_to_pending not implemented"""
         raise NotImplementedError("_add_to_pending doesn't apply to BuildLine")

--- a/src/build123d/build_part.py
+++ b/src/build123d/build_part.py
@@ -79,7 +79,7 @@ class BuildPart(Builder):
 
     def __init__(
         self,
-        *workplanes: Union[Face, Plane, Location],
+        *workplanes: Face | Plane | Location,
         mode: Mode = Mode.ADD,
     ):
         self.joints: dict[str, Joint] = {}
@@ -90,7 +90,7 @@ class BuildPart(Builder):
         self.pending_edges: list[Edge] = []
         super().__init__(*workplanes, mode=mode)
 
-    def _add_to_pending(self, *objects: Union[Edge, Face], face_plane: Plane = None):
+    def _add_to_pending(self, *objects: Edge | Face, face_plane: Plane = None):
         """Add objects to BuildPart pending lists
 
         Args:

--- a/src/build123d/build_sketch.py
+++ b/src/build123d/build_sketch.py
@@ -87,7 +87,7 @@ class BuildSketch(Builder):
 
     def __init__(
         self,
-        *workplanes: Union[Face, Plane, Location],
+        *workplanes: Face | Plane | Location,
         mode: Mode = Mode.ADD,
     ):
         self.mode = mode
@@ -103,7 +103,7 @@ class BuildSketch(Builder):
         """solid() not implemented"""
         raise NotImplementedError("solid() doesn't apply to BuildSketch")
 
-    def consolidate_edges(self) -> Union[Wire, list[Wire]]:
+    def consolidate_edges(self) -> Wire | list[Wire]:
         """Unify pending edges into one or more Wires"""
         wires = Wire.combine(self.pending_edges)
         return wires if len(wires) > 1 else wires[0]

--- a/src/build123d/drafting.py
+++ b/src/build123d/drafting.py
@@ -29,7 +29,9 @@ license:
 from dataclasses import dataclass
 from datetime import date
 from math import copysign, floor, gcd, log2, pi
-from typing import ClassVar, Iterable, Optional, Union
+from typing import ClassVar, Optional, Union
+
+from collections.abc import Iterable
 
 from build123d.build_common import IN, MM
 from build123d.build_enums import (
@@ -112,7 +114,7 @@ class Arrow(BaseSketchObject):
     def __init__(
         self,
         arrow_size: float,
-        shaft_path: Union[Edge, Wire],
+        shaft_path: Edge | Wire,
         shaft_width: float,
         head_at_start: bool = True,
         head_type: HeadType = HeadType.CURVED,
@@ -221,8 +223,8 @@ class Draft:
     def _number_with_units(
         self,
         number: float,
-        tolerance: Union[float, tuple[float, float]] = None,
-        display_units: Optional[bool] = None,
+        tolerance: float | tuple[float, float] = None,
+        display_units: bool | None = None,
     ) -> str:
         """Convert a raw number to a unit of measurement string based on the class settings"""
 
@@ -272,7 +274,7 @@ class Draft:
         return return_value
 
     @staticmethod
-    def _process_path(path: PathDescriptor) -> Union[Edge, Wire]:
+    def _process_path(path: PathDescriptor) -> Edge | Wire:
         """Convert a PathDescriptor into a Edge/Wire"""
         if isinstance(path, (Edge, Wire)):
             processed_path = path
@@ -296,7 +298,7 @@ class Draft:
         label: str,
         line_wire: Wire,
         label_angle: bool,
-        tolerance: Optional[Union[float, tuple[float, float]]],
+        tolerance: float | tuple[float, float] | None,
     ) -> str:
         """Create the str to use as the label text"""
         line_length = line_wire.length
@@ -317,7 +319,7 @@ class Draft:
 
     @staticmethod
     def _sketch_location(
-        path: Union[Edge, Wire], u_value: float, flip: bool = False
+        path: Edge | Wire, u_value: float, flip: bool = False
     ) -> Location:
         """Given a path on Plane.XY, determine the Location for object placement"""
         angle = path.tangent_angle_at(u_value) + int(flip) * 180
@@ -370,7 +372,7 @@ class DimensionLine(BaseSketchObject):
         sketch: Sketch = None,
         label: str = None,
         arrows: tuple[bool, bool] = (True, True),
-        tolerance: Union[float, tuple[float, float]] = None,
+        tolerance: float | tuple[float, float] = None,
         label_angle: bool = False,
         mode: Mode = Mode.ADD,
     ) -> Sketch:
@@ -508,7 +510,7 @@ class ExtensionLine(BaseSketchObject):
         sketch: Sketch = None,
         label: str = None,
         arrows: tuple[bool, bool] = (True, True),
-        tolerance: Union[float, tuple[float, float]] = None,
+        tolerance: float | tuple[float, float] = None,
         label_angle: bool = False,
         project_line: VectorLike = None,
         mode: Mode = Mode.ADD,
@@ -622,7 +624,7 @@ class TechnicalDrawing(BaseSketchObject):
     def __init__(
         self,
         designed_by: str = "build123d",
-        design_date: Optional[date] = None,
+        design_date: date | None = None,
         page_size: PageSize = PageSize.A4,
         title: str = "Title",
         sub_title: str = "Sub Title",

--- a/src/build123d/exporters.py
+++ b/src/build123d/exporters.py
@@ -36,7 +36,9 @@ from copy import copy
 from enum import Enum, auto
 from os import PathLike, fsdecode, fspath
 from pathlib import Path
-from typing import Callable, Iterable, List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
+
+from collections.abc import Callable, Iterable
 
 import ezdxf
 import svgpathtools as PT
@@ -84,7 +86,7 @@ class Drawing:
         look_from: VectorLike = (1, -1, 1),
         look_up: VectorLike = (0, 0, 1),
         with_hidden: bool = True,
-        focus: Union[float, None] = None,
+        focus: float | None = None,
     ):
         # pylint: disable=too-many-locals
         hlr = HLRBRep_Algo()
@@ -506,9 +508,9 @@ class ExportDXF(Export2D):
         self,
         version: str = ezdxf.DXF2013,
         unit: Unit = Unit.MM,
-        color: Optional[ColorIndex] = None,
-        line_weight: Optional[float] = None,
-        line_type: Optional[LineType] = None,
+        color: ColorIndex | None = None,
+        line_weight: float | None = None,
+        line_type: LineType | None = None,
     ):
         self._non_planar_point_count = 0
         if unit not in self._UNITS_LOOKUP:
@@ -538,9 +540,9 @@ class ExportDXF(Export2D):
         self,
         name: str,
         *,
-        color: Optional[ColorIndex] = None,
-        line_weight: Optional[float] = None,
-        line_type: Optional[LineType] = None,
+        color: ColorIndex | None = None,
+        line_weight: float | None = None,
+        line_type: LineType | None = None,
     ) -> Self:
         """add_layer
 
@@ -597,7 +599,7 @@ class ExportDXF(Export2D):
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-    def add_shape(self, shape: Union[Shape, Iterable[Shape]], layer: str = "") -> Self:
+    def add_shape(self, shape: Shape | Iterable[Shape], layer: str = "") -> Self:
         """add_shape
 
         Adds a shape to the specified layer.
@@ -633,7 +635,7 @@ class ExportDXF(Export2D):
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-    def write(self, file_name: Union[PathLike, str, bytes]):
+    def write(self, file_name: PathLike | str | bytes):
         """write
 
         Writes the DXF data to the specified file name.
@@ -651,7 +653,7 @@ class ExportDXF(Export2D):
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-    def _convert_point(self, pt: Union[gp_XYZ, gp_Pnt, gp_Vec, Vector]) -> Vec2:
+    def _convert_point(self, pt: gp_XYZ | gp_Pnt | gp_Vec | Vector) -> Vec2:
         """Create a Vec2 from a gp_Pnt or Vector.
         This method also checks for points z != 0."""
         if isinstance(pt, (gp_XYZ, gp_Pnt, gp_Vec)):
@@ -870,14 +872,14 @@ class ExportSVG(Export2D):
         def __init__(
             self,
             name: str,
-            fill_color: Union[ColorIndex, RGB, Color, None],
-            line_color: Union[ColorIndex, RGB, Color, None],
+            fill_color: ColorIndex | RGB | Color | None,
+            line_color: ColorIndex | RGB | Color | None,
             line_weight: float,
             line_type: LineType,
         ):
             def convert_color(
-                c: Union[ColorIndex, RGB, Color, None],
-            ) -> Union[Color, None]:
+                c: ColorIndex | RGB | Color | None,
+            ) -> Color | None:
                 if isinstance(c, ColorIndex):
                     # The easydxf color indices BLACK and WHITE have the same
                     # value (7), and are both mapped to (255,255,255) by the
@@ -908,11 +910,11 @@ class ExportSVG(Export2D):
         margin: float = 0,
         fit_to_stroke: bool = True,
         precision: int = 6,
-        fill_color: Union[ColorIndex, RGB, Color, None] = None,
-        line_color: Union[ColorIndex, RGB, Color, None] = Export2D.DEFAULT_COLOR_INDEX,
+        fill_color: ColorIndex | RGB | Color | None = None,
+        line_color: ColorIndex | RGB | Color | None = Export2D.DEFAULT_COLOR_INDEX,
         line_weight: float = Export2D.DEFAULT_LINE_WEIGHT,  # in millimeters
         line_type: LineType = Export2D.DEFAULT_LINE_TYPE,
-        dot_length: Union[DotLength, float] = DotLength.INKSCAPE_COMPAT,
+        dot_length: DotLength | float = DotLength.INKSCAPE_COMPAT,
     ):
         if unit not in ExportSVG._UNIT_STRING:
             raise ValueError(
@@ -944,8 +946,8 @@ class ExportSVG(Export2D):
         self,
         name: str,
         *,
-        fill_color: Union[ColorIndex, RGB, Color, None] = None,
-        line_color: Union[ColorIndex, RGB, Color, None] = Export2D.DEFAULT_COLOR_INDEX,
+        fill_color: ColorIndex | RGB | Color | None = None,
+        line_color: ColorIndex | RGB | Color | None = Export2D.DEFAULT_COLOR_INDEX,
         line_weight: float = Export2D.DEFAULT_LINE_WEIGHT,  # in millimeters
         line_type: LineType = Export2D.DEFAULT_LINE_TYPE,
     ) -> Self:
@@ -991,7 +993,7 @@ class ExportSVG(Export2D):
 
     def add_shape(
         self,
-        shape: Union[Shape, Iterable[Shape]],
+        shape: Shape | Iterable[Shape],
         layer: str = "",
         reverse_wires: bool = False,
     ):
@@ -1097,7 +1099,7 @@ class ExportSVG(Export2D):
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     @staticmethod
-    def _wire_edges(wire: Wire, reverse: bool) -> List[Edge]:
+    def _wire_edges(wire: Wire, reverse: bool) -> list[Edge]:
         # edges = []
         # explorer = BRepTools_WireExplorer(wire.wrapped)
         # while explorer.More():
@@ -1136,7 +1138,7 @@ class ExportSVG(Export2D):
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-    def _path_point(self, pt: Union[gp_Pnt, Vector]) -> complex:
+    def _path_point(self, pt: gp_Pnt | Vector) -> complex:
         """Create a complex point from a gp_Pnt or Vector.
         We are using complex because that is what svgpathtools wants.
         This method also checks for points z != 0."""
@@ -1390,7 +1392,7 @@ class ExportSVG(Export2D):
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     def _group_for_layer(self, layer: _Layer, attribs: dict = None) -> ET.Element:
-        def _color_attribs(c: Color) -> Tuple[str, str]:
+        def _color_attribs(c: Color) -> tuple[str, str]:
             if c:
                 (r, g, b, a) = tuple(c)
                 (r, g, b, a) = (int(r * 255), int(g * 255), int(b * 255), round(a, 3))
@@ -1427,7 +1429,7 @@ class ExportSVG(Export2D):
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-    def write(self, path: Union[PathLike, str, bytes]):
+    def write(self, path: PathLike | str | bytes):
         """write
 
         Writes the SVG data to the specified file path.

--- a/src/build123d/exporters3d.py
+++ b/src/build123d/exporters3d.py
@@ -156,7 +156,7 @@ def _create_xde(to_export: Shape, unit: Unit = Unit.MM) -> TDocStd_Document:
 
 def export_brep(
     to_export: Shape,
-    file_path: Union[PathLike, str, bytes, BytesIO],
+    file_path: PathLike | str | bytes | BytesIO,
 ) -> bool:
     """Export this shape to a BREP file
 
@@ -177,7 +177,7 @@ def export_brep(
 
 def export_gltf(
     to_export: Shape,
-    file_path: Union[PathLike, str, bytes],
+    file_path: PathLike | str | bytes,
     unit: Unit = Unit.MM,
     binary: bool = False,
     linear_deflection: float = 0.001,
@@ -255,7 +255,7 @@ def export_gltf(
 
 def export_step(
     to_export: Shape,
-    file_path: Union[PathLike, str, bytes],
+    file_path: PathLike | str | bytes,
     unit: Unit = Unit.MM,
     write_pcurves: bool = True,
     precision_mode: PrecisionMode = PrecisionMode.AVERAGE,
@@ -323,7 +323,7 @@ def export_step(
 
 def export_stl(
     to_export: Shape,
-    file_path: Union[PathLike, str, bytes],
+    file_path: PathLike | str | bytes,
     tolerance: float = 1e-3,
     angular_tolerance: float = 0.1,
     ascii_format: bool = False,

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -42,15 +42,15 @@ import numpy as np
 from math import degrees, pi, radians
 from typing import (
     Any,
-    Iterable,
     List,
     Optional,
-    Sequence,
     Tuple,
     Union,
     overload,
     TypeVar,
 )
+
+from collections.abc import Iterable, Sequence
 
 from OCP.Bnd import Bnd_Box, Bnd_OBB
 from OCP.BRep import BRep_Tool
@@ -165,7 +165,7 @@ class Vector:
         ...
 
     @overload
-    def __init__(self, v: Union[gp_Vec, gp_Pnt, gp_Dir, gp_XYZ]):  # pragma: no cover
+    def __init__(self, v: gp_Vec | gp_Pnt | gp_Dir | gp_XYZ):  # pragma: no cover
         ...
 
     @overload
@@ -429,7 +429,7 @@ class Vector:
         """Vector length operator abs()"""
         return self.length
 
-    def __and__(self: Plane, other: Union[Axis, Location, Plane, VectorLike, "Shape"]):
+    def __and__(self: Plane, other: Axis | Location | Plane | VectorLike | Shape):
         """intersect vector with other &"""
         return self.intersect(other)
 
@@ -506,19 +506,19 @@ class Vector:
         return Vector(self.wrapped.Rotated(axis.wrapped, pi * angle / 180))
 
     @overload
-    def intersect(self, vector: VectorLike) -> Union[Vector, None]:
+    def intersect(self, vector: VectorLike) -> Vector | None:
         """Find intersection of vector and vector"""
 
     @overload
-    def intersect(self, location: Location) -> Union[Vector, None]:
+    def intersect(self, location: Location) -> Vector | None:
         """Find intersection of location and vector"""
 
     @overload
-    def intersect(self, axis: Axis) -> Union[Vector, None]:
+    def intersect(self, axis: Axis) -> Vector | None:
         """Find intersection of axis and vector"""
 
     @overload
-    def intersect(self, plane: Plane) -> Union[Vector, None]:
+    def intersect(self, plane: Plane) -> Vector | None:
         """Find intersection of plane and vector"""
 
     def intersect(self, *args, **kwargs):
@@ -597,7 +597,7 @@ class Axis(metaclass=AxisMeta):
         """Axis: point and direction"""
 
     @overload
-    def __init__(self, edge: "Edge"):  # pragma: no cover
+    def __init__(self, edge: Edge):  # pragma: no cover
         """Axis: start of Edge"""
 
     def __init__(self, *args, **kwargs):
@@ -774,24 +774,24 @@ class Axis(metaclass=AxisMeta):
         """Flip direction operator -"""
         return self.reverse()
 
-    def __and__(self: Plane, other: Union[Axis, Location, Plane, VectorLike, "Shape"]):
+    def __and__(self: Plane, other: Axis | Location | Plane | VectorLike | Shape):
         """intersect vector with other &"""
         return self.intersect(other)
 
     @overload
-    def intersect(self, vector: VectorLike) -> Union[Vector, None]:
+    def intersect(self, vector: VectorLike) -> Vector | None:
         """Find intersection of vector and axis"""
 
     @overload
-    def intersect(self, location: Location) -> Union[Location, None]:
+    def intersect(self, location: Location) -> Location | None:
         """Find intersection of location and axis"""
 
     @overload
-    def intersect(self, axis: Axis) -> Union[Axis, None]:
+    def intersect(self, axis: Axis) -> Axis | None:
         """Find intersection of axis and axis"""
 
     @overload
-    def intersect(self, plane: Plane) -> Union[Axis, None]:
+    def intersect(self, plane: Plane) -> Axis | None:
         """Find intersection of plane and axis"""
 
     def intersect(self, *args, **kwargs):
@@ -891,7 +891,7 @@ class BoundBox:
 
     def add(
         self,
-        obj: Union[tuple[float, float, float], Vector, BoundBox],
+        obj: tuple[float, float, float] | Vector | BoundBox,
         tol: float = None,
     ) -> BoundBox:
         """Returns a modified (expanded) bounding box
@@ -933,7 +933,7 @@ class BoundBox:
         return BoundBox(tmp)
 
     @staticmethod
-    def find_outside_box_2d(bb1: BoundBox, bb2: BoundBox) -> Optional[BoundBox]:
+    def find_outside_box_2d(bb1: BoundBox, bb2: BoundBox) -> BoundBox | None:
         """Compares bounding boxes
 
         Compares bounding boxes. Returns none if neither is inside the other.
@@ -1026,7 +1026,7 @@ class BoundBox:
             and second_box.max.Z < self.max.Z
         )
 
-    def to_align_offset(self, align: Union[Align2DType, Align3DType]) -> Vector:
+    def to_align_offset(self, align: Align2DType | Align3DType) -> Vector:
         """Amount to move object to achieve the desired alignment"""
         return to_align_offset(self.min.to_tuple(), self.max.to_tuple(), align)
 
@@ -1329,7 +1329,7 @@ class Location:
         self,
         translation: VectorLike,
         rotation: RotationLike,
-        ordering: Union[Extrinsic, Intrinsic],
+        ordering: Extrinsic | Intrinsic,
     ):  # pragma: no cover
         """Location with translation with respect to the original location.
         If rotation is not None then the location includes the rotation (see also Rotation class)
@@ -1502,7 +1502,7 @@ class Location:
         """Flip the orientation without changing the position operator -"""
         return Location(-Plane(self))
 
-    def __and__(self: Plane, other: Union[Axis, Location, Plane, VectorLike, "Shape"]):
+    def __and__(self: Plane, other: Axis | Location | Plane | VectorLike | Shape):
         """intersect axis with other &"""
         return self.intersect(other)
 
@@ -1532,8 +1532,8 @@ class Location:
         Returns:
             Location as String
         """
-        position_str = ", ".join((f"{v:.2f}" for v in self.to_tuple()[0]))
-        orientation_str = ", ".join((f"{v:.2f}" for v in self.to_tuple()[1]))
+        position_str = ", ".join(f"{v:.2f}" for v in self.to_tuple()[0])
+        orientation_str = ", ".join(f"{v:.2f}" for v in self.to_tuple()[1])
         return f"(p=({position_str}), o=({orientation_str}))"
 
     def __str__(self):
@@ -1544,24 +1544,24 @@ class Location:
         Returns:
             Location as String
         """
-        position_str = ", ".join((f"{v:.2f}" for v in self.to_tuple()[0]))
-        orientation_str = ", ".join((f"{v:.2f}" for v in self.to_tuple()[1]))
+        position_str = ", ".join(f"{v:.2f}" for v in self.to_tuple()[0])
+        orientation_str = ", ".join(f"{v:.2f}" for v in self.to_tuple()[1])
         return f"Location: (position=({position_str}), orientation=({orientation_str}))"
 
     @overload
-    def intersect(self, vector: VectorLike) -> Union[Vector, None]:
+    def intersect(self, vector: VectorLike) -> Vector | None:
         """Find intersection of vector and location"""
 
     @overload
-    def intersect(self, location: Location) -> Union[Location, None]:
+    def intersect(self, location: Location) -> Location | None:
         """Find intersection of location and location"""
 
     @overload
-    def intersect(self, axis: Axis) -> Union[Location, None]:
+    def intersect(self, axis: Axis) -> Location | None:
         """Find intersection of axis and location"""
 
     @overload
-    def intersect(self, plane: Plane) -> Union[Location, None]:
+    def intersect(self, plane: Plane) -> Location | None:
         """Find intersection of plane and location"""
 
     def intersect(self, *args, **kwargs):
@@ -1641,7 +1641,7 @@ class Rotation(Location):
     def __init__(
         self,
         rotation: RotationLike,
-        ordering: Union[Extrinsic, Intrinsic] == Intrinsic.XYZ,
+        ordering: Extrinsic | Intrinsic == Intrinsic.XYZ,
     ):
         """Subclass of Location used only for object rotation
         ordering is for order of rotations in Intrinsic or Extrinsic enums"""
@@ -1652,7 +1652,7 @@ class Rotation(Location):
         X: float = 0,
         Y: float = 0,
         Z: float = 0,
-        ordering: Union[Extrinsic, Intrinsic] = Intrinsic.XYZ,
+        ordering: Extrinsic | Intrinsic = Intrinsic.XYZ,
     ):
         """Subclass of Location used only for object rotation
         ordering is for order of rotations in Intrinsic or Extrinsic enums"""
@@ -1760,7 +1760,7 @@ class Matrix:
         ...
 
     @overload
-    def __init__(self, matrix: Union[gp_GTrsf, gp_Trsf]) -> None:  # pragma: no cover
+    def __init__(self, matrix: gp_GTrsf | gp_Trsf) -> None:  # pragma: no cover
         ...
 
     @overload
@@ -2016,7 +2016,7 @@ class Plane(metaclass=PlaneMeta):
 
     @overload
     def __init__(
-        self, face: "Face", x_dir: Optional[VectorLike] = None
+        self, face: Face, x_dir: VectorLike | None = None
     ):  # pragma: no cover
         """Return a plane extending the face.
         Note: for non planar face this will return the underlying work plane"""
@@ -2181,8 +2181,8 @@ class Plane(metaclass=PlaneMeta):
         return Plane(self.origin, self.x_dir, -self.z_dir)
 
     def __mul__(
-        self, other: Union[Location, "Shape"]
-    ) -> Union[Plane, List[Plane], "Shape"]:
+        self, other: Location | Shape
+    ) -> Plane | list[Plane] | Shape:
         if isinstance(other, Location):
             result = Plane(self.location * other)
         elif (  # LocationList
@@ -2201,7 +2201,7 @@ class Plane(metaclass=PlaneMeta):
             )
         return result
 
-    def __and__(self: Plane, other: Union[Axis, Location, Plane, VectorLike, "Shape"]):
+    def __and__(self: Plane, other: Axis | Location | Plane | VectorLike | Shape):
         """intersect plane with other &"""
         return self.intersect(other)
 
@@ -2213,9 +2213,9 @@ class Plane(metaclass=PlaneMeta):
         Returns:
             Plane as String
         """
-        origin_str = ", ".join((f"{v:.2f}" for v in self._origin.to_tuple()))
-        x_dir_str = ", ".join((f"{v:.2f}" for v in self.x_dir.to_tuple()))
-        z_dir_str = ", ".join((f"{v:.2f}" for v in self.z_dir.to_tuple()))
+        origin_str = ", ".join(f"{v:.2f}" for v in self._origin.to_tuple())
+        x_dir_str = ", ".join(f"{v:.2f}" for v in self.x_dir.to_tuple())
+        z_dir_str = ", ".join(f"{v:.2f}" for v in self.z_dir.to_tuple())
         return f"Plane(o=({origin_str}), x=({x_dir_str}), z=({z_dir_str}))"
 
     def reverse(self) -> Plane:
@@ -2236,7 +2236,7 @@ class Plane(metaclass=PlaneMeta):
             gp_Ax3(self._origin.to_pnt(), self.z_dir.to_dir(), self.x_dir.to_dir())
         )
 
-    def shift_origin(self, locator: Union[Axis, VectorLike, "Vertex"]) -> Plane:
+    def shift_origin(self, locator: Axis | VectorLike | Vertex) -> Plane:
         """shift plane origin
 
         Creates a new plane with the origin moved within the plane to the point of intersection
@@ -2274,7 +2274,7 @@ class Plane(metaclass=PlaneMeta):
     def rotated(
         self,
         rotation: VectorLike = (0, 0, 0),
-        ordering: Union[Extrinsic, Intrinsic] = None,
+        ordering: Extrinsic | Intrinsic = None,
     ) -> Plane:
         """Returns a copy of this plane, rotated about the specified axes
 
@@ -2366,7 +2366,7 @@ class Plane(metaclass=PlaneMeta):
         return axis
 
     def _to_from_local_coords(
-        self, obj: Union[VectorLike, Any, BoundBox], to_from: bool = True
+        self, obj: VectorLike | Any | BoundBox, to_from: bool = True
     ):
         """_to_from_local_coords
 
@@ -2406,7 +2406,7 @@ class Plane(metaclass=PlaneMeta):
             )
         return return_value
 
-    def to_local_coords(self, obj: Union[VectorLike, Any, BoundBox]):
+    def to_local_coords(self, obj: VectorLike | Any | BoundBox):
         """Reposition the object relative to this plane
 
         Args:
@@ -2419,7 +2419,7 @@ class Plane(metaclass=PlaneMeta):
         """
         return self._to_from_local_coords(obj, True)
 
-    def from_local_coords(self, obj: Union[tuple, Vector, Any, BoundBox]):
+    def from_local_coords(self, obj: tuple | Vector | Any | BoundBox):
         """Reposition the object relative from this plane
 
         Args:
@@ -2442,7 +2442,7 @@ class Plane(metaclass=PlaneMeta):
         return Location(transformation)
 
     def contains(
-        self, obj: Union[VectorLike, Axis], tolerance: float = TOLERANCE
+        self, obj: VectorLike | Axis, tolerance: float = TOLERANCE
     ) -> bool:
         """contains
 
@@ -2467,23 +2467,23 @@ class Plane(metaclass=PlaneMeta):
         return return_value
 
     @overload
-    def intersect(self, vector: VectorLike) -> Union[Vector, None]:
+    def intersect(self, vector: VectorLike) -> Vector | None:
         """Find intersection of vector and plane"""
 
     @overload
-    def intersect(self, location: Location) -> Union[Location, None]:
+    def intersect(self, location: Location) -> Location | None:
         """Find intersection of location and plane"""
 
     @overload
-    def intersect(self, axis: Axis) -> Union[Axis, Vector, None]:
+    def intersect(self, axis: Axis) -> Axis | Vector | None:
         """Find intersection of axis and plane"""
 
     @overload
-    def intersect(self, plane: Plane) -> Union[Axis, None]:
+    def intersect(self, plane: Plane) -> Axis | None:
         """Find intersection of plane and plane"""
 
     @overload
-    def intersect(self, shape: "Shape") -> Union["Shape", None]:
+    def intersect(self, shape: Shape) -> Shape | None:
         """Find intersection of plane and shape"""
 
     def intersect(self, *args, **kwargs):
@@ -2536,8 +2536,8 @@ class Plane(metaclass=PlaneMeta):
 def to_align_offset(
     min_point: VectorLike,
     max_point: VectorLike,
-    align: Union[Align2DType, Align3DType],
-    center: Optional[VectorLike] = None,
+    align: Align2DType | Align3DType,
+    center: VectorLike | None = None,
 ) -> Vector:
     """Amount to move object to achieve the desired alignment"""
     align_offset = []

--- a/src/build123d/importers.py
+++ b/src/build123d/importers.py
@@ -93,7 +93,7 @@ topods_lut = {
 }
 
 
-def import_brep(file_name: Union[PathLike, str, bytes]) -> Shape:
+def import_brep(file_name: PathLike | str | bytes) -> Shape:
     """Import shape from a BREP file
 
     Args:
@@ -116,7 +116,7 @@ def import_brep(file_name: Union[PathLike, str, bytes]) -> Shape:
     return Compound.cast(shape)
 
 
-def import_step(filename: Union[PathLike, str, bytes]) -> Compound:
+def import_step(filename: PathLike | str | bytes) -> Compound:
     """import_step
 
     Extract shapes from a STEP file and return them as a Compound object.
@@ -173,7 +173,7 @@ def import_step(filename: Union[PathLike, str, bytes]) -> Compound:
 
         return shape_color
 
-    def build_assembly(parent_tdf_label: Optional[TDF_Label] = None) -> list[Shape]:
+    def build_assembly(parent_tdf_label: TDF_Label | None = None) -> list[Shape]:
         """Recursively extract object into an assembly"""
         sub_tdf_labels = TDF_LabelSequence()
         if parent_tdf_label is None:
@@ -228,7 +228,7 @@ def import_step(filename: Union[PathLike, str, bytes]) -> Compound:
     return root
 
 
-def import_stl(file_name: Union[PathLike, str, bytes]) -> Face:
+def import_stl(file_name: PathLike | str | bytes) -> Face:
     """import_stl
 
     Extract shape from an STL file and return it as a Face reference object.
@@ -255,7 +255,7 @@ def import_stl(file_name: Union[PathLike, str, bytes]) -> Face:
 
 
 def import_svg_as_buildline_code(
-    file_name: Union[PathLike, str, bytes],
+    file_name: PathLike | str | bytes,
 ) -> tuple[str, str]:
     """translate_to_buildline_code
 
@@ -332,13 +332,13 @@ def import_svg_as_buildline_code(
 
 
 def import_svg(
-    svg_file: Union[str, Path, TextIO],
+    svg_file: str | Path | TextIO,
     *,
     flip_y: bool = True,
     ignore_visibility: bool = False,
     label_by: str = "id",
     is_inkscape_label: bool = False,
-) -> ShapeList[Union[Wire, Face]]:
+) -> ShapeList[Wire | Face]:
     """import_svg
 
     Args:

--- a/src/build123d/joints.py
+++ b/src/build123d/joints.py
@@ -75,8 +75,8 @@ class RigidJoint(Joint):
     def __init__(
         self,
         label: str,
-        to_part: Optional[Union[Solid, Compound]] = None,
-        joint_location: Union[Location, None] = None,
+        to_part: Solid | Compound | None = None,
+        joint_location: Location | None = None,
     ):
         context: BuildPart = BuildPart._get_context(self)
         validate_inputs(context, self)
@@ -244,7 +244,7 @@ class RevoluteJoint(Joint):
     def __init__(
         self,
         label: str,
-        to_part: Union[Solid, Compound] = None,
+        to_part: Solid | Compound = None,
         axis: Axis = Axis.Z,
         angle_reference: VectorLike = None,
         angular_range: tuple[float, float] = (0, 360),
@@ -353,7 +353,7 @@ class LinearJoint(Joint):
     def __init__(
         self,
         label: str,
-        to_part: Union[Solid, Compound] = None,
+        to_part: Solid | Compound = None,
         axis: Axis = Axis.Z,
         linear_range: tuple[float, float] = (0, inf),
     ):
@@ -530,7 +530,7 @@ class CylindricalJoint(Joint):
     def __init__(
         self,
         label: str,
-        to_part: Union[Solid, Compound] = None,
+        to_part: Solid | Compound = None,
         axis: Axis = Axis.Z,
         angle_reference: VectorLike = None,
         linear_range: tuple[float, float] = (0, inf),
@@ -680,8 +680,8 @@ class BallJoint(Joint):
     def __init__(
         self,
         label: str,
-        to_part: Optional[Union[Solid, Compound]] = None,
-        joint_location: Optional[Location] = None,
+        to_part: Solid | Compound | None = None,
+        joint_location: Location | None = None,
         angular_range: tuple[
             tuple[float, float], tuple[float, float], tuple[float, float]
         ] = ((0, 360), (0, 360), (0, 360)),

--- a/src/build123d/jupyter_tools.py
+++ b/src/build123d/jupyter_tools.py
@@ -216,7 +216,7 @@ def display(shape: Any) -> Javascript:
     Returns:
         Javascript: code
     """
-    payload: List[Dict[str, Any]] = []
+    payload: list[dict[str, Any]] = []
 
     if not hasattr(shape, "wrapped"):  # Is a "Shape"
         raise ValueError(f"Type {type(shape)} is not supported")

--- a/src/build123d/mesher.py
+++ b/src/build123d/mesher.py
@@ -89,7 +89,9 @@ import sys
 import uuid
 import warnings
 from os import PathLike, fsdecode
-from typing import Iterable, Union
+from typing import Union
+
+from collections.abc import Iterable
 
 import OCP.TopAbs as ta
 from OCP.BRep import BRep_Tool
@@ -214,7 +216,7 @@ class Mesher:
         name space `build123d`, name equal to the base file name and the type
         as `python`"""
         caller_file = sys._getframe().f_back.f_code.co_filename
-        with open(caller_file, mode="r", encoding="utf-8") as code_file:
+        with open(caller_file, encoding="utf-8") as code_file:
             source_code = code_file.read()  # read whole file to a string
 
         self.add_meta_data(
@@ -354,7 +356,7 @@ class Mesher:
 
     def add_shape(
         self,
-        shape: Union[Shape, Iterable[Shape]],
+        shape: Shape | Iterable[Shape],
         linear_deflection: float = 0.001,
         angular_deflection: float = 0.1,
         mesh_type: MeshType = MeshType.MODEL,
@@ -483,7 +485,7 @@ class Mesher:
 
         return shape_obj
 
-    def read(self, file_name: Union[PathLike, str, bytes]) -> list[Shape]:
+    def read(self, file_name: PathLike | str | bytes) -> list[Shape]:
         """read
 
         Args:
@@ -527,7 +529,7 @@ class Mesher:
 
         return shapes
 
-    def write(self, file_name: Union[PathLike, str, bytes]):
+    def write(self, file_name: PathLike | str | bytes):
         """write
 
         Args:

--- a/src/build123d/objects_curve.py
+++ b/src/build123d/objects_curve.py
@@ -31,7 +31,9 @@ from __future__ import annotations
 import copy
 from math import copysign, cos, radians, sin, sqrt
 from scipy.optimize import minimize
-from typing import Iterable, Union
+from typing import Union
+
+from collections.abc import Iterable
 
 from build123d.build_common import WorkplaneList, flatten_sequence, validate_inputs
 from build123d.build_enums import AngularDirection, GeomType, Keep, LengthMode, Mode
@@ -197,7 +199,7 @@ class DoubleTangentArc(BaseEdgeObject):
         self,
         pnt: VectorLike,
         tangent: VectorLike,
-        other: Union[Curve, Edge, Wire],
+        other: Curve | Edge | Wire,
         keep: Keep = Keep.TOP,
         mode: Mode = Mode.ADD,
     ):
@@ -489,7 +491,7 @@ class FilletPolyline(BaseLineObject):
 
     def __init__(
         self,
-        *pts: Union[VectorLike, Iterable[VectorLike]],
+        *pts: VectorLike | Iterable[VectorLike],
         radius: float,
         close: bool = False,
         mode: Mode = Mode.ADD,
@@ -537,9 +539,9 @@ class FilletPolyline(BaseLineObject):
         for vertex, edges in vertex_to_edges.items():
             if len(edges) != 2:
                 continue
-            other_vertices = set(
+            other_vertices = {
                 ve for e in edges for ve in e.vertices() if ve != vertex
-            )
+            }
             third_edge = Edge.make_line(*[v.to_tuple() for v in other_vertices])
             fillet_face = Face(Wire(edges + [third_edge])).fillet_2d(radius, [vertex])
             fillets.append(fillet_face.edges().filter_by(GeomType.CIRCLE)[0])
@@ -641,7 +643,7 @@ class Line(BaseEdgeObject):
     _applies_to = [BuildLine._tag]
 
     def __init__(
-        self, *pts: Union[VectorLike, Iterable[VectorLike]], mode: Mode = Mode.ADD
+        self, *pts: VectorLike | Iterable[VectorLike], mode: Mode = Mode.ADD
     ):
         pts = flatten_sequence(*pts)
         if len(pts) != 2:
@@ -677,7 +679,7 @@ class IntersectingLine(BaseEdgeObject):
         self,
         start: VectorLike,
         direction: VectorLike,
-        other: Union[Curve, Edge, Wire],
+        other: Curve | Edge | Wire,
         mode: Mode = Mode.ADD,
     ):
         context: BuildLine = BuildLine._get_context(self)
@@ -777,7 +779,7 @@ class Polyline(BaseLineObject):
 
     def __init__(
         self,
-        *pts: Union[VectorLike, Iterable[VectorLike]],
+        *pts: VectorLike | Iterable[VectorLike],
         close: bool = False,
         mode: Mode = Mode.ADD,
     ):
@@ -912,7 +914,7 @@ class Spline(BaseEdgeObject):
 
     def __init__(
         self,
-        *pts: Union[VectorLike, Iterable[VectorLike]],
+        *pts: VectorLike | Iterable[VectorLike],
         tangents: Iterable[VectorLike] = None,
         tangent_scalars: Iterable[float] = None,
         periodic: bool = False,
@@ -972,7 +974,7 @@ class TangentArc(BaseEdgeObject):
 
     def __init__(
         self,
-        *pts: Union[VectorLike, Iterable[VectorLike]],
+        *pts: VectorLike | Iterable[VectorLike],
         tangent: VectorLike,
         tangent_from_first: bool = True,
         mode: Mode = Mode.ADD,
@@ -1010,7 +1012,7 @@ class ThreePointArc(BaseEdgeObject):
     _applies_to = [BuildLine._tag]
 
     def __init__(
-        self, *pts: Union[VectorLike, Iterable[VectorLike]], mode: Mode = Mode.ADD
+        self, *pts: VectorLike | Iterable[VectorLike], mode: Mode = Mode.ADD
     ):
         context: BuildLine = BuildLine._get_context(self)
         validate_inputs(context, self)

--- a/src/build123d/objects_part.py
+++ b/src/build123d/objects_part.py
@@ -55,9 +55,9 @@ class BasePartObject(Part):
 
     def __init__(
         self,
-        part: Union[Part, Solid],
+        part: Part | Solid,
         rotation: RotationLike = (0, 0, 0),
-        align: Union[Align, tuple[Align, Align, Align]] = None,
+        align: Align | tuple[Align, Align, Align] = None,
         mode: Mode = Mode.ADD,
     ):
         if align is not None:
@@ -124,7 +124,7 @@ class Box(BasePartObject):
         width: float,
         height: float,
         rotation: RotationLike = (0, 0, 0),
-        align: Union[Align, tuple[Align, Align, Align]] = (
+        align: Align | tuple[Align, Align, Align] = (
             Align.CENTER,
             Align.CENTER,
             Align.CENTER,
@@ -170,7 +170,7 @@ class Cone(BasePartObject):
         height: float,
         arc_size: float = 360,
         rotation: RotationLike = (0, 0, 0),
-        align: Union[Align, tuple[Align, Align, Align]] = (
+        align: Align | tuple[Align, Align, Align] = (
             Align.CENTER,
             Align.CENTER,
             Align.CENTER,
@@ -322,7 +322,7 @@ class Cylinder(BasePartObject):
         height: float,
         arc_size: float = 360,
         rotation: RotationLike = (0, 0, 0),
-        align: Union[Align, tuple[Align, Align, Align]] = (
+        align: Align | tuple[Align, Align, Align] = (
             Align.CENTER,
             Align.CENTER,
             Align.CENTER,
@@ -419,7 +419,7 @@ class Sphere(BasePartObject):
         arc_size2: float = 90,
         arc_size3: float = 360,
         rotation: RotationLike = (0, 0, 0),
-        align: Union[Align, tuple[Align, Align, Align]] = (
+        align: Align | tuple[Align, Align, Align] = (
             Align.CENTER,
             Align.CENTER,
             Align.CENTER,
@@ -473,7 +473,7 @@ class Torus(BasePartObject):
         minor_end_angle: float = 360,
         major_angle: float = 360,
         rotation: RotationLike = (0, 0, 0),
-        align: Union[Align, tuple[Align, Align, Align]] = (
+        align: Align | tuple[Align, Align, Align] = (
             Align.CENTER,
             Align.CENTER,
             Align.CENTER,
@@ -533,7 +533,7 @@ class Wedge(BasePartObject):
         xmax: float,
         zmax: float,
         rotation: RotationLike = (0, 0, 0),
-        align: Union[Align, tuple[Align, Align, Align]] = (
+        align: Align | tuple[Align, Align, Align] = (
             Align.CENTER,
             Align.CENTER,
             Align.CENTER,

--- a/src/build123d/objects_sketch.py
+++ b/src/build123d/objects_sketch.py
@@ -31,7 +31,9 @@ from __future__ import annotations
 import trianglesolver
 
 from math import cos, degrees, pi, radians, sin, tan
-from typing import Iterable, Union
+from typing import Union
+
+from collections.abc import Iterable
 
 from build123d.build_common import LocationList, flatten_sequence, validate_inputs
 from build123d.build_enums import Align, FontStyle, Mode
@@ -74,9 +76,9 @@ class BaseSketchObject(Sketch):
 
     def __init__(
         self,
-        obj: Union[Compound, Face],
+        obj: Compound | Face,
         rotation: float = 0,
-        align: Union[Align, tuple[Align, Align]] = None,
+        align: Align | tuple[Align, Align] = None,
         mode: Mode = Mode.ADD,
     ):
         if align is not None:
@@ -121,7 +123,7 @@ class Circle(BaseSketchObject):
     def __init__(
         self,
         radius: float,
-        align: Union[Align, tuple[Align, Align]] = (Align.CENTER, Align.CENTER),
+        align: Align | tuple[Align, Align] = (Align.CENTER, Align.CENTER),
         mode: Mode = Mode.ADD,
     ):
         context = BuildSketch._get_context(self)
@@ -155,7 +157,7 @@ class Ellipse(BaseSketchObject):
         x_radius: float,
         y_radius: float,
         rotation: float = 0,
-        align: Union[Align, tuple[Align, Align]] = (Align.CENTER, Align.CENTER),
+        align: Align | tuple[Align, Align] = (Align.CENTER, Align.CENTER),
         mode: Mode = Mode.ADD,
     ):
         context = BuildSketch._get_context(self)
@@ -192,9 +194,9 @@ class Polygon(BaseSketchObject):
 
     def __init__(
         self,
-        *pts: Union[VectorLike, Iterable[VectorLike]],
+        *pts: VectorLike | Iterable[VectorLike],
         rotation: float = 0,
-        align: Union[Align, tuple[Align, Align]] = (Align.CENTER, Align.CENTER),
+        align: Align | tuple[Align, Align] = (Align.CENTER, Align.CENTER),
         mode: Mode = Mode.ADD,
     ):
         context = BuildSketch._get_context(self)
@@ -230,7 +232,7 @@ class Rectangle(BaseSketchObject):
         width: float,
         height: float,
         rotation: float = 0,
-        align: Union[Align, tuple[Align, Align]] = (Align.CENTER, Align.CENTER),
+        align: Align | tuple[Align, Align] = (Align.CENTER, Align.CENTER),
         mode: Mode = Mode.ADD,
     ):
         context = BuildSketch._get_context(self)
@@ -267,7 +269,7 @@ class RectangleRounded(BaseSketchObject):
         height: float,
         radius: float,
         rotation: float = 0,
-        align: Union[Align, tuple[Align, Align]] = (Align.CENTER, Align.CENTER),
+        align: Align | tuple[Align, Align] = (Align.CENTER, Align.CENTER),
         mode: Mode = Mode.ADD,
     ):
         context = BuildSketch._get_context(self)
@@ -374,7 +376,7 @@ class SlotArc(BaseSketchObject):
 
     def __init__(
         self,
-        arc: Union[Edge, Wire],
+        arc: Edge | Wire,
         height: float,
         rotation: float = 0,
         mode: Mode = Mode.ADD,
@@ -508,7 +510,7 @@ class SlotOverall(BaseSketchObject):
         width: float,
         height: float,
         rotation: float = 0,
-        align: Union[Align, tuple[Align, Align]] = (Align.CENTER, Align.CENTER),
+        align: Align | tuple[Align, Align] = (Align.CENTER, Align.CENTER),
         mode: Mode = Mode.ADD,
     ):
         if width <= height:
@@ -566,8 +568,8 @@ class Text(BaseSketchObject):
         font: str = "Arial",
         font_path: str = None,
         font_style: FontStyle = FontStyle.REGULAR,
-        align: Union[Align, tuple[Align, Align]] = (Align.CENTER, Align.CENTER),
-        path: Union[Edge, Wire] = None,
+        align: Align | tuple[Align, Align] = (Align.CENTER, Align.CENTER),
+        path: Edge | Wire = None,
         position_on_path: float = 0.0,
         rotation: float = 0,
         mode: Mode = Mode.ADD,
@@ -628,7 +630,7 @@ class Trapezoid(BaseSketchObject):
         left_side_angle: float,
         right_side_angle: float = None,
         rotation: float = 0,
-        align: Union[Align, tuple[Align, Align]] = (Align.CENTER, Align.CENTER),
+        align: Align | tuple[Align, Align] = (Align.CENTER, Align.CENTER),
         mode: Mode = Mode.ADD,
     ):
         context = BuildSketch._get_context(self)
@@ -714,7 +716,7 @@ class Triangle(BaseSketchObject):
         A: float = None,
         B: float = None,
         C: float = None,
-        align: Union[None, Align, tuple[Align, Align]] = None,
+        align: None | Align | tuple[Align, Align] = None,
         rotation: float = 0,
         mode: Mode = Mode.ADD,
     ):

--- a/src/build123d/operations_generic.py
+++ b/src/build123d/operations_generic.py
@@ -30,7 +30,9 @@ license:
 import copy
 import logging
 from math import radians, tan
-from typing import Union, Iterable
+from typing import Union
+
+from collections.abc import Iterable
 
 from build123d.build_common import (
     Builder,
@@ -81,8 +83,8 @@ AddType = Union[Edge, Wire, Face, Solid, Compound, Builder]
 
 
 def add(
-    objects: Union[AddType, Iterable[AddType]],
-    rotation: Union[float, RotationLike] = None,
+    objects: AddType | Iterable[AddType],
+    rotation: float | RotationLike = None,
     clean: bool = True,
     mode: Mode = Mode.ADD,
 ) -> Compound:
@@ -199,9 +201,9 @@ def add(
 
 
 def bounding_box(
-    objects: Union[Shape, Iterable[Shape]] = None,
+    objects: Shape | Iterable[Shape] = None,
     mode: Mode = Mode.PRIVATE,
-) -> Union[Sketch, Part]:
+) -> Sketch | Part:
     """Generic Operation: Add Bounding Box
 
     Applies to: BuildSketch and BuildPart
@@ -264,12 +266,12 @@ ChamferFilletType = Union[Edge, Vertex]
 
 
 def chamfer(
-    objects: Union[ChamferFilletType, Iterable[ChamferFilletType]],
+    objects: ChamferFilletType | Iterable[ChamferFilletType],
     length: float,
     length2: float = None,
     angle: float = None,
-    reference: Union[Edge, Face] = None,
-) -> Union[Sketch, Part]:
+    reference: Edge | Face = None,
+) -> Sketch | Part:
     """Generic Operation: chamfer
 
     Applies to 2 and 3 dimensional objects.
@@ -385,9 +387,9 @@ def chamfer(
 
 
 def fillet(
-    objects: Union[ChamferFilletType, Iterable[ChamferFilletType]],
+    objects: ChamferFilletType | Iterable[ChamferFilletType],
     radius: float,
-) -> Union[Sketch, Part, Curve]:
+) -> Sketch | Part | Curve:
     """Generic Operation: fillet
 
     Applies to 2 and 3 dimensional objects.
@@ -488,10 +490,10 @@ MirrorType = Union[Edge, Wire, Face, Compound, Curve, Sketch, Part]
 
 
 def mirror(
-    objects: Union[MirrorType, Iterable[MirrorType]] = None,
+    objects: MirrorType | Iterable[MirrorType] = None,
     about: Plane = Plane.XZ,
     mode: Mode = Mode.ADD,
-) -> Union[Curve, Sketch, Part, Compound]:
+) -> Curve | Sketch | Part | Compound:
     """Generic Operation: mirror
 
     Applies to 1, 2, and 3 dimensional objects.
@@ -538,15 +540,15 @@ OffsetType = Union[Edge, Face, Solid, Compound]
 
 
 def offset(
-    objects: Union[OffsetType, Iterable[OffsetType]] = None,
+    objects: OffsetType | Iterable[OffsetType] = None,
     amount: float = 0,
-    openings: Union[Face, list[Face]] = None,
+    openings: Face | list[Face] = None,
     kind: Kind = Kind.ARC,
     side: Side = Side.BOTH,
     closed: bool = True,
     min_edge_length: float = None,
     mode: Mode = Mode.REPLACE,
-) -> Union[Curve, Sketch, Part, Compound]:
+) -> Curve | Sketch | Part | Compound:
     """Generic Operation: offset
 
     Applies to 1, 2, and 3 dimensional objects.
@@ -682,11 +684,11 @@ ProjectType = Union[Edge, Face, Wire, Vector, Vertex]
 
 
 def project(
-    objects: Union[ProjectType, Iterable[ProjectType]] = None,
+    objects: ProjectType | Iterable[ProjectType] = None,
     workplane: Plane = None,
-    target: Union[Solid, Compound, Part] = None,
+    target: Solid | Compound | Part = None,
     mode: Mode = Mode.ADD,
-) -> Union[Curve, Sketch, Compound, ShapeList[Vector]]:
+) -> Curve | Sketch | Compound | ShapeList[Vector]:
     """Generic Operation: project
 
     Applies to 0, 1, and 2 dimensional objects.
@@ -823,10 +825,10 @@ def project(
 
 
 def scale(
-    objects: Union[Shape, Iterable[Shape]] = None,
-    by: Union[float, tuple[float, float, float]] = 1,
+    objects: Shape | Iterable[Shape] = None,
+    by: float | tuple[float, float, float] = 1,
     mode: Mode = Mode.REPLACE,
-) -> Union[Curve, Sketch, Part, Compound]:
+) -> Curve | Sketch | Part | Compound:
     """Generic Operation: scale
 
     Applies to 1, 2, and 3 dimensional objects.
@@ -903,8 +905,8 @@ SplitType = Union[Edge, Wire, Face, Solid]
 
 
 def split(
-    objects: Union[SplitType, Iterable[SplitType]] = None,
-    bisect_by: Union[Plane, Face, Shell] = Plane.XZ,
+    objects: SplitType | Iterable[SplitType] = None,
+    bisect_by: Plane | Face | Shell = Plane.XZ,
     keep: Keep = Keep.TOP,
     mode: Mode = Mode.REPLACE,
 ):
@@ -966,16 +968,16 @@ SweepType = Union[Compound, Edge, Wire, Face, Solid]
 
 
 def sweep(
-    sections: Union[SweepType, Iterable[SweepType]] = None,
-    path: Union[Curve, Edge, Wire, Iterable[Edge]] = None,
+    sections: SweepType | Iterable[SweepType] = None,
+    path: Curve | Edge | Wire | Iterable[Edge] = None,
     multisection: bool = False,
     is_frenet: bool = False,
     transition: Transition = Transition.TRANSFORMED,
     normal: VectorLike = None,
-    binormal: Union[Edge, Wire] = None,
+    binormal: Edge | Wire = None,
     clean: bool = True,
     mode: Mode = Mode.ADD,
-) -> Union[Part, Sketch]:
+) -> Part | Sketch:
     """Generic Operation: sweep
 
     Sweep pending 1D or 2D objects along path.

--- a/src/build123d/operations_part.py
+++ b/src/build123d/operations_part.py
@@ -27,7 +27,9 @@ license:
 """
 
 from __future__ import annotations
-from typing import Union, Iterable
+from typing import Union
+
+from collections.abc import Iterable
 from build123d.build_enums import Mode, Until, Kind, Side
 from build123d.build_part import BuildPart
 from build123d.geometry import Axis, Plane, Vector, VectorLike
@@ -54,11 +56,11 @@ from build123d.build_common import (
 
 
 def extrude(
-    to_extrude: Union[Face, Sketch] = None,
+    to_extrude: Face | Sketch = None,
     amount: float = None,
     dir: VectorLike = None,  # pylint: disable=redefined-builtin
     until: Until = None,
-    target: Union[Compound, Solid] = None,
+    target: Compound | Solid = None,
     both: bool = False,
     taper: float = 0.0,
     clean: bool = True,
@@ -184,7 +186,7 @@ def extrude(
 
 
 def loft(
-    sections: Union[Face, Sketch, Iterable[Union[Vertex, Face, Sketch]]] = None,
+    sections: Face | Sketch | Iterable[Vertex | Face | Sketch] = None,
     ruled: bool = False,
     clean: bool = True,
     mode: Mode = Mode.ADD,
@@ -259,8 +261,8 @@ def loft(
 
 def make_brake_formed(
     thickness: float,
-    station_widths: Union[float, Iterable[float]],
-    line: Union[Edge, Wire, Curve] = None,
+    station_widths: float | Iterable[float],
+    line: Edge | Wire | Curve = None,
     side: Side = Side.LEFT,
     kind: Kind = Kind.ARC,
     clean: bool = True,
@@ -364,8 +366,8 @@ def make_brake_formed(
 
 
 def project_workplane(
-    origin: Union[VectorLike, Vertex],
-    x_dir: Union[VectorLike, Vertex],
+    origin: VectorLike | Vertex,
+    x_dir: VectorLike | Vertex,
     projection_dir: VectorLike,
     distance: float,
 ) -> Plane:
@@ -420,7 +422,7 @@ def project_workplane(
 
 
 def revolve(
-    profiles: Union[Face, Iterable[Face]] = None,
+    profiles: Face | Iterable[Face] = None,
     axis: Axis = Axis.Z,
     revolution_arc: float = 360.0,
     clean: bool = True,
@@ -478,7 +480,7 @@ def revolve(
 
 def section(
     obj: Part = None,
-    section_by: Union[Plane, Iterable[Plane]] = Plane.XZ,
+    section_by: Plane | Iterable[Plane] = Plane.XZ,
     height: float = 0.0,
     clean: bool = True,
     mode: Mode = Mode.PRIVATE,
@@ -540,7 +542,7 @@ def section(
 
 
 def thicken(
-    to_thicken: Union[Face, Sketch] = None,
+    to_thicken: Face | Sketch = None,
     amount: float = None,
     normal_override: VectorLike = None,
     both: bool = False,

--- a/src/build123d/operations_sketch.py
+++ b/src/build123d/operations_sketch.py
@@ -28,7 +28,9 @@ license:
 """
 
 from __future__ import annotations
-from typing import Iterable, Union
+from typing import Union
+
+from collections.abc import Iterable
 from build123d.build_enums import Mode, SortBy
 from build123d.topology import (
     Compound,
@@ -193,7 +195,7 @@ def full_round(
 
 
 def make_face(
-    edges: Union[Edge, Iterable[Edge]] = None, mode: Mode = Mode.ADD
+    edges: Edge | Iterable[Edge] = None, mode: Mode = Mode.ADD
 ) -> Sketch:
     """Sketch Operation: make_face
 
@@ -228,7 +230,7 @@ def make_face(
 
 
 def make_hull(
-    edges: Union[Edge, Iterable[Edge]] = None, mode: Mode = Mode.ADD
+    edges: Edge | Iterable[Edge] = None, mode: Mode = Mode.ADD
 ) -> Sketch:
     """Sketch Operation: make_hull
 
@@ -266,7 +268,7 @@ def make_hull(
 
 
 def trace(
-    lines: Union[Curve, Edge, Wire, Iterable[Union[Curve, Edge, Wire]]] = None,
+    lines: Curve | Edge | Wire | Iterable[Curve | Edge | Wire] = None,
     line_width: float = 1,
     mode: Mode = Mode.ADD,
 ) -> Sketch:

--- a/src/build123d/pack.py
+++ b/src/build123d/pack.py
@@ -12,7 +12,9 @@ desc:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Collection, Optional, cast
+from typing import Optional, cast
+
+from collections.abc import Callable, Collection
 
 from build123d import Location, Shape, Pos
 
@@ -37,8 +39,8 @@ def _pack2d(
         y: float = 0
         w: float = 0
         h: float = 0
-        down: Optional["_Node"] = None
-        right: Optional["_Node"] = None
+        down: _Node | None = None
+        right: _Node | None = None
 
     def find_node(start, w, h):
         if start.used:

--- a/src/build123d/topology/__init__.py
+++ b/src/build123d/topology/__init__.py
@@ -1,4 +1,3 @@
-
 """
 build123d.topology package
 

--- a/src/build123d/topology/composite.py
+++ b/src/build123d/topology/composite.py
@@ -59,7 +59,9 @@ import os
 import sys
 import warnings
 from itertools import combinations
-from typing import Iterable, Iterator, Sequence, Type, Union
+from typing import Type, Union
+
+from collections.abc import Iterable, Iterator, Sequence
 
 import OCP.TopAbs as ta
 from OCP.BRepAlgoAPI import BRepAlgoAPI_Fuse
@@ -238,7 +240,7 @@ class Compound(Mixin3D, Shape[TopoDS_Compound]):
         align: Align | tuple[Align, Align] = (Align.CENTER, Align.CENTER),
         position_on_path: float = 0.0,
         text_path: Edge | Wire | None = None,
-    ) -> "Compound":
+    ) -> Compound:
         """2D Text that optionally follows a path.
 
         The text that is created can be combined as with other sketch features by specifying
@@ -609,14 +611,14 @@ class Compound(Mixin3D, Shape[TopoDS_Compound]):
     def get_type(
         self,
         obj_type: (
-            Type[Vertex]
-            | Type[Edge]
-            | Type[Face]
-            | Type[Shell]
-            | Type[Solid]
-            | Type[Wire]
+            type[Vertex]
+            | type[Edge]
+            | type[Face]
+            | type[Shell]
+            | type[Solid]
+            | type[Wire]
         ),
-    ) -> list[Union[Vertex, Edge, Face, Shell, Solid, Wire]]:
+    ) -> list[Vertex | Edge | Face | Shell | Solid | Wire]:
         """get_type
 
         Extract the objects of the given type from a Compound. Note that this

--- a/src/build123d/topology/one_d.py
+++ b/src/build123d/topology/one_d.py
@@ -56,7 +56,9 @@ import itertools
 import warnings
 from itertools import combinations
 from math import radians, inf, pi, cos, copysign, ceil, floor
-from typing import Iterable, Tuple, Union, overload, TYPE_CHECKING
+from typing import Tuple, Union, overload, TYPE_CHECKING
+
+from collections.abc import Iterable
 
 import OCP.TopAbs as ta
 from OCP.BRep import BRep_Tool
@@ -164,7 +166,9 @@ from build123d.geometry import (
 from numpy import ndarray
 from scipy.optimize import minimize
 from scipy.spatial import ConvexHull
-from typing_extensions import Self, Literal
+from typing_extensions import Self
+
+from typing import Literal
 
 from .shape_core import (
     Shape,
@@ -1536,7 +1540,7 @@ class Edge(Mixin1D, Shape[TopoDS_Edge]):
         cls,
         points: list[VectorLike],
         tol: float = 1e-3,
-        smoothing: Tuple[float, float, float] | None = None,
+        smoothing: tuple[float, float, float] | None = None,
         min_deg: int = 1,
         max_deg: int = 6,
     ) -> Edge:
@@ -2302,7 +2306,7 @@ class Wire(Mixin1D, Shape[TopoDS_Wire]):
 
     @classmethod
     def combine(
-        cls, wires: Iterable[Union[Wire, Edge]], tol: float = 1e-9
+        cls, wires: Iterable[Wire | Edge], tol: float = 1e-9
     ) -> ShapeList[Wire]:
         """combine
 

--- a/src/build123d/topology/shape_core.py
+++ b/src/build123d/topology/shape_core.py
@@ -53,11 +53,8 @@ from abc import ABC, abstractmethod
 from typing import (
     cast as tcast,
     Any,
-    Callable,
     Dict,
     Generic,
-    Iterable,
-    Iterator,
     Optional,
     Protocol,
     SupportsIndex,
@@ -68,6 +65,8 @@ from typing import (
     overload,
     TYPE_CHECKING,
 )
+
+from collections.abc import Callable, Iterable, Iterator
 
 import OCP.GeomAbs as ga
 import OCP.TopAbs as ta
@@ -153,7 +152,9 @@ from build123d.geometry import (
     VectorLike,
     logger,
 )
-from typing_extensions import Self, Literal
+from typing_extensions import Self
+
+from typing import Literal
 from vtkmodules.vtkCommonDataModel import vtkPolyData
 from vtkmodules.vtkFiltersCore import vtkPolyDataNormals, vtkTriangleFilter
 
@@ -226,7 +227,7 @@ class Shape(NodeMixin, Generic[TOPODS]):
         ta.TopAbs_COMPSOLID: TopoDS.CompSolid_s,
     }
 
-    geom_LUT_EDGE: Dict[ga.GeomAbs_CurveType, GeomType] = {
+    geom_LUT_EDGE: dict[ga.GeomAbs_CurveType, GeomType] = {
         ga.GeomAbs_Line: GeomType.LINE,
         ga.GeomAbs_Circle: GeomType.CIRCLE,
         ga.GeomAbs_Ellipse: GeomType.ELLIPSE,
@@ -237,7 +238,7 @@ class Shape(NodeMixin, Generic[TOPODS]):
         ga.GeomAbs_OffsetCurve: GeomType.OFFSET,
         ga.GeomAbs_OtherCurve: GeomType.OTHER,
     }
-    geom_LUT_FACE: Dict[ga.GeomAbs_SurfaceType, GeomType] = {
+    geom_LUT_FACE: dict[ga.GeomAbs_SurfaceType, GeomType] = {
         ga.GeomAbs_Plane: GeomType.PLANE,
         ga.GeomAbs_Cylinder: GeomType.CYLINDER,
         ga.GeomAbs_Cone: GeomType.CONE,
@@ -484,7 +485,7 @@ class Shape(NodeMixin, Generic[TOPODS]):
 
     @classmethod
     @abstractmethod
-    def cast(cls: Type[Self], obj: TopoDS_Shape) -> Self:
+    def cast(cls: type[Self], obj: TopoDS_Shape) -> Self:
         """Returns the right type of wrapper, given a OCCT object"""
 
     @classmethod
@@ -1742,7 +1743,7 @@ class Shape(NodeMixin, Generic[TOPODS]):
 
     def tessellate(
         self, tolerance: float, angular_tolerance: float = 0.1
-    ) -> Tuple[list[Vector], list[Tuple[int, int, int]]]:
+    ) -> tuple[list[Vector], list[tuple[int, int, int]]]:
         """General triangulated approximation"""
         if self.wrapped is None:
             raise ValueError("Cannot tessellate an empty shape")
@@ -1750,7 +1751,7 @@ class Shape(NodeMixin, Generic[TOPODS]):
         self.mesh(tolerance, angular_tolerance)
 
         vertices: list[Vector] = []
-        triangles: list[Tuple[int, int, int]] = []
+        triangles: list[tuple[int, int, int]] = []
         offset = 0
 
         for face in self.faces():

--- a/src/build123d/topology/three_d.py
+++ b/src/build123d/topology/three_d.py
@@ -57,7 +57,9 @@ from __future__ import annotations
 import platform
 import warnings
 from math import radians, cos, tan
-from typing import Iterable, Union, TYPE_CHECKING
+from typing import Union, TYPE_CHECKING
+
+from collections.abc import Iterable
 
 import OCP.TopAbs as ta
 from OCP.BRepAlgoAPI import BRepAlgoAPI_Cut
@@ -219,7 +221,7 @@ class Mixin3D(Shape):
         """
         edge_list = list(edge_list)
         if face:
-            if any((edge for edge in edge_list if edge not in face.edges())):
+            if any(edge for edge in edge_list if edge not in face.edges()):
                 raise ValueError("Some edges are not part of the face")
 
         native_edges = [e.wrapped for e in edge_list]
@@ -264,7 +266,7 @@ class Mixin3D(Shape):
     def dprism(
         self,
         basis: Face | None,
-        bounds: list[Union[Face, Wire]],
+        bounds: list[Face | Wire],
         depth: float | None = None,
         taper: float = 0,
         up_to_face: Face | None = None,
@@ -1042,7 +1044,7 @@ class Solid(Mixin3D, Shape[TopoDS_Solid]):
 
     @classmethod
     def make_loft(
-        cls, objs: Iterable[Union[Vertex, Wire]], ruled: bool = False
+        cls, objs: Iterable[Vertex | Wire], ruled: bool = False
     ) -> Solid:
         """make loft
 
@@ -1277,7 +1279,7 @@ class Solid(Mixin3D, Shape[TopoDS_Solid]):
     @classmethod
     def sweep_multi(
         cls,
-        profiles: Iterable[Union[Wire, Face]],
+        profiles: Iterable[Wire | Face],
         path: Wire | Edge,
         make_solid: bool = True,
         is_frenet: bool = False,

--- a/src/build123d/topology/two_d.py
+++ b/src/build123d/topology/two_d.py
@@ -57,7 +57,9 @@ from __future__ import annotations
 
 import copy
 import warnings
-from typing import Any, Iterable, Sequence, Tuple, Union, overload, TYPE_CHECKING
+from typing import Any, Tuple, Union, overload, TYPE_CHECKING
+
+from collections.abc import Iterable, Sequence
 
 import OCP.TopAbs as ta
 from OCP.BRep import BRep_Tool
@@ -631,7 +633,7 @@ class Face(Mixin2D, Shape[TopoDS_Face]):
         cls,
         points: list[list[VectorLike]],
         tol: float = 1e-2,
-        smoothing: Tuple[float, float, float] | None = None,
+        smoothing: tuple[float, float, float] | None = None,
         min_deg: int = 1,
         max_deg: int = 3,
     ) -> Face:
@@ -1219,7 +1221,7 @@ class Face(Mixin2D, Shape[TopoDS_Face]):
             )
         return self.outer_wire()
 
-    def _uv_bounds(self) -> Tuple[float, float, float, float]:
+    def _uv_bounds(self) -> tuple[float, float, float, float]:
         """Return the u min, u max, v min, v max values"""
         return BRepTools.UVBounds_s(self.wrapped)
 
@@ -1305,7 +1307,7 @@ class Shell(Mixin2D, Shape[TopoDS_Shell]):
 
     @classmethod
     def make_loft(
-        cls, objs: Iterable[Union[Vertex, Wire]], ruled: bool = False
+        cls, objs: Iterable[Vertex | Wire], ruled: bool = False
     ) -> Shell:
         """make loft
 

--- a/src/build123d/topology/utils.py
+++ b/src/build123d/topology/utils.py
@@ -54,7 +54,9 @@ license:
 from __future__ import annotations
 
 from math import radians, sin, cos, isclose
-from typing import Any, Iterable, Union, TYPE_CHECKING
+from typing import Any, Union, TYPE_CHECKING
+
+from collections.abc import Iterable
 
 from OCP.BRep import BRep_Tool
 from OCP.BRepAlgoAPI import (
@@ -136,7 +138,7 @@ def _extrude_topods_shape(obj: TopoDS_Shape, direction: VectorLike) -> TopoDS_Sh
 
 
 def _make_loft(
-    objs: Iterable[Union[Vertex, Wire]],
+    objs: Iterable[Vertex | Wire],
     filled: bool,
     ruled: bool = False,
 ) -> TopoDS_Shape:
@@ -323,8 +325,8 @@ def delta(shapes_one: Iterable[Shape], shapes_two: Iterable[Shape]) -> list[Shap
     """Compare the OCCT objects of each list and return the differences"""
     shapes_one = list(shapes_one)
     shapes_two = list(shapes_two)
-    occt_one = set(shape.wrapped for shape in shapes_one)
-    occt_two = set(shape.wrapped for shape in shapes_two)
+    occt_one = {shape.wrapped for shape in shapes_one}
+    occt_two = {shape.wrapped for shape in shapes_two}
     occt_delta = list(occt_one - occt_two)
 
     all_shapes = []
@@ -421,7 +423,7 @@ def tuplify(obj: Any, dim: int) -> tuple | None:
 def unwrapped_shapetype(obj: Shape) -> TopAbs_ShapeEnum:
     """Return Shape's TopAbs_ShapeEnum"""
     if isinstance(obj.wrapped, TopoDS_Compound):
-        shapetypes = set(shapetype(o.wrapped) for o in obj)
+        shapetypes = {shapetype(o.wrapped) for o in obj}
         if len(shapetypes) == 1:
             result = shapetypes.pop()
         else:

--- a/src/build123d/topology/zero_d.py
+++ b/src/build123d/topology/zero_d.py
@@ -54,7 +54,9 @@ license:
 from __future__ import annotations
 
 import itertools
-from typing import Iterable, overload, TYPE_CHECKING
+from typing import overload, TYPE_CHECKING
+
+from collections.abc import Iterable
 
 import OCP.TopAbs as ta
 from OCP.BRep import BRep_Tool


### PR DESCRIPTION
Most of the changes are related to eliminating the use of Union, but there are also some changes to other things like string literal types and some changed imports as well. The changes were generated by the pyupgrade package.