### PR TITLE
Move new mesher benchmark to `test_benchmarks.py`

### DIFF
--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,10 +1,12 @@
 import pytest
 import importlib
 from math import sqrt
+import time
 from build123d import *
 
 
 pytest_benchmark = pytest.importorskip("pytest_benchmark")
+
 
 def test_ppp_0101(benchmark):
     def model():
@@ -616,8 +618,10 @@ def test_ttt_23_02_02(benchmark):
 
     benchmark(model)
 
+
 # def test_ttt_23_T_24(benchmark):
 # excluding because it requires sympy
+
 
 def test_ttt_24_SPO_06(benchmark):
     def model():
@@ -675,3 +679,17 @@ def test_ttt_24_SPO_06(benchmark):
         assert p.part.scale(IN).volume * densa / LB == pytest.approx(3.92, 0.03)
 
     benchmark(model)
+
+
+@pytest.mark.parametrize("test_input", [100, 1000, 10000, 100000])
+def test_mesher_benchmark(benchmark, test_input):
+    # in the 100_000 case test should take on the order of 0.2 seconds
+    # but usually less than 1 second
+    def test_create_3mf_mesh(i):
+        vertices = [(float(i), 0.0, 0.0) for i in range(i)]
+        triangles = [[i, i + 1, i + 2] for i in range(0, i - 3, 3)]
+        mesher = Mesher()._create_3mf_mesh(vertices, triangles)
+        assert len(mesher[0]) == i
+        assert len(mesher[1]) == int(i / 3)
+
+    benchmark(test_create_3mf_mesh, test_input)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,7 +1,5 @@
 import pytest
-import importlib
 from math import sqrt
-import time
 from build123d import *
 
 

--- a/tests/test_mesher.py
+++ b/tests/test_mesher.py
@@ -17,19 +17,6 @@ from build123d.topology import Compound, Solid
 from build123d.geometry import Axis, Color, Location, Vector, VectorLike
 from build123d.mesher import Mesher
 
-class InternalApiBenchmark(unittest.TestCase):
-    def test_create_3mf_mesh(self):
-        start = time.perf_counter()
-        for i in [100, 1000, 10000, 100000]:
-            vertices = [(float(i), 0.0, 0.0) for i in range(i)]
-            triangles = [[i, i+1, i+2] for i in range(0, i-3, 3)] 
-            start = time.perf_counter()
-            Mesher()._create_3mf_mesh(vertices, triangles)
-            runtime = time.perf_counter() - start
-            print(f"| {i} | {runtime:.3f} |")
-        final_runtime = time.perf_counter() - start
-        max_runtime = 1.0
-        self.assertLessEqual(final_runtime, max_runtime, f"All meshes took {final_runtime:.3f}s > {max_runtime}s")
 
 class DirectApiTestCase(unittest.TestCase):
     def assertTupleAlmostEquals(


### PR DESCRIPTION
Per the recent PR https://github.com/gumyr/build123d/pull/868 we have already observed a test failure on CI since the free github runners can be pretty slow. I decided to move a simplified version of this test to the `tests/test_benchmarks.py` file and importantly I eliminated the performance assertion. Instead the benchmarks workflow will print the benchmark results to stdout during CI.

CC: @drbh 