### PR TITLE
Minimal changes to support OCP >= 7.8 in gumy/build123d@ocp781

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "cadquery-ocp >= 7.7.0",
+    "cadquery-ocp >= 7.8.1",
     "typing_extensions >= 4.6.0, <5",
     "numpy >= 2, <3",
     "svgpathtools >= 1.5.1, <2",


### PR DESCRIPTION
OCCT/OCP 7.8+ has some changes to the hashing functionality, this PR makes these changes and also changes the necessary version to `cadquery-ocp >= 7.8.1` 

As of the writing of this post, `cadquery-ocp >= 7.8.1` is NOT released on pypi https://pypi.org/project/cadquery-ocp/#history which means that users that wish to test this must manually install an appropriate wheel from one of the appropriate sources. It also means that all tests on this new branch will fail currently.

such as here:
https://github.com/CadQuery/ocp-build-system/actions

note that this should be treated as alpha, broken functionality is possible