### PR TITLE
Change _topods_entities

### DIFF
--- a/src/build123d/topology/shape_core.py
+++ b/src/build123d/topology/shape_core.py
@@ -117,6 +117,7 @@ from OCP.TopExp import TopExp, TopExp_Explorer
 from OCP.TopLoc import TopLoc_Location
 from OCP.TopTools import (
     TopTools_IndexedDataMapOfShapeListOfShape,
+    TopTools_IndexedMapOfShape,
     TopTools_ListOfShape,
     TopTools_SequenceOfShape,
 )
@@ -2833,16 +2834,10 @@ def _sew_topods_faces(faces: Iterable[TopoDS_Face]) -> TopoDS_Shape:
 
 def _topods_entities(shape: TopoDS_Shape, topo_type: Shapes) -> list[TopoDS_Shape]:
     """Return the TopoDS_Shapes of topo_type from this TopoDS_Shape"""
-    out = {}  # using dict to prevent duplicates
+    shape_set = TopTools_IndexedMapOfShape()
+    TopExp.MapShapes_s(shape, Shape.inverse_shape_LUT[topo_type], shape_set)
 
-    explorer = TopExp_Explorer(shape, Shape.inverse_shape_LUT[topo_type])
-
-    while explorer.More():
-        item = explorer.Current()
-        out[hash(item)] = item  # needed to avoid pseudo-duplicate entities
-        explorer.Next()
-
-    return list(out.values())
+    return shape_set
 
 
 def _topods_face_normal_at(face: TopoDS_Face, surface_point: gp_Pnt) -> Vector:

--- a/src/build123d/topology/shape_core.py
+++ b/src/build123d/topology/shape_core.py
@@ -2836,8 +2836,7 @@ def _topods_entities(shape: TopoDS_Shape, topo_type: Shapes) -> list[TopoDS_Shap
     """Return the TopoDS_Shapes of topo_type from this TopoDS_Shape"""
     shape_set = TopTools_IndexedMapOfShape()
     TopExp.MapShapes_s(shape, Shape.inverse_shape_LUT[topo_type], shape_set)
-
-    return shape_set
+    return [shape_set.FindKey(i) for i in range(1, shape_set.Size() + 1)]
 
 
 def _topods_face_normal_at(face: TopoDS_Face, surface_point: gp_Pnt) -> Vector:

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -2417,8 +2417,8 @@ class TestMixin1D(DirectApiTestCase):
     def test_is_forward(self):
         plate = Box(10, 10, 1) - Cylinder(1, 1)
         hole_edges = plate.edges().filter_by(GeomType.CIRCLE)
-        self.assertTrue(hole_edges.sort_by(Axis.Z)[-1].is_forward)
-        self.assertFalse(hole_edges.sort_by(Axis.Z)[0].is_forward)
+        self.assertTrue(hole_edges.sort_by(Axis.Z)[0].is_forward)
+        self.assertFalse(hole_edges.sort_by(Axis.Z)[-1].is_forward)
 
     def test_offset_2d(self):
         base_wire = Wire.make_polygon([(0, 0), (1, 0), (1, 1)], close=False)


### PR DESCRIPTION
Preliminary testing show the new version has slightly better performance. According to several sources the returned order when using `TopTools_IndexedMapOfShape` and `TopExp.MapShapes_s` is perfectly repeatable -- unlike the existing version. I believe the one test that was failing is a result of the topology being explored in a different order, which according to what I have read, can affect the forward/reverse properties of TopoDS shapes.

I still would like a MacOS arm64 user to test this and confirm performance is not significantly worse (the macos github runners have extremely variable performance). Opening as a draft PR for now as a result of this uncertainty.