### PR TITLE
feat: switch to lib3mf official pypi release from py_lib3mf

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -41,5 +41,5 @@ ignore_missing_imports = True
 [mypy-setuptools_scm.*]
 ignore_missing_imports = True
 
-[mypy-py_lib3mf.*]
+[mypy-lib3mf.*]
 ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "anytree >= 2.8.0, < 3",
     "ezdxf >= 1.1.0, < 2",
     "ipython >= 8.0.0, < 9",
-    "py-lib3mf >= 2.3.1",
+    "lib3mf >= 2.4.1",
     "ocpsvg >= 0.5, < 0.6",
     "trianglesolver",
 ]

--- a/src/build123d/mesher.py
+++ b/src/build123d/mesher.py
@@ -109,7 +109,7 @@ from OCP.TopAbs import TopAbs_ShapeEnum
 from OCP.TopExp import TopExp_Explorer
 from OCP.TopLoc import TopLoc_Location
 from OCP.TopoDS import TopoDS_Compound
-from py_lib3mf import Lib3MF
+from lib3mf import Lib3MF
 
 from build123d.build_enums import MeshType, Unit
 from build123d.geometry import TOLERANCE, Color


### PR DESCRIPTION
Previously there was no official release of lib3mf on pypi, so I instead created and published py_lib3mf to pypi. The lib3mf release on pypi was recently improved to the point that it now surpasses the py_lib3mf that I bundled -- namely to explicitly separate the library files for each platform (linux, macos, windows) and have 3 separate wheels (macos has a universal2 wheel).

The only "downside" of switching is that there is not (and never has been) support for other CPU architectures such as linux-aarch64. It was previously possible to install build123d on e.g. a raspberry pi (with some workarounds) and py_lib3mf/lib3mf would appear to install successfully (but there was not actually an appropriate *.so file for this platform/CPU type). This ambiguity has been corrected in the recent release of lib3mf, which means it is now worth switching in my opinion.

Some other important bugs have also been corrected in lib3mf 2.4.x as well such as https://github.com/3MFConsortium/lib3mf/issues/355

This PR fixes https://github.com/gumyr/build123d/issues/799