### PR TITLE
Avoid deepcopy'ing Shape.topo_parent.

### DIFF
--- a/src/build123d/topology/shape_core.py
+++ b/src/build123d/topology/shape_core.py
@@ -866,7 +866,10 @@ class Shape(NodeMixin, Generic[TOPODS]):
         if self.wrapped is not None:
             memo[id(self.wrapped)] = downcast(BRepBuilderAPI_Copy(self.wrapped).Shape())
         for key, value in self.__dict__.items():
-            setattr(result, key, copy.deepcopy(value, memo))
+            if key == 'topo_parent':
+                result.topo_parent = value
+            else:
+                setattr(result, key, copy.deepcopy(value, memo))
             if key == "joints":
                 for joint in result.joints.values():
                     joint.parent = result


### PR DESCRIPTION
Speeds up benchy example from 27s to 5.5s.

Motivated by #909 adding examples that take a while to run.
Discussion in Discord: [thread](https://discord.com/channels/964330484911972403/1343338604180803646).