### PR TITLE
pyproject.toml -> add optional `cadquery-ocp-stubs` to [development] optional extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "cadquery-ocp >= 7.8.0, < 7.9.0",
+    "cadquery-ocp >= 7.8, < 7.9",
     "typing_extensions >= 4.6.0, < 5",
     "numpy >= 2, < 3",
     "svgpathtools >= 1.5.1, < 2",
@@ -60,6 +60,7 @@ ocp_vscode = [
 
 # development dependencies
 development = [
+    "cadquery-ocp-stubs >= 7.8, < 7.9",
     "wheel",
     "pytest",
     "pytest-cov",


### PR DESCRIPTION
Please review version pin too. Tests currently fail because this package does not yet exist on PyPI, therefore opening as a draft PR for now.

Also simplified version pin for `cadquery-ocp`