### PR TITLE
Fix source typos

### DIFF
--- a/src/build123d/drafting.py
+++ b/src/build123d/drafting.py
@@ -228,10 +228,10 @@ class Draft:
 
         def simplify_fraction(numerator: int, denominator: int) -> tuple[int, int]:
             """Mathematically simplify a fraction given a numerator and denominator"""
-            greatest_common_demoninator = gcd(numerator, denominator)
+            greatest_common_denominator = gcd(numerator, denominator)
             return (
-                int(numerator / greatest_common_demoninator),
-                int(denominator / greatest_common_demoninator),
+                int(numerator / greatest_common_denominator),
+                int(denominator / greatest_common_denominator),
             )
 
         if display_units is None:
@@ -258,15 +258,15 @@ class Draft:
             return_value = f"{measurement}{unit_str}{tolerance_str}"
         else:
             whole_part = floor(number / IN)
-            (numerator, demoninator) = simplify_fraction(
+            (numerator, denominator) = simplify_fraction(
                 round((number / IN - whole_part) * self.fractional_precision),
                 self.fractional_precision,
             )
             if whole_part == 0:
-                return_value = f"{numerator}/{demoninator}{unit_str}{tolerance_str}"
+                return_value = f"{numerator}/{denominator}{unit_str}{tolerance_str}"
             else:
                 return_value = (
-                    f"{whole_part} {numerator}/{demoninator}{unit_str}{tolerance_str}"
+                    f"{whole_part} {numerator}/{denominator}{unit_str}{tolerance_str}"
                 )
 
         return return_value

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -1138,8 +1138,8 @@ class Color:
         """Color from a hexadecimal color code with an optional alpha value
 
         Args:
-            color_code (hexidecimal int): 0xRRGGBB
-            alpha (hexidecimal int): 0x00 <= alpha as hex <= 0xFF
+            color_code (hexadecimal int): 0xRRGGBB
+            alpha (hexadecimal int): 0x00 <= alpha as hex <= 0xFF
         """
 
     def __init__(self, *args, **kwargs):
@@ -1733,7 +1733,7 @@ class OrientedBoundBox:
     It exposes properties such as the center, principal axis directions, the
     extents along these axes, and the full diagonal length of the box.
 
-    Note: The axes of the oriented bounding box are arbitary and may not be
+    Note: The axes of the oriented bounding box are arbitrary and may not be
     consistent across platforms or time.
     """
 


### PR DESCRIPTION
Found via `codespell -q 3 -w -L parm,parms,re-use,substract`

Greenlit in #892 