### PR TITLE
Upgrade build123d to OCP>=7.8

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -9,7 +9,8 @@ jobs:
         python-version: [
           "3.10",
           # "3.11",
-          "3.12",
+          # "3.12",
+          "3.13",
           ]
 
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,8 @@ jobs:
         python-version: [
           "3.10",
           # "3.11",
-          "3.12",
+          # "3.12",
+          "3.13",
           ]
         os: [macos-13, macos-14, ubuntu-latest, windows-latest]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "cadquery-ocp >= 7.7.0",
+    "cadquery-ocp >= 7.8.1",
     "typing_extensions >= 4.6.0, <5",
     "numpy >= 2, <3",
     "svgpathtools >= 1.5.1, <2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
 ]
 description = "A python CAD programming library"
 readme = "README.md"
-requires-python = ">= 3.10, < 3.13"
+requires-python = ">= 3.10, < 3.14"
 keywords = [
     "3d models",
     "3d printing",
@@ -61,5 +61,5 @@ exclude = ["build123d._dev"]
 write_to = "src/build123d/_version.py"
 
 [tool.black]
-target-version = ["py310", "py311", "py312"]
+target-version = ["py310", "py311", "py312", "py313"]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,16 +35,16 @@ classifiers = [
 ]
 
 dependencies = [
-    "cadquery-ocp >= 7.8.1",
-    "typing_extensions >= 4.6.0, <5",
-    "numpy >= 2, <3",
-    "svgpathtools >= 1.5.1, <2",
-    "anytree >= 2.8.0, <3",
+    "cadquery-ocp >= 7.8.0, < 7.9.0",
+    "typing_extensions >= 4.6.0, < 5",
+    "numpy >= 2, < 3",
+    "svgpathtools >= 1.5.1, < 2",
+    "anytree >= 2.8.0, < 3",
     "ezdxf >= 1.1.0, < 2",
-    "ipython >= 8.0.0, <9",
+    "ipython >= 8.0.0, < 9",
     "py-lib3mf >= 2.3.1",
-    "ocpsvg",
-    "trianglesolver"
+    "ocpsvg >= 0.4",
+    "trianglesolver",
 ]
 
 [project.urls]

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -3559,7 +3559,7 @@ class TestShape(DirectApiTestCase):
         with self.assertRaises(ValueError):
             empty.geom_type
         self.assertIs(empty, empty.fix())
-        self.assertEqual(empty.hash_code(), 0)
+        self.assertEqual(hash(empty), 0)
         self.assertFalse(empty.is_same(Solid()))
         self.assertFalse(empty.is_equal(Solid()))
         self.assertTrue(empty.is_valid())


### PR DESCRIPTION
Keeping as draft until release of ocpsvg>=0.4 (will edit pyproject.toml at that point).

This PR includes minimal changes to the hash functionality related to changes in the OCCT 7.8 API.