### PR TITLE
pyproject.toml -> add optional dependencies

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,14 @@ build:
 sphinx:
   configuration: docs/conf.py
 
-# Explicitly set the version of Python and its requirements
 python:
   install:
-    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+
+# Explicitly set the version of Python and its requirements
+# python:
+#   install:
+#     - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+# TODO: delete this file as it is no longer used to build the docs
 # Defining the exact version will make sure things don't break
 sphinx==5.3.0
 sphinx_rtd_theme>=0.5.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,43 @@ dependencies = [
 "Documentation" = "https://build123d.readthedocs.io/en/latest/index.html"
 "Bug Tracker" = "https://github.com/gumyr/build123d/issues"
 
+[project.optional-dependencies]
+# enable the optional ocp_vscode visualization package
+ocp_vscode = [
+    "ocp_vscode",
+]
+
+# development dependencies
+development = [
+    "wheel",
+    "pytest",
+    "pytest-cov",
+    "pylint",
+    "mypy",
+    "black",
+]
+
+# dependency to run the pytest benchmarks
+benchmark = [
+    "pytest-benchmark",
+]
+
+# dependencies to build the docs
+docs = [
+    "sphinx",
+    "sphinx-design",
+    "sphinx-copybutton",
+    "sphinx-hoverxref",
+]
+
+# all dependencies
+all = [
+    "build123d[ocp_vscode]",
+    "build123d[development]",
+    "build123d[benchmark]",
+    "build123d[docs]",
+]
+
 [tool.setuptools.packages.find]
 where = ["src"]
 # exclude build123d._dev from wheels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,10 +75,12 @@ benchmark = [
 
 # dependencies to build the docs
 docs = [
-    "sphinx",
+    "sphinx==8.1.3", # pin for stability of docs builds
     "sphinx-design",
     "sphinx-copybutton",
     "sphinx-hoverxref",
+    "sphinx-rtd-theme",
+    "sphinx_autodoc_typehints",
 ]
 
 # all dependencies


### PR DESCRIPTION
Thanks to @bernhard-42 some version of VTK is now available for all python versions (py310 through py313). For this reason it does not currently make sense to drop support for `jupyter_tools.display` which depends on VTK until a suitable replacement can be made.

This PR is a simplified version of PR https://github.com/gumyr/build123d/pull/820 which made more changes related to VTK.

This PR will allow one to install e.g. `pip install build123d[ocp_vscode]` or `pip install build123d[all]` to install all optional dependencies.