### PR TITLE
feat: create mesh in fewer iterations

### DIFF
--- a/tests/test_mesher.py
+++ b/tests/test_mesher.py
@@ -2,6 +2,7 @@ import unittest, uuid
 from packaging.specifiers import SpecifierSet
 from pathlib import Path
 from os import fsdecode, fsencode
+import time
 
 import pytest
 
@@ -16,6 +17,19 @@ from build123d.topology import Compound, Solid
 from build123d.geometry import Axis, Color, Location, Vector, VectorLike
 from build123d.mesher import Mesher
 
+class InternalApiBenchmark(unittest.TestCase):
+    def test_create_3mf_mesh(self):
+        start = time.perf_counter()
+        for i in [100, 1000, 10000, 100000]:
+            vertices = [(float(i), 0.0, 0.0) for i in range(i)]
+            triangles = [[i, i+1, i+2] for i in range(0, i-3, 3)] 
+            start = time.perf_counter()
+            Mesher()._create_3mf_mesh(vertices, triangles)
+            runtime = time.perf_counter() - start
+            print(f"| {i} | {runtime:.3f} |")
+        final_runtime = time.perf_counter() - start
+        max_runtime = 1.0
+        self.assertLessEqual(final_runtime, max_runtime, f"All meshes took {final_runtime:.3f}s > {max_runtime}s")
 
 class DirectApiTestCase(unittest.TestCase):
     def assertTupleAlmostEquals(


### PR DESCRIPTION
Hi @gumyr thank you for this awesome library! 

this PR includes some small changes to the meshing logic that greatly improve the export speed for a couple of toy projects I'm working on (300K+ vertices), and wanted to share it as it may be helpful to others.

with change

| Number of vertices | Time (s) |
|-|-|
| 100 | 0.003 |
| 1000 | 0.002 |
| 10000 | 0.014 |
| 100000 | 0.215 |

without change

| Number of vertices | Time (s) |
|-|-|
| 100 | 0.004 |
| 1000 | 0.007 |
| 10000 | 0.509 |
| 100000 | 58.602 |


additional this PR adds a small test to ensure that `100K` vertices always take less than 1 second.

```bash
pytest tests/test_mesher.py -v
# tests/test_mesher.py::InternalApiBenchmark::test_create_3mf_mesh PASSED
```

Please let me know if I should make any changes, and thanks again! 🙏