### PR TITLE
Test and fix for exporting small arcs to SVG.

### DIFF
--- a/src/build123d/exporters.py
+++ b/src/build123d/exporters.py
@@ -36,6 +36,7 @@ from copy import copy
 from enum import Enum, auto
 from os import PathLike, fsdecode
 from typing import Any, TypeAlias
+from warnings import warn
 
 from collections.abc import Callable, Iterable
 
@@ -1196,6 +1197,12 @@ class ExportSVG(Export2D):
 
     def _circle_segments(self, edge: Edge, reverse: bool) -> list[PathSegment]:
         # pylint: disable=too-many-locals
+        if edge.length < 1e-6:
+            warn(
+                "Skipping arc that is too small to export safely (length < 1e-6).",
+                stacklevel=7,
+            )
+            return []
         curve = edge.geom_adaptor()
         circle = curve.Circle()
         radius = circle.Radius()
@@ -1242,6 +1249,12 @@ class ExportSVG(Export2D):
 
     def _ellipse_segments(self, edge: Edge, reverse: bool) -> list[PathSegment]:
         # pylint: disable=too-many-locals
+        if edge.length < 1e-6:
+            warn(
+                "Skipping ellipse that is too small to export safely (length < 1e-6).",
+                stacklevel=7,
+            )
+            return []
         curve = edge.geom_adaptor()
         ellipse = curve.Ellipse()
         minor_radius = ellipse.MinorRadius()

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -29,6 +29,7 @@ from build123d import (
     add,
     mirror,
     section,
+    ThreePointArc,
 )
 from build123d.exporters import ExportSVG, ExportDXF, Drawing, LineType
 
@@ -172,6 +173,24 @@ class ExportersTestCase(unittest.TestCase):
         )
         svg.add_shape(sketch)
         svg.write("test-colors.svg")
+
+    def test_svg_small_arc(self):
+        pnts = ((0, 0), (0, 0.000001), (0.000001, 0))
+        small_arc = ThreePointArc(pnts).scale(0.01)
+        with self.assertWarns(UserWarning):
+            svg_exporter = ExportSVG()
+            segments = svg_exporter._circle_segments(small_arc.edges()[0], False)
+            self.assertEqual(len(segments), 0, "Small arc should produce no segments")
+
+    def test_svg_small_ellipse(self):
+        pnts = ((0, 0), (0, 0.000001), (0.000002, 0))
+        small_ellipse = ThreePointArc(pnts).scale(0.01)
+        with self.assertWarns(UserWarning):
+            svg_exporter = ExportSVG()
+            segments = svg_exporter._ellipse_segments(small_ellipse.edges()[0], False)
+            self.assertEqual(
+                len(segments), 0, "Small ellipse should produce no segments"
+            )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Small arcs and ellipses did not export properly to SVG.
Code has been added to ignore arcs and ellipses smaller than can safely be exported.
Tests have also been added.