### PR TITLE
allow to filter and group by property

### DIFF
--- a/src/build123d/topology/shape_core.py
+++ b/src/build123d/topology/shape_core.py
@@ -2447,7 +2447,10 @@ class ShapeList(list[T]):
         if callable(filter_by):
             predicate = filter_by
         elif isinstance(filter_by, property):
-            predicate = filter_by.__get__
+
+            def predicate(obj):
+                return filter_by.__get__(obj)
+
         elif isinstance(filter_by, Axis):
             predicate = axis_parallel_predicate(filter_by, tolerance=tolerance)
         elif isinstance(filter_by, Plane):

--- a/src/build123d/topology/shape_core.py
+++ b/src/build123d/topology/shape_core.py
@@ -2351,7 +2351,7 @@ class ShapeList(list[T]):
 
     def filter_by(
         self,
-        filter_by: ShapePredicate | Axis | Plane | GeomType,
+        filter_by: ShapePredicate | Axis | Plane | GeomType | property,
         reverse: bool = False,
         tolerance: float = 1e-5,
     ) -> ShapeList[T]:
@@ -2446,6 +2446,8 @@ class ShapeList(list[T]):
         # convert input to callable predicate
         if callable(filter_by):
             predicate = filter_by
+        elif isinstance(filter_by, property):
+            predicate = filter_by.__get__
         elif isinstance(filter_by, Axis):
             predicate = axis_parallel_predicate(filter_by, tolerance=tolerance)
         elif isinstance(filter_by, Plane):
@@ -2524,7 +2526,9 @@ class ShapeList(list[T]):
 
     def group_by(
         self,
-        group_by: Callable[[Shape], K] | Axis | Edge | Wire | SortBy = Axis.Z,
+        group_by: (
+            Callable[[Shape], K] | Axis | Edge | Wire | SortBy | property
+        ) = Axis.Z,
         reverse=False,
         tol_digits=6,
     ) -> GroupBy[T, K]:
@@ -2593,6 +2597,9 @@ class ShapeList(list[T]):
 
         elif callable(group_by):
             key_f = group_by
+
+        elif isinstance(group_by, property):
+            key_f = group_by.__get__
 
         else:
             raise ValueError(f"Unsupported group_by function: {group_by}")

--- a/src/build123d/topology/shape_core.py
+++ b/src/build123d/topology/shape_core.py
@@ -2635,7 +2635,7 @@ class ShapeList(list[T]):
 
     def sort_by(
         self,
-        sort_by: Axis | Callable[[T], K] | Edge | Wire | SortBy = Axis.Z,
+        sort_by: Axis | Callable[[T], K] | Edge | Wire | SortBy | property = Axis.Z,
         reverse: bool = False,
     ) -> ShapeList[T]:
         """sort by
@@ -2660,6 +2660,9 @@ class ShapeList(list[T]):
         if callable(sort_by):
             # If a callable is provided, use it directly as the key
             objects = sorted(self, key=sort_by, reverse=reverse)
+
+        elif isinstance(sort_by, property):
+            objects = sorted(self, key=sort_by.__get__, reverse=reverse)
 
         elif isinstance(sort_by, Axis):
             if sort_by.wrapped is None:

--- a/tests/test_direct_api/test_shape_list.py
+++ b/tests/test_direct_api/test_shape_list.py
@@ -89,6 +89,12 @@ class TestShapeList(unittest.TestCase):
         self.assertAlmostEqual(smallest.area, math.pi * 1**2, 5)
         self.assertAlmostEqual(largest.area, math.pi * 2**2, 5)
 
+    def test_sort_by_property(self):
+        box1 = Box(2, 2, 2)
+        box2 = Box(2, 2, 2).translate((1, 1, 1))
+        assert len((box1 + box2).edges().filter_by(Edge.is_interior)) == 6
+        assert len((box1 - box2).edges().filter_by(Edge.is_interior)) == 3
+
     def test_sort_by_invalid(self):
         with self.assertRaises(ValueError):
             Solid.make_box(1, 1, 1).faces().sort_by(">Z")
@@ -186,6 +192,17 @@ class TestShapeList(unittest.TestCase):
         result = shapelist.group_by(lambda shape: shape.label)
 
         self.assertEqual([len(group) for group in result], [1, 3, 2])
+
+    def test_group_by_property(self):
+        box1 = Box(2, 2, 2)
+        box2 = Box(2, 2, 2).translate((1, 1, 1))
+        g1 = (box1 + box2).edges().group_by(Edge.is_interior)
+        assert len(g1.group(True)) == 6
+        assert len(g1.group(False)) == 24
+
+        g2 = (box1 - box2).edges().group_by(Edge.is_interior)
+        assert len(g2.group(True)) == 3
+        assert len(g2.group(False)) == 18
 
     def test_group_by_retrieve_groups(self):
         boxesA = [Solid.make_box(1, 1, 1) for _ in range(3)]

--- a/tests/test_direct_api/test_shape_list.py
+++ b/tests/test_direct_api/test_shape_list.py
@@ -90,10 +90,12 @@ class TestShapeList(unittest.TestCase):
         self.assertAlmostEqual(largest.area, math.pi * 2**2, 5)
 
     def test_sort_by_property(self):
-        box1 = Box(2, 2, 2)
-        box2 = Box(2, 2, 2).translate((1, 1, 1))
-        assert len((box1 + box2).edges().filter_by(Edge.is_interior)) == 6
-        assert len((box1 - box2).edges().filter_by(Edge.is_interior)) == 3
+        box1 = Box(1, 1, 1)
+        box2 = Box(2, 2, 2)
+        box3 = Box(3, 3, 3)
+        unsorted_boxes = ShapeList([box2, box3, box1])
+        assert unsorted_boxes.sort_by(Solid.volume) == [box1, box2, box3]
+        assert unsorted_boxes.sort_by(Solid.volume, reverse=True) == [box3, box2, box1]
 
     def test_sort_by_invalid(self):
         with self.assertRaises(ValueError):
@@ -124,6 +126,12 @@ class TestShapeList(unittest.TestCase):
 
         self.assertEqual(len(shapelist.filter_by(lambda s: s.label == "A")), 2)
         self.assertEqual(len(shapelist.filter_by(lambda s: s.label == "B")), 1)
+
+    def test_filter_by_property(self):
+        box1 = Box(2, 2, 2)
+        box2 = Box(2, 2, 2).translate((1, 1, 1))
+        assert len((box1 + box2).edges().filter_by(Edge.is_interior)) == 6
+        assert len((box1 - box2).edges().filter_by(Edge.is_interior)) == 3
 
     def test_first_last(self):
         vertices = (


### PR DESCRIPTION
This would allow 
```py
shape.edges().filter_by(Edge.is_interior)
```
as an alternative to 
```py
shape.edges().filter_by(lambda e: e.is_interior)
```