### PR TITLE
use `BRep_Builder` for single face shell

### DIFF
--- a/src/build123d/topology/two_d.py
+++ b/src/build123d/topology/two_d.py
@@ -62,7 +62,7 @@ from typing import Any, Tuple, Union, overload, TYPE_CHECKING
 from collections.abc import Iterable, Sequence
 
 import OCP.TopAbs as ta
-from OCP.BRep import BRep_Tool
+from OCP.BRep import BRep_Tool, BRep_Builder
 from OCP.BRepAdaptor import BRepAdaptor_Surface
 from OCP.BRepAlgo import BRepAlgo
 from OCP.BRepAlgoAPI import BRepAlgoAPI_Common
@@ -1263,10 +1263,12 @@ class Shell(Mixin2D, Shape[TopoDS_Shell]):
             obj = obj_list[0]
 
         if isinstance(obj, Face):
-            builder = BRepBuilderAPI_MakeShell(
-                BRepAdaptor_Surface(obj.wrapped).Surface().Surface()
-            )
-            obj = builder.Shape()
+            assert isinstance(obj.wrapped, TopoDS_Face)
+            builder = BRep_Builder()
+            shell = TopoDS_Shell()
+            builder.MakeShell(shell)
+            builder.Add(shell, obj.wrapped)
+            obj = shell
         elif isinstance(obj, Iterable):
             obj = _sew_topods_faces([f.wrapped for f in obj])
 

--- a/tests/test_direct_api.py
+++ b/tests/test_direct_api.py
@@ -4019,6 +4019,11 @@ class TestShells(DirectApiTestCase):
         box_shell = Shell(box_faces)
         self.assertTrue(box_shell.is_valid())
 
+    def test_shell_init_single_face(self):
+        face = Solid.make_cone(1, 0, 2).faces().filter_by(GeomType.CONE).first
+        shell = Shell(face)
+        self.assertTrue(shell.is_valid())
+
     def test_center(self):
         box_faces = Solid.make_box(1, 1, 1).faces()
         box_shell = Shell(box_faces)


### PR DESCRIPTION
Tried making a shell from the single curved face of a cone, got segfault from `BRepBuilderAPI_MakeShell`. `BRep_Builder` seems to work fine in that case.
I'm not sure this is a 100% reliable solution but according to the tests it's not worse.