### PR TITLE
Fix various typos

### DIFF
--- a/docs/algebra_definition.rst
+++ b/docs/algebra_definition.rst
@@ -61,7 +61,7 @@ with :math:`B^3 \subset C^3, B^2 \subset C^2` and :math:`B^1 \subset C^1`
 * This definition also includes that neither ``-`` nor ``&`` are commutative.
 
 
-Locations, planes and location arithmentic
+Locations, planes and location arithmetic
 ---------------------------------------------
 
 **Set definitions:**

--- a/docs/joints.rst
+++ b/docs/joints.rst
@@ -196,7 +196,7 @@ is found within a rod end as shown here:
     :emphasize-lines: 40-44,51,53
 
 Note how limits are defined during the instantiation of the ball joint when ensures that the pin or bolt 
-within the rod end does not interfer with the rod end itself. The ``connect_to`` sets the three angles
+within the rod end does not interfere with the rod end itself. The ``connect_to`` sets the three angles
 (only two are significant in this example).
 
 .. autoclass:: BallJoint

--- a/docs/key_concepts_algebra.rst
+++ b/docs/key_concepts_algebra.rst
@@ -60,7 +60,7 @@ The generic forms of object placement are:
         location * alg_compound
 
 2. Placement on the ``plane`` and then moved relative to the ``plane`` by ``location`` 
-(the location is relative to the local corrdinate system of the plane).
+(the location is relative to the local coordinate system of the plane).
 
     .. code-block:: python
 

--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -271,7 +271,7 @@ reoriented, all ``BuildLine`` instances within the scope of ``BuildSketch`` shou
 on the default ``Plane.XY``.
 
 ***************************************************************
-Don't Builders inherit workplane/coordinate sytems when nested
+Don't Builders inherit workplane/coordinate systems when nested
 ***************************************************************
 
 Some users expect that nested Builders will inherit the workplane or coordinate system from

--- a/docs/tutorial_design.rst
+++ b/docs/tutorial_design.rst
@@ -106,7 +106,7 @@ For solid or prismatic shapes, extrude the 2D profiles along the necessary axis.
 also combine multiple extrusions by intersecting or unionizing them to form complex shapes. 
 Use the resulting geometry as sub-parts if needed.
 
-*The next step in implmenting our design in build123d is to convert the above sketch into
+*The next step in implementing our design in build123d is to convert the above sketch into
 a part by extruding it as shown in this code:*
 
 .. code-block:: python

--- a/src/build123d/build_sketch.py
+++ b/src/build123d/build_sketch.py
@@ -50,7 +50,7 @@ class BuildSketch(Builder):
     Note that all sketch construction is done within sketch_local on Plane.XY.
     When objects are added to the sketch they must be coplanar to Plane.XY,
     usually handled automatically but may need user input for Edges and Wires
-    since their construction plane isn't alway able to be determined.
+    since their construction plane isn't always able to be determined.
 
     Args:
         workplanes (Union[Face, Plane, Location], optional): objects converted to

--- a/src/build123d/drafting.py
+++ b/src/build123d/drafting.py
@@ -227,7 +227,7 @@ class Draft:
         """Convert a raw number to a unit of measurement string based on the class settings"""
 
         def simplify_fraction(numerator: int, denominator: int) -> tuple[int, int]:
-            """Mathematically simplify a fraction given a numerator and demoninator"""
+            """Mathematically simplify a fraction given a numerator and denominator"""
             greatest_common_demoninator = gcd(numerator, denominator)
             return (
                 int(numerator / greatest_common_demoninator),

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -1134,7 +1134,7 @@ class Color:
 
     @overload
     def __init__(self, color_code: int, alpha: int = 0xFF):
-        """Color from a hexidecimal color code with an optional alpha value
+        """Color from a hexadecimal color code with an optional alpha value
 
         Args:
             color_code (hexidecimal int): 0xRRGGBB

--- a/src/build123d/mesher.py
+++ b/src/build123d/mesher.py
@@ -242,7 +242,7 @@ class Mesher:
         return meta_data_contents
 
     def get_meta_data_by_key(self, name_space: str, name: str) -> dict:
-        """Retrive the metadata value and type for the provided name space and name"""
+        """Retrieve the metadata value and type for the provided name space and name"""
         meta_data_group = self.model.GetMetaDataGroup()
         meta_data_contents = {}
         meta_data = meta_data_group.GetMetaDataByKey(name_space, name)

--- a/src/build123d/topology/one_d.py
+++ b/src/build123d/topology/one_d.py
@@ -997,7 +997,7 @@ class Mixin1D(Shape):
             split_result = unwrap_topods_compound(split_result, True)
 
         # For speed the user may just want all the objects which they
-        # can sort more efficiently then the generic algoritm below
+        # can sort more efficiently then the generic algorithm below
         if keep == Keep.ALL:
             return ShapeList(
                 self.__class__.cast(part)

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -39,7 +39,7 @@ class TestPack(unittest.TestCase):
         test_boxes = [
             Box(random.randint(1, 20), random.randint(1, 20), 1) for _ in range(50)
         ]
-        # Not raising in this call shows successfull non-overlap.
+        # Not raising in this call shows successful non-overlap.
         packed = pack(test_boxes, 1)
         self.assertEqual(
             "bbox: 0.0 <= x <= 94.0, 0.0 <= y <= 86.0, -0.5 <= z <= 0.5",
@@ -54,7 +54,7 @@ class TestPack(unittest.TestCase):
         widths = [random.randint(2, 20) for _ in range(50)]
         heights = [random.randint(1, width - 1) for width in widths]
         inputs = [SlotOverall(width, height) for width, height in zip(widths, heights)]
-        # Not raising in this call shows successfull non-overlap.
+        # Not raising in this call shows successful non-overlap.
         packed = pack(inputs, 1)
         bb = (Sketch() + packed).bounding_box()
         self.assertEqual(bb.min, Vector(0, 0, 0))

--- a/tools/refactor_topo.py
+++ b/tools/refactor_topo.py
@@ -7,7 +7,7 @@ date: Dec 05, 2024
 
 desc:
     This python script refactors the very large topology.py module into several
-    files based on the topological heirarchical order:
+    files based on the topological hierarchical order:
     + shape_core.py - base classes Shape, ShapeList
     + utils.py - utility classes & functions
     + zero_d.py - Vertex


### PR DESCRIPTION
Found with `codespell -q 3 -L parm,parms,re-use`

Note: some source typos were found but not modified
```
./src/build123d/drafting.py:261: demoninator ==> denominator
./src/build123d/drafting.py:266: demoninator ==> denominator
./src/build123d/drafting.py:269: demoninator ==> denominator
./src/build123d/geometry.py:1140: hexidecimal ==> hexadecimal
./src/build123d/geometry.py:1141: hexidecimal ==> hexadecimal
```