### PR TITLE
make `Axis.position` and `Axis.direction` properties

### DIFF
--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -661,16 +661,21 @@ class Axis(metaclass=AxisMeta):
                 gp_Dir(*tuple(direction_vector.normalized())),
             )
 
-        self.position = Vector(
-            self.wrapped.Location().X(),
-            self.wrapped.Location().Y(),
-            self.wrapped.Location().Z(),
-        )  #: Axis origin
-        self.direction = Vector(
-            self.wrapped.Direction().X(),
-            self.wrapped.Direction().Y(),
-            self.wrapped.Direction().Z(),
-        )  #: Axis direction
+    @property
+    def position(self):
+        return Vector(self.wrapped.Location())
+
+    @position.setter
+    def position(self, position: VectorLike):
+        self.wrapped.SetLocation(Vector(position).to_pnt())
+
+    @property
+    def direction(self):
+        return Vector(self.wrapped.Direction())
+
+    @direction.setter
+    def direction(self, direction: VectorLike):
+        self.wrapped.SetDirection(Vector(direction).to_dir())
 
     @property
     def location(self) -> Location:

--- a/tests/test_direct_api/test_axis.py
+++ b/tests/test_direct_api/test_axis.py
@@ -230,6 +230,27 @@ class TestAxis(unittest.TestCase):
         random_obj = object()
         self.assertNotEqual(Axis.X, random_obj)
 
+    def test_position_property(self):
+        axis = Axis.X
+        axis.position = 1, 2, 3
+        self.assertAlmostEqual(axis.position, (1, 2, 3))
+
+        axis.position += 1, 2, 3
+        self.assertAlmostEqual(axis.position, (2, 4, 6))
+
+        self.assertAlmostEqual(Axis(axis.wrapped).position, (2, 4, 6))
+
+    def test_direction_property(self):
+        axis = Axis.X
+        axis.direction = 1, 2, 3
+        self.assertAlmostEqual(axis.direction, Vector(1, 2, 3).normalized())
+
+        axis.direction += 5, 3, 1
+        expected = (Vector(1, 2, 3).normalized() + Vector(5, 3, 1)).normalized()
+        self.assertAlmostEqual(axis.direction, expected)
+
+        self.assertAlmostEqual(Axis(axis.wrapped).direction, expected)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The `.position` and `.direction` members of the `Axis` class are currently copies made at initialization which means that they are modifiable but not kept in sync with the underlying `.wrapped` object.

```py
axes = [Axis.Y for _ in range(10)]
for i, a in enumerate(axes):
    a.position += (i, 0, 0)  # translating each axis
show_all()  # all axes show at (0,0,0)
```
