### PR TITLE
Move `cadquery-ocp-stubs` from [development] to new [stubs] and exclude from [all] (optional dependencies)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -17,6 +17,9 @@ ignore_missing_imports = True
 [mypy-OCP.*]
 ignore_missing_imports = True
 
+[mypy-OCP-stubs.*]
+ignore_missing_imports = True
+
 [mypy-ocpsvg.*]
 ignore_missing_imports = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -17,7 +17,7 @@ ignore_missing_imports = True
 [mypy-OCP.*]
 ignore_missing_imports = True
 
-[mypy-OCP-stubs.*]
+[mypy-ocp-stubs.*]
 ignore_missing_imports = True
 
 [mypy-ocpsvg.*]

--- a/mypy.ini
+++ b/mypy.ini
@@ -20,9 +20,6 @@ ignore_missing_imports = True
 [mypy-OCP.*]
 ignore_missing_imports = True
 
-[mypy-ocp-stubs.*]
-ignore_missing_imports = True
-
 [mypy-ocpsvg.*]
 ignore_missing_imports = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,13 +60,17 @@ ocp_vscode = [
 
 # development dependencies
 development = [
-    "cadquery-ocp-stubs >= 7.8, < 7.9",
     "wheel",
     "pytest",
     "pytest-cov",
     "pylint",
     "mypy",
     "black",
+]
+
+# typing stubs for the OCP CAD kernel
+stubs = [
+    "cadquery-ocp-stubs >= 7.8, < 7.9",
 ]
 
 # dependency to run the pytest benchmarks
@@ -90,6 +94,7 @@ all = [
     "build123d[development]",
     "build123d[benchmark]",
     "build123d[docs]",
+    # "build123d[stubs]", # excluded for now as mypy fails
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Also eliminated changes to `mypy.ini` that attempted to exclude the pyi files from `cadquery-ocp-stubs`