### PR TITLE
Revise docstrings for build objects

### DIFF
--- a/src/build123d/objects_curve.py
+++ b/src/build123d/objects_curve.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 import copy as copy_module
 from math import copysign, cos, radians, sin, sqrt
 from scipy.optimize import minimize
-from typing import Union
 
 from collections.abc import Iterable
 
@@ -46,8 +45,8 @@ def _add_curve_to_context(curve, mode: Mode):
     """Helper function to add a curve to the context.
 
     Args:
-        curve (Union[Wire, Edge]): curve to add to the context (either a Wire or an Edge).
-        mode (Mode): combination mode.
+        curve (Wire | Edge): curve to add to the context (either a Wire or an Edge)
+        mode (Mode): combination mode
     """
     context: BuildLine | None = BuildLine._get_context(log=False)
 
@@ -62,8 +61,8 @@ class BaseLineObject(Wire):
     """BaseLineObject specialized for Wire.
 
     Args:
-        curve (Wire): wire to create.
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        curve (Wire): wire to create
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildLine._tag]
@@ -78,8 +77,8 @@ class BaseEdgeObject(Edge):
     """BaseEdgeObject specialized for Edge.
 
     Args:
-        curve (Edge): edge to create.
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        curve (Edge): edge to create
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildLine._tag]
@@ -93,14 +92,14 @@ class BaseEdgeObject(Edge):
 class Bezier(BaseEdgeObject):
     """Line Object: Bezier Curve
 
-    Create a rational (with weights) or non-rational bezier curve.  The first and last
-    control points represent the start and end of the curve respectively.  If weights
-    are provided, there must be one provided for each control point.
+    Add a non-rational bezier curve defined by a sequence of points and include optional
+    weights to add a rational bezier curve. The number of weights must match the number
+    of control points.
 
     Args:
         cntl_pnts (sequence[VectorLike]): points defining the curve
-        weights (list[float], optional): control point weights list. Defaults to None.
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        weights (list[float], optional): control point weights. Defaults to None
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildLine._tag]
@@ -124,14 +123,14 @@ class Bezier(BaseEdgeObject):
 class CenterArc(BaseEdgeObject):
     """Line Object: Center Arc
 
-    Add center arc to the line.
+    Add a circular arc defined by a center point and radius.
 
     Args:
         center (VectorLike): center point of arc
         radius (float): arc radius
-        start_angle (float): arc staring angle
-        arc_size (float): arc size
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        start_angle (float): arc starting angle from x-axis
+        arc_size (float): angular size of arc
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildLine._tag]
@@ -177,19 +176,19 @@ class CenterArc(BaseEdgeObject):
 class DoubleTangentArc(BaseEdgeObject):
     """Line Object: Double Tangent Arc
 
-    Create an arc defined by a point/tangent pair and another line which the other end
-    is tangent to.
+    Add a circular arc defined by a point/tangent pair and another line find a tangent to.
+
+    The arc specified with TOP or BOTTOM depends on the geometry and isn't predictable.
 
     Contains a solver.
 
     Args:
-        pnt (VectorLike): starting point of tangent arc
-        tangent (VectorLike): tangent at starting point of tangent arc
-        other (Union[Curve, Edge, Wire]): reference line
-        keep (Keep, optional): selector for which arc to keep when two arcs are
-            possible. The arc generated with TOP or BOTTOM depends on the geometry
-            and isn't necessarily easy to predict. Defaults to Keep.TOP.
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        pnt (VectorLike): start point
+        tangent (VectorLike): tangent at start point
+        other (Curve | Edge | Wire): line object to tangent
+        keep (Keep, optional): specify which arc if more than one, TOP or BOTTOM.
+            Defaults to Keep.TOP
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
 
     Raises:
         RunTimeError: no double tangent arcs found
@@ -276,21 +275,21 @@ class DoubleTangentArc(BaseEdgeObject):
 class EllipticalStartArc(BaseEdgeObject):
     """Line Object: Elliptical Start Arc
 
-    Makes an arc of an ellipse from the start point.
+    Add an elliptical arc defined by a start point, end point, x- and y- radii.
 
     Args:
-        start (VectorLike): initial point of arc
-        end (VectorLike): final point of arc
-        x_radius (float): semi-major radius
-        y_radius (float): semi-minor radius
+        start (VectorLike): start point
+        end (VectorLike): end point
+        x_radius (float): x radius of the ellipse (along the x-axis of plane)
+        y_radius (float): y radius of the ellipse (along the y-axis of plane)
         rotation (float, optional): the angle from the x-axis of the plane to the x-axis
-            of the ellipse. Defaults to 0.0.
+            of the ellipse. Defaults to 0.0
         large_arc (bool, optional): True if the arc spans greater than 180 degrees.
-            Defaults to True.
+            Defaults to True
         sweep_flag (bool, optional): False if the line joining center to arc sweeps through
-            decreasing angles, or True if it sweeps through increasing angles. Defaults to True.
-        plane (Plane, optional): base plane. Defaults to Plane.XY.
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+            decreasing angles, or True if it sweeps through increasing angles. Defaults to True
+        plane (Plane, optional): base plane. Defaults to Plane.XY
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildLine._tag]
@@ -382,19 +381,21 @@ class EllipticalStartArc(BaseEdgeObject):
 class EllipticalCenterArc(BaseEdgeObject):
     """Line Object: Elliptical Center Arc
 
-    Makes an arc of an ellipse from a center point.
+    Adds an elliptical arc defined by a center point, x- and y- radii.
 
     Args:
         center (VectorLike): ellipse center
         x_radius (float): x radius of the ellipse (along the x-axis of plane)
         y_radius (float): y radius of the ellipse (along the y-axis of plane)
-        start_angle (float, optional): Defaults to 0.0.
-        end_angle (float, optional): Defaults to 90.0.
-        rotation (float, optional): amount to rotate arc. Defaults to 0.0.
+        start_angle (float, optional): arc start angle from x-axis.
+            Defaults to 0.0
+        end_angle (float, optional): arc end angle from x-axis.
+            Defaults to 90.0
+        rotation (float, optional): angle to rotate arc. Defaults to 0.0
         angular_direction (AngularDirection, optional): arc direction.
-            Defaults to AngularDirection.COUNTER_CLOCKWISE.
-        plane (Plane, optional): base plane. Defaults to Plane.XY.
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+            Defaults to AngularDirection.COUNTER_CLOCKWISE
+        plane (Plane, optional): base plane. Defaults to Plane.XY
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildLine._tag]
@@ -438,17 +439,20 @@ class EllipticalCenterArc(BaseEdgeObject):
 class Helix(BaseEdgeObject):
     """Line Object: Helix
 
-    Add a helix to the line.
+    Add a helix defined by pitch, height, and radius. The helix may have a taper
+    defined by cone_angle.
+
 
     Args:
-        pitch (float): distance between successive loops
-        height (float): helix size
+        pitch (float): distance between loops
+        height (float): helix height
         radius (float): helix radius
         center (VectorLike, optional): center point. Defaults to (0, 0, 0).
         direction (VectorLike, optional): direction of central axis. Defaults to (0, 0, 1).
-        cone_angle (float, optional): conical angle. Defaults to 0.
-        lefthand (bool, optional): left handed helix. Defaults to False.
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        cone_angle (float, optional): conical angle from direction.
+            Defaults to 0
+        lefthand (bool, optional): left handed helix. Defaults to False
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildLine._tag]
@@ -475,16 +479,17 @@ class Helix(BaseEdgeObject):
 
 
 class FilletPolyline(BaseLineObject):
-    """Line Object: FilletPolyline
+    """Line Object: Fillet Polyline
 
-    Add a sequence of straight lines defined by successive points that
-    are filleted to a given radius.
+    Add a sequence of straight lines defined by successive points that are filleted
+    to a given radius.
 
     Args:
-        pts (Union[VectorLike, Iterable[VectorLike]]): sequence of two or more points
-        radius (float): radius of filleted corners
-        close (bool, optional): close by generating an extra Edge. Defaults to False.
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        pts (VectorLike | Iterable[VectorLike]): sequence of two or more points
+        radius (float): fillet radius
+        close (bool, optional): close end points with extra Edge and corner fillets.
+            Defaults to False
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
 
     Raises:
         ValueError: Two or more points not provided
@@ -570,16 +575,16 @@ class FilletPolyline(BaseLineObject):
 
 
 class JernArc(BaseEdgeObject):
-    """JernArc
+    """Line Object: Jern Arc
 
-    Circular tangent arc with given radius and arc_size
+    Add a circular arc defined by a start point/tangent pair, radius and arc size.
 
     Args:
         start (VectorLike): start point
         tangent (VectorLike): tangent at start point
         radius (float): arc radius
-        arc_size (float): arc size in degrees (negative to change direction)
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        arc_size (float): angular size of arc (negative to change direction)
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
 
     Attributes:
         start (Vector): start point
@@ -634,11 +639,11 @@ class JernArc(BaseEdgeObject):
 class Line(BaseEdgeObject):
     """Line Object: Line
 
-    Add a straight line defined by two end points.
+    Add a straight line defined by two points.
 
     Args:
-        pts (Union[VectorLike, Iterable[VectorLike]]): sequence of two points
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        pts (VectorLike | Iterable[VectorLike]): sequence of two points
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
 
     Raises:
         ValueError: Two point not provided
@@ -665,13 +670,13 @@ class Line(BaseEdgeObject):
 class IntersectingLine(BaseEdgeObject):
     """Intersecting Line Object: Line
 
-    Add a straight line that intersects another line at a given parameter and angle.
+    Add a straight line defined by a point/direction pair and another line to intersect.
 
     Args:
         start (VectorLike): start point
         direction (VectorLike): direction to make line
-        other (Edge): stop at the intersection of other
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        other (Edge): line object to intersect
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
 
     """
 
@@ -706,15 +711,17 @@ class IntersectingLine(BaseEdgeObject):
 class PolarLine(BaseEdgeObject):
     """Line Object: Polar Line
 
-    Add line defined by a start point, length and angle.
+    Add a straight line defined by a start point, length, and angle.
+    The length can specify the DIAGONAL, HORIZONTAL, or VERTICAL component of the triangle
+    defined by the angle.
 
     Args:
         start (VectorLike): start point
         length (float): line length
-        angle (float): angle from the local "X" axis.
-        length_mode (LengthMode, optional): length value specifies a diagonal, horizontal
-            or vertical value. Defaults to LengthMode.DIAGONAL
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        angle (float, optional): angle from the local x-axis
+        length_mode (LengthMode, optional): how length defines the line.
+            Defaults to LengthMode.DIAGONAL
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
 
     Raises:
         ValueError: Either angle or direction must be provided
@@ -768,12 +775,12 @@ class PolarLine(BaseEdgeObject):
 class Polyline(BaseLineObject):
     """Line Object: Polyline
 
-    Add a sequence of straight lines defined by successive point pairs.
+    Add a sequence of straight lines defined by successive points.
 
     Args:
-        pts (Union[VectorLike, Iterable[VectorLike]]): sequence of two or more points
-        close (bool, optional): close by generating an extra Edge. Defaults to False.
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        pts (VectorLike | Iterable[VectorLike]): sequence of two or more points
+        close (bool, optional): close by generating an extra Edge. Defaults to False
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
 
     Raises:
         ValueError: Two or more points not provided
@@ -809,15 +816,15 @@ class Polyline(BaseLineObject):
 class RadiusArc(BaseEdgeObject):
     """Line Object: Radius Arc
 
-    Add an arc defined by two end points and a radius
+    Add a circular arc defined by two points and a radius.
 
     Args:
-        start_point (VectorLike): start
-        end_point (VectorLike): end
-        radius (float): radius
-        short_sagitta (bool): If True selects the short sagitta, else the
-            long sagitta crossing the center. Defaults to True.
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        start_point (VectorLike): start point
+        end_point (VectorLike): end point
+        radius (float): arc radius
+        short_sagitta (bool): If True selects the short sagitta (height of arc from
+            chord), else the long sagitta crossing the center. Defaults to True
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
 
     Raises:
         ValueError: Insufficient radius to connect end points
@@ -861,13 +868,13 @@ class RadiusArc(BaseEdgeObject):
 class SagittaArc(BaseEdgeObject):
     """Line Object: Sagitta Arc
 
-    Add an arc defined by two points and the height of the arc (sagitta).
+    Add a circular arc defined by two points and the sagitta (height of the arc from chord).
 
     Args:
-        start_point (VectorLike): start
-        end_point (VectorLike): end
-        sagitta (float): arc height
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        start_point (VectorLike): start point
+        end_point (VectorLike): end point
+        sagitta (float): arc height from chord between points
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildLine._tag]
@@ -905,15 +912,16 @@ class SagittaArc(BaseEdgeObject):
 class Spline(BaseEdgeObject):
     """Line Object: Spline
 
-    Add a spline through the provided points optionally constrained by tangents.
+    Add a spline defined by a sequence of points, optionally constrained by tangents.
+    Tangents and tangent scalars must have length of 2 for only the end points or a length
+    of the number of points.
 
     Args:
-        pts (Union[VectorLike, Iterable[VectorLike]]): sequence of two or more points
-        tangents (Iterable[VectorLike], optional): tangents at end points. Defaults to None.
-        tangent_scalars (Iterable[float], optional): change shape by amplifying tangent.
-            Defaults to None.
-        periodic (bool, optional): make the spline periodic. Defaults to False.
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        pts (VectorLike | Iterable[VectorLike]): sequence of two or more points
+        tangents (Iterable[VectorLike], optional): tangent directions. Defaults to None
+        tangent_scalars (Iterable[float], optional): tangent scales. Defaults to None
+        periodic (bool, optional): make the spline periodic (closed). Defaults to False
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildLine._tag]
@@ -963,14 +971,14 @@ class Spline(BaseEdgeObject):
 class TangentArc(BaseEdgeObject):
     """Line Object: Tangent Arc
 
-    Add an arc defined by two points and a tangent.
+    Add a circular arc defined by two points and a tangent.
 
     Args:
-        pts (Union[VectorLike, Iterable[VectorLike]]): sequence of two points
+        pts (VectorLike | Iterable[VectorLike]): sequence of two points
         tangent (VectorLike): tangent to constrain arc
-        tangent_from_first (bool, optional): apply tangent to first point. Note, applying
-            tangent to end point will flip the orientation of the arc. Defaults to True.
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        tangent_from_first (bool, optional): apply tangent to first point. Applying
+            tangent to end point will flip the orientation of the arc. Defaults to True
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
 
     Raises:
         ValueError: Two points are required
@@ -1005,11 +1013,11 @@ class TangentArc(BaseEdgeObject):
 class ThreePointArc(BaseEdgeObject):
     """Line Object: Three Point Arc
 
-    Add an arc generated by three points.
+    Add a circular arc defined by three points.
 
     Args:
-        pts (Union[VectorLike, Iterable[VectorLike]]): sequence of three points
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        pts (VectorLike | Iterable[VectorLike]): sequence of three points
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
 
     Raises:
         ValueError: Three points must be provided

--- a/src/build123d/objects_curve.py
+++ b/src/build123d/objects_curve.py
@@ -92,8 +92,8 @@ class BaseEdgeObject(Edge):
 class Bezier(BaseEdgeObject):
     """Line Object: Bezier Curve
 
-    Add a non-rational bezier curve defined by a sequence of points and include optional
-    weights to add a rational bezier curve. The number of weights must match the number
+    Create a non-rational bezier curve defined by a sequence of points and include optional
+    weights to create a rational bezier curve. The number of weights must match the number
     of control points.
 
     Args:
@@ -123,7 +123,7 @@ class Bezier(BaseEdgeObject):
 class CenterArc(BaseEdgeObject):
     """Line Object: Center Arc
 
-    Add a circular arc defined by a center point and radius.
+    Create a circular arc defined by a center point and radius.
 
     Args:
         center (VectorLike): center point of arc
@@ -176,7 +176,7 @@ class CenterArc(BaseEdgeObject):
 class DoubleTangentArc(BaseEdgeObject):
     """Line Object: Double Tangent Arc
 
-    Add a circular arc defined by a point/tangent pair and another line find a tangent to.
+    Create a circular arc defined by a point/tangent pair and another line find a tangent to.
 
     The arc specified with TOP or BOTTOM depends on the geometry and isn't predictable.
 
@@ -275,7 +275,7 @@ class DoubleTangentArc(BaseEdgeObject):
 class EllipticalStartArc(BaseEdgeObject):
     """Line Object: Elliptical Start Arc
 
-    Add an elliptical arc defined by a start point, end point, x- and y- radii.
+    Create an elliptical arc defined by a start point, end point, x- and y- radii.
 
     Args:
         start (VectorLike): start point
@@ -381,7 +381,7 @@ class EllipticalStartArc(BaseEdgeObject):
 class EllipticalCenterArc(BaseEdgeObject):
     """Line Object: Elliptical Center Arc
 
-    Adds an elliptical arc defined by a center point, x- and y- radii.
+    Create an elliptical arc defined by a center point, x- and y- radii.
 
     Args:
         center (VectorLike): ellipse center
@@ -439,7 +439,7 @@ class EllipticalCenterArc(BaseEdgeObject):
 class Helix(BaseEdgeObject):
     """Line Object: Helix
 
-    Add a helix defined by pitch, height, and radius. The helix may have a taper
+    Create a helix defined by pitch, height, and radius. The helix may have a taper
     defined by cone_angle.
 
 
@@ -481,7 +481,7 @@ class Helix(BaseEdgeObject):
 class FilletPolyline(BaseLineObject):
     """Line Object: Fillet Polyline
 
-    Add a sequence of straight lines defined by successive points that are filleted
+    Create a sequence of straight lines defined by successive points that are filleted
     to a given radius.
 
     Args:
@@ -577,7 +577,7 @@ class FilletPolyline(BaseLineObject):
 class JernArc(BaseEdgeObject):
     """Line Object: Jern Arc
 
-    Add a circular arc defined by a start point/tangent pair, radius and arc size.
+    Create a circular arc defined by a start point/tangent pair, radius and arc size.
 
     Args:
         start (VectorLike): start point
@@ -639,7 +639,7 @@ class JernArc(BaseEdgeObject):
 class Line(BaseEdgeObject):
     """Line Object: Line
 
-    Add a straight line defined by two points.
+    Create a straight line defined by two points.
 
     Args:
         pts (VectorLike | Iterable[VectorLike]): sequence of two points
@@ -670,7 +670,7 @@ class Line(BaseEdgeObject):
 class IntersectingLine(BaseEdgeObject):
     """Intersecting Line Object: Line
 
-    Add a straight line defined by a point/direction pair and another line to intersect.
+    Create a straight line defined by a point/direction pair and another line to intersect.
 
     Args:
         start (VectorLike): start point
@@ -711,7 +711,7 @@ class IntersectingLine(BaseEdgeObject):
 class PolarLine(BaseEdgeObject):
     """Line Object: Polar Line
 
-    Add a straight line defined by a start point, length, and angle.
+    Create a straight line defined by a start point, length, and angle.
     The length can specify the DIAGONAL, HORIZONTAL, or VERTICAL component of the triangle
     defined by the angle.
 
@@ -775,7 +775,7 @@ class PolarLine(BaseEdgeObject):
 class Polyline(BaseLineObject):
     """Line Object: Polyline
 
-    Add a sequence of straight lines defined by successive points.
+    Create a sequence of straight lines defined by successive points.
 
     Args:
         pts (VectorLike | Iterable[VectorLike]): sequence of two or more points
@@ -816,7 +816,7 @@ class Polyline(BaseLineObject):
 class RadiusArc(BaseEdgeObject):
     """Line Object: Radius Arc
 
-    Add a circular arc defined by two points and a radius.
+    Create a circular arc defined by two points and a radius.
 
     Args:
         start_point (VectorLike): start point
@@ -868,7 +868,7 @@ class RadiusArc(BaseEdgeObject):
 class SagittaArc(BaseEdgeObject):
     """Line Object: Sagitta Arc
 
-    Add a circular arc defined by two points and the sagitta (height of the arc from chord).
+    Create a circular arc defined by two points and the sagitta (height of the arc from chord).
 
     Args:
         start_point (VectorLike): start point
@@ -912,7 +912,7 @@ class SagittaArc(BaseEdgeObject):
 class Spline(BaseEdgeObject):
     """Line Object: Spline
 
-    Add a spline defined by a sequence of points, optionally constrained by tangents.
+    Create a spline defined by a sequence of points, optionally constrained by tangents.
     Tangents and tangent scalars must have length of 2 for only the end points or a length
     of the number of points.
 
@@ -971,7 +971,7 @@ class Spline(BaseEdgeObject):
 class TangentArc(BaseEdgeObject):
     """Line Object: Tangent Arc
 
-    Add a circular arc defined by two points and a tangent.
+    Create a circular arc defined by two points and a tangent.
 
     Args:
         pts (VectorLike | Iterable[VectorLike]): sequence of two points
@@ -1013,7 +1013,7 @@ class TangentArc(BaseEdgeObject):
 class ThreePointArc(BaseEdgeObject):
     """Line Object: Three Point Arc
 
-    Add a circular arc defined by three points.
+    Create a circular arc defined by three points.
 
     Args:
         pts (VectorLike | Iterable[VectorLike]): sequence of three points

--- a/src/build123d/objects_part.py
+++ b/src/build123d/objects_part.py
@@ -44,10 +44,10 @@ class BasePartObject(Part):
 
     Args:
         solid (Solid): object to create
-        rotation (RotationLike, optional): angles to rotate about axes. Defaults to (0, 0, 0).
-        align (Align | tuple[Align, Align, Align] | None, optional): align min, center,
-            or max of object. Defaults to None.
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        rotation (RotationLike, optional): angles to rotate about axes. Defaults to (0, 0, 0)
+        align (Align | tuple[Align, Align, Align] | None, optional): align MIN, CENTER,
+            or MAX of object. Defaults to None
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildPart._tag]
@@ -103,16 +103,16 @@ class BasePartObject(Part):
 class Box(BasePartObject):
     """Part Object: Box
 
-    Create a box(es) and combine with part.
+    Add a box defined by length, width, and height.
 
     Args:
-        length (float): box size
-        width (float): box size
-        height (float): box size
-        rotation (RotationLike, optional): angles to rotate about axes. Defaults to (0, 0, 0).
-        align (Align | tuple[Align, Align, Align] | None, optional): align min, center,
-            or max of object. Defaults to (Align.CENTER, Align.CENTER, Align.CENTER).
-        mode (Mode, optional): combine mode. Defaults to Mode.ADD.
+        length (float): box length
+        width (float): box width
+        height (float): box height
+        rotation (RotationLike, optional): angles to rotate about axes. Defaults to (0, 0, 0)
+        align (Align | tuple[Align, Align, Align] | None, optional): align MIN, CENTER,
+            or MAX of object. Defaults to (Align.CENTER, Align.CENTER, Align.CENTER)
+        mode (Mode, optional): combine mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildPart._tag]
@@ -147,17 +147,17 @@ class Box(BasePartObject):
 class Cone(BasePartObject):
     """Part Object: Cone
 
-    Create a cone(s) and combine with part.
+    Add a cone defined by bottom radius, top radius, and height.
 
     Args:
-        bottom_radius (float): cone size
-        top_radius (float): top size, could be zero
-        height (float): cone size
-        arc_size (float, optional): angular size of cone. Defaults to 360.
-        rotation (RotationLike, optional): angles to rotate about axes. Defaults to (0, 0, 0).
-        align (Align | tuple[Align, Align, Align] | None, optional): align min, center,
-            or max of object. Defaults to (Align.CENTER, Align.CENTER, Align.CENTER).
-        mode (Mode, optional): combine mode. Defaults to Mode.ADD.
+        bottom_radius (float): bottom radius
+        top_radius (float): top radius, may be zero
+        height (float): cone height
+        arc_size (float, optional): angular size of cone. Defaults to 360
+        rotation (RotationLike, optional): angles to rotate about axes. Defaults to (0, 0, 0)
+        align (Align | tuple[Align, Align, Align] | None, optional): align MIN, CENTER,
+            or MAX of object. Defaults to (Align.CENTER, Align.CENTER, Align.CENTER)
+        mode (Mode, optional): combine mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildPart._tag]
@@ -200,14 +200,14 @@ class Cone(BasePartObject):
 class CounterBoreHole(BasePartObject):
     """Part Operation: Counter Bore Hole
 
-    Create a counter bore hole in part.
+    Subtract a counter bore hole defined by radius, counter bore radius, counter bore and depth.
 
     Args:
-        radius (float): hole size
-        counter_bore_radius (float): counter bore size
+        radius (float): hole radius
+        counter_bore_radius (float): counter bore radius
         counter_bore_depth (float): counter bore depth
-        depth (float, optional): hole depth - None implies through part. Defaults to None.
-        mode (Mode, optional): combination mode. Defaults to Mode.SUBTRACT.
+        depth (float, optional): hole depth, through part if None. Defaults to None
+        mode (Mode, optional): combination mode. Defaults to Mode.SUBTRACT
     """
 
     _applies_to = [BuildPart._tag]
@@ -253,14 +253,15 @@ class CounterBoreHole(BasePartObject):
 class CounterSinkHole(BasePartObject):
     """Part Operation: Counter Sink Hole
 
-    Create a counter sink hole in part.
+    Subtract a countersink hole defined by radius, countersink radius, countersink
+        angle, and depth.
 
     Args:
-        radius (float): hole size
-        counter_sink_radius (float): counter sink size
-        depth (float, optional): hole depth - None implies through part. Defaults to None.
-        counter_sink_angle (float, optional): cone angle. Defaults to 82.
-        mode (Mode, optional): combination mode. Defaults to Mode.SUBTRACT.
+        radius (float): hole radius
+        counter_sink_radius (float): countersink radius
+        depth (float, optional): hole depth, through part if None. Defaults to None
+        counter_sink_angle (float, optional): cone angle. Defaults to 82
+        mode (Mode, optional): combination mode. Defaults to Mode.SUBTRACT
     """
 
     _applies_to = [BuildPart._tag]
@@ -310,16 +311,16 @@ class CounterSinkHole(BasePartObject):
 class Cylinder(BasePartObject):
     """Part Object: Cylinder
 
-    Create a cylinder(s) and combine with part.
+    Add a cylinder defined by radius and height.
 
     Args:
-        radius (float): cylinder size
-        height (float): cylinder size
+        radius (float): cylinder radius
+        height (float): cylinder height
         arc_size (float, optional): angular size of cone. Defaults to 360.
-        rotation (RotationLike, optional): angles to rotate about axes. Defaults to (0, 0, 0).
-        align (Align | tuple[Align, Align, Align] | None, optional): align min, center,
-            or max of object. Defaults to (Align.CENTER, Align.CENTER, Align.CENTER).
-        mode (Mode, optional): combine mode. Defaults to Mode.ADD.
+        rotation (RotationLike, optional): angles to rotate about axes. Defaults to (0, 0, 0)
+        align (Align | tuple[Align, Align, Align] | None, optional): align MIN, CENTER,
+            or MAX of object. Defaults to (Align.CENTER, Align.CENTER, Align.CENTER)
+        mode (Mode, optional): combine mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildPart._tag]
@@ -358,12 +359,12 @@ class Cylinder(BasePartObject):
 class Hole(BasePartObject):
     """Part Operation: Hole
 
-    Create a hole in part.
+    Subtract a hole defined by radius and depth.
 
     Args:
-        radius (float): hole size
-        depth (float, optional): hole depth - None implies through part. Defaults to None.
-        mode (Mode, optional): combination mode. Defaults to Mode.SUBTRACT.
+        radius (float): hole radius
+        depth (float, optional): hole depth, through part if None. Defaults to None
+        mode (Mode, optional): combination mode. Defaults to Mode.SUBTRACT
     """
 
     _applies_to = [BuildPart._tag]
@@ -405,17 +406,17 @@ class Hole(BasePartObject):
 class Sphere(BasePartObject):
     """Part Object: Sphere
 
-    Create a sphere(s) and combine with part.
+    Add a sphere defined by a radius.
 
     Args:
-        radius (float): sphere size
-        arc_size1 (float, optional): angular size of sphere. Defaults to -90.
-        arc_size2 (float, optional): angular size of sphere. Defaults to 90.
-        arc_size3 (float, optional): angular size of sphere. Defaults to 360.
-        rotation (RotationLike, optional): angles to rotate about axes. Defaults to (0, 0, 0).
-        align (Align | tuple[Align, Align, Align] | None, optional): align min, center,
-            or max of object. Defaults to (Align.CENTER, Align.CENTER, Align.CENTER).
-        mode (Mode, optional): combine mode. Defaults to Mode.ADD.
+        radius (float): sphere radius
+        arc_size1 (float, optional): angular size of bottom hemisphere. Defaults to -90.
+        arc_size2 (float, optional): angular size of top hemisphere. Defaults to 90.
+        arc_size3 (float, optional): angular revolution about pole. Defaults to 360.
+        rotation (RotationLike, optional): angles to rotate about axes. Defaults to (0, 0, 0)
+        align (Align | tuple[Align, Align, Align] | None, optional): align MIN, CENTER,
+            or MAX of object. Defaults to (Align.CENTER, Align.CENTER, Align.CENTER)
+        mode (Mode, optional): combine mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildPart._tag]
@@ -457,18 +458,18 @@ class Sphere(BasePartObject):
 class Torus(BasePartObject):
     """Part Object: Torus
 
-    Create a torus(es) and combine with part.
-
+    Add a torus defined by major and minor radii.
 
     Args:
-        major_radius (float): torus size
-        minor_radius (float): torus size
-        major_arc_size (float, optional): angular size of torus. Defaults to 0.
-        minor_arc_size (float, optional): angular size or torus. Defaults to 360.
-        rotation (RotationLike, optional): angles to rotate about axes. Defaults to (0, 0, 0).
-        align (Align | tuple[Align, Align, Align] | None, optional): align min, center,
-            or max of object. Defaults to (Align.CENTER, Align.CENTER, Align.CENTER).
-        mode (Mode, optional): combine mode. Defaults to Mode.ADD.
+        major_radius (float): major torus radius
+        minor_radius (float): minor torus radius
+        minor_start_angle (float, optional): angle to start minor arc. Defaults to 0
+        minor_end_angle (float, optional): angle to end minor arc. Defaults to 360
+        major_angle (float, optional): angle to revolve minor arc. Defaults to 360
+        rotation (RotationLike, optional): angles to rotate about axes. Defaults to (0, 0, 0)
+        align (Align | tuple[Align, Align, Align] | None, optional): align MIN, CENTER,
+            or MAX of object. Defaults to (Align.CENTER, Align.CENTER, Align.CENTER)
+        mode (Mode, optional): combine mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildPart._tag]
@@ -513,20 +514,21 @@ class Torus(BasePartObject):
 class Wedge(BasePartObject):
     """Part Object: Wedge
 
-    Create a wedge(s) and combine with part.
+    Add a wedge with a near face defined by xsize and z size, a far face defined by
+    xmin to xmax and zmin to zmax, and a depth of ysize.
 
     Args:
-        xsize (float): distance along the X axis
-        ysize (float): distance along the Y axis
-        zsize (float): distance along the Z axis
-        xmin (float): minimum X location
-        zmin (float): minimum Z location
-        xmax (float): maximum X location
-        zmax (float): maximum Z location
-        rotation (RotationLike, optional): angles to rotate about axes. Defaults to (0, 0, 0).
-        align (Align | tuple[Align, Align, Align] | None, optional): align min, center,
-            or max of object. Defaults to (Align.CENTER, Align.CENTER, Align.CENTER).
-        mode (Mode, optional): combine mode. Defaults to Mode.ADD.
+        xsize (float): length of near face along x-axis
+        ysize (float): length of part along y-axis
+        zsize (float): length of near face z-axis
+        xmin (float): minimum position far face along x-axis
+        zmin (float): minimum position far face along z-axis
+        xmax (float): maximum position far face along x-axis
+        zmax (float): maximum position far face along z-axis
+        rotation (RotationLike, optional): angles to rotate about axes. Defaults to (0, 0, 0)
+        align (Align | tuple[Align, Align, Align] | None, optional): align MIN, CENTER,
+            or MAX of object. Defaults to (Align.CENTER, Align.CENTER, Align.CENTER)
+        mode (Mode, optional): combine mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildPart._tag]

--- a/src/build123d/objects_part.py
+++ b/src/build123d/objects_part.py
@@ -103,7 +103,7 @@ class BasePartObject(Part):
 class Box(BasePartObject):
     """Part Object: Box
 
-    Add a box defined by length, width, and height.
+    Create a box defined by length, width, and height.
 
     Args:
         length (float): box length
@@ -147,7 +147,7 @@ class Box(BasePartObject):
 class Cone(BasePartObject):
     """Part Object: Cone
 
-    Add a cone defined by bottom radius, top radius, and height.
+    Create a cone defined by bottom radius, top radius, and height.
 
     Args:
         bottom_radius (float): bottom radius
@@ -200,7 +200,7 @@ class Cone(BasePartObject):
 class CounterBoreHole(BasePartObject):
     """Part Operation: Counter Bore Hole
 
-    Subtract a counter bore hole defined by radius, counter bore radius, counter bore and depth.
+    Create a counter bore hole defined by radius, counter bore radius, counter bore and depth.
 
     Args:
         radius (float): hole radius
@@ -253,8 +253,8 @@ class CounterBoreHole(BasePartObject):
 class CounterSinkHole(BasePartObject):
     """Part Operation: Counter Sink Hole
 
-    Subtract a countersink hole defined by radius, countersink radius, countersink
-        angle, and depth.
+    Create a countersink hole defined by radius, countersink radius, countersink
+    angle, and depth.
 
     Args:
         radius (float): hole radius
@@ -311,7 +311,7 @@ class CounterSinkHole(BasePartObject):
 class Cylinder(BasePartObject):
     """Part Object: Cylinder
 
-    Add a cylinder defined by radius and height.
+    Create a cylinder defined by radius and height.
 
     Args:
         radius (float): cylinder radius
@@ -359,7 +359,7 @@ class Cylinder(BasePartObject):
 class Hole(BasePartObject):
     """Part Operation: Hole
 
-    Subtract a hole defined by radius and depth.
+    Create a hole defined by radius and depth.
 
     Args:
         radius (float): hole radius
@@ -406,7 +406,7 @@ class Hole(BasePartObject):
 class Sphere(BasePartObject):
     """Part Object: Sphere
 
-    Add a sphere defined by a radius.
+    Create a sphere defined by a radius.
 
     Args:
         radius (float): sphere radius
@@ -458,7 +458,7 @@ class Sphere(BasePartObject):
 class Torus(BasePartObject):
     """Part Object: Torus
 
-    Add a torus defined by major and minor radii.
+    Create a torus defined by major and minor radii.
 
     Args:
         major_radius (float): major torus radius
@@ -514,7 +514,7 @@ class Torus(BasePartObject):
 class Wedge(BasePartObject):
     """Part Object: Wedge
 
-    Add a wedge with a near face defined by xsize and z size, a far face defined by
+    Create a wedge with a near face defined by xsize and z size, a far face defined by
     xmin to xmax and zmin to zmax, and a depth of ysize.
 
     Args:

--- a/src/build123d/objects_sketch.py
+++ b/src/build123d/objects_sketch.py
@@ -66,10 +66,10 @@ class BaseSketchObject(Sketch):
 
     Args:
         face (Face): face to create
-        rotation (float, optional): angles to rotate objects. Defaults to 0.
-        align (Union[Align, tuple[Align, Align]], optional): align min, center, or max of object.
-            Defaults to None.
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        rotation (float, optional): angle to rotate object. Defaults to 0
+        align (Align | tuple[Align, Align], optional): align MIN, CENTER, or MAX of object.
+            Defaults to None
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildSketch._tag]
@@ -109,13 +109,13 @@ class BaseSketchObject(Sketch):
 class Circle(BaseSketchObject):
     """Sketch Object: Circle
 
-    Add circle(s) to the sketch.
+    Add circle defined by radius.
 
     Args:
-        radius (float): circle size
-        align (Union[Align, tuple[Align, Align]], optional): align min, center, or max of object.
-            Defaults to (Align.CENTER, Align.CENTER).
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        radius (float): circle radius
+        align (Align | tuple[Align, Align], optional): align MIN, CENTER, or MAX of object.
+            Defaults to (Align.CENTER, Align.CENTER)
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildSketch._tag]
@@ -139,15 +139,15 @@ class Circle(BaseSketchObject):
 class Ellipse(BaseSketchObject):
     """Sketch Object: Ellipse
 
-    Add ellipse(s) to sketch.
+    Add ellipse defined by x- and y- radii.
 
     Args:
-        x_radius (float): horizontal radius
-        y_radius (float): vertical radius
-        rotation (float, optional): angles to rotate objects. Defaults to 0.
-        align (Union[Align, tuple[Align, Align]], optional): align min, center, or max of object.
-            Defaults to (Align.CENTER, Align.CENTER).
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        x_radius (float): x radius of the ellipse (along the x-axis of plane)
+        y_radius (float): y radius of the ellipse (along the y-axis of plane)
+        rotation (float, optional): angle to rotate object. Defaults to 0
+        align (Align | tuple[Align, Align], optional): align MIN, CENTER, or MAX of object.
+            Defaults to (Align.CENTER, Align.CENTER)
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildSketch._tag]
@@ -174,20 +174,19 @@ class Ellipse(BaseSketchObject):
 class Polygon(BaseSketchObject):
     """Sketch Object: Polygon
 
-    Add polygon(s) defined by given sequence of points to sketch.
+    Add polygon defined by given sequence of points.
 
-    Note that the order of the points define the normal of the Face that is created in
-    Algebra mode, where counter clockwise order creates Faces with their normal being up
-    while a clockwise order will have a normal that is down.  In Builder mode, all Faces
-    added to the sketch are up.
+    Note: the order of the points defines the resulting normal of the Face in Algebra
+    mode, where counter-clockwise order creates an upward normal while clockwise order
+    a downward normal. In Builder mode, the Face is added with an upward normal.
 
     Args:
-        pts (Union[VectorLike, Iterable[VectorLike]]): sequence of points defining the
+        pts (VectorLike | Iterable[VectorLike]): sequence of points defining the
             vertices of the polygon
-        rotation (float, optional): angles to rotate objects. Defaults to 0.
-        align (Union[Align, tuple[Align, Align]], optional): align min, center, or max of object.
-            Defaults to (Align.CENTER, Align.CENTER).
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        rotation (float, optional): angle to rotate object. Defaults to 0
+        align (Align | tuple[Align, Align], optional): align MIN, CENTER, or MAX of object.
+            Defaults to (Align.CENTER, Align.CENTER)
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildSketch._tag]
@@ -214,15 +213,15 @@ class Polygon(BaseSketchObject):
 class Rectangle(BaseSketchObject):
     """Sketch Object: Rectangle
 
-    Add rectangle(s) to sketch.
+    Add rectangle defined by width and height.
 
     Args:
-        width (float): horizontal size
-        height (float): vertical size
-        rotation (float, optional): angles to rotate objects. Defaults to 0.
-        align (Union[Align, tuple[Align, Align]], optional): align min, center, or max of object.
-            Defaults to (Align.CENTER, Align.CENTER).
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        width (float): rectangle width
+        height (float): rectangle height
+        rotation (float, optional): angle to rotate object. Defaults to 0
+        align (Align | tuple[Align, Align], optional): align MIN, CENTER, or MAX of object.
+            Defaults to (Align.CENTER, Align.CENTER)
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildSketch._tag]
@@ -247,18 +246,18 @@ class Rectangle(BaseSketchObject):
 
 
 class RectangleRounded(BaseSketchObject):
-    """Sketch Object: RectangleRounded
+    """Sketch Object: Rectangle Rounded
 
-    Add rectangle(s) with filleted corners to sketch.
+    Add rectangle defined by width and height with filleted corners.
 
     Args:
-        width (float): horizontal size
-        height (float): vertical size
+        width (float): rectangle width
+        height (float): rectangle height
         radius (float): fillet radius
-        rotation (float, optional): angles to rotate objects. Defaults to 0.
-        align (Union[Align, tuple[Align, Align]], optional): align min, center, or max of object.
-            Defaults to (Align.CENTER, Align.CENTER).
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        rotation (float, optional): angle to rotate object. Defaults to 0
+        align (Align | tuple[Align, Align], optional): align MIN, CENTER, or MAX of object.
+            Defaults to (Align.CENTER, Align.CENTER)
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildSketch._tag]
@@ -290,19 +289,18 @@ class RectangleRounded(BaseSketchObject):
 class RegularPolygon(BaseSketchObject):
     """Sketch Object: Regular Polygon
 
-    Add regular polygon(s) to sketch.
+    Add regular polygon defined by radius and side count. Use major_radius to define whether
+    the polygon circumscribes (along the vertices) or inscribes (along the sides) the radius circle.
 
     Args:
-        radius (float): distance from origin to vertices (major), or
-            optionally from the origin to side (minor) with major_radius = False
-        side_count (int): number of polygon sides
-        major_radius (bool): If True the radius is the major radius, else the
-            radius is the minor radius (also known as inscribed radius).
-            Defaults to True.
-        rotation (float, optional): angles to rotate objects. Defaults to 0.
-        align (Union[Align, tuple[Align, Align]], optional): align min, center, or max of object.
-            Defaults to (Align.CENTER, Align.CENTER).
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        radius (float): construction radius
+        side_count (int): number of sides
+        major_radius (bool): If True the radius is the major radius (circumscribed circle),
+            else the radius is the minor radius (inscribed circle). Defaults to True
+        rotation (float, optional): angle to rotate object. Defaults to 0
+        align (Align | tuple[Align, Align], optional): align MIN, CENTER, or MAX of object.
+            Defaults to (Align.CENTER, Align.CENTER)
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildSketch._tag]
@@ -361,15 +359,15 @@ class RegularPolygon(BaseSketchObject):
 
 
 class SlotArc(BaseSketchObject):
-    """Sketch Object: Arc Slot
+    """Sketch Object: Slot Arc
 
-    Add slot(s) following an arc to sketch.
+    Add slot defined by a line and height. May be an arc, stright line, spline, etc.
 
     Args:
-        arc (Union[Edge, Wire]): center line of slot
-        height (float): diameter of end circles
-        rotation (float, optional): angles to rotate objects. Defaults to 0.
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        arc (Edge | Wire): center line of slot
+        height (float): diameter of end arcs
+        rotation (float, optional): angle to rotate object. Defaults to 0
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildSketch._tag]
@@ -393,18 +391,17 @@ class SlotArc(BaseSketchObject):
 
 
 class SlotCenterPoint(BaseSketchObject):
-    """Sketch Object: Center Point Slot
+    """Sketch Object: Slot Center Point
 
-    Add a slot(s) defined by the center of the slot and the center of one of the
-    circular arcs at the end. The other end will be generated to create a symmetric
-    slot.
+    Add a slot defined by the center of the slot and the center of one end arc.
+    The slot will be symmetric about the center point.
 
     Args:
-        center (VectorLike): slot center point
-        point (VectorLike): slot center of arc point
-        height (float): diameter of end circles
-        rotation (float, optional): angles to rotate objects. Defaults to 0.
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        center (VectorLike): center point
+        point (VectorLike): center of arc point
+        height (float): diameter of end arcs
+        rotation (float, optional): angle to rotate object. Defaults to 0
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildSketch._tag]
@@ -446,16 +443,15 @@ class SlotCenterPoint(BaseSketchObject):
 
 
 class SlotCenterToCenter(BaseSketchObject):
-    """Sketch Object: Center to Center points Slot
+    """Sketch Object: Slot Center To Center
 
-    Add slot(s) defined by the distance between the center of the two
-    end arcs.
+    Add slot defined by the distance between the centers of the two end arcs.
 
     Args:
-        center_separation (float): distance between two arc centers
-        height (float): diameter of end circles
-        rotation (float, optional): angles to rotate objects. Defaults to 0.
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        center_separation (float): distance between arc centers
+        height (float): diameter of end arcs
+        rotation (float, optional): angle to rotate object. Defaults to 0
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildSketch._tag]
@@ -490,17 +486,17 @@ class SlotCenterToCenter(BaseSketchObject):
 
 
 class SlotOverall(BaseSketchObject):
-    """Sketch Object: Center to Center points Slot
+    """Sketch Object: Slot Overall
 
-    Add slot(s) defined by the overall with of the slot.
+    Add slot defined by the overall width and height.
 
     Args:
-        width (float): overall width of the slot
-        height (float): diameter of end circles
-        rotation (float, optional): angles to rotate objects. Defaults to 0.
-        align (Union[Align, tuple[Align, Align]], optional): align min, center, or max of object.
-            Defaults to (Align.CENTER, Align.CENTER).
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        width (float): overall width of slot
+        height (float): diameter of end arcs
+        rotation (float, optional): angle to rotate object. Defaults to 0
+        align (Align | tuple[Align, Align], optional): align MIN, CENTER, or MAX of object.
+            Defaults to (Align.CENTER, Align.CENTER)
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
     """
 
     _applies_to = [BuildSketch._tag]
@@ -541,21 +537,24 @@ class SlotOverall(BaseSketchObject):
 class Text(BaseSketchObject):
     """Sketch Object: Text
 
-    Add text(s) to the sketch.
+    Add text defined by text string and font size.
+    May have difficulty finding non-system fonts depending on platform and render default.
+    font_path defines an exact path to a font file and overrides font.
 
     Args:
-        txt (str): text to be rendered
+        txt (str): text to render
         font_size (float): size of the font in model units
-        font (str, optional): font name. Defaults to "Arial".
-        font_path (str, optional): system path to font library. Defaults to None.
-        font_style (Font_Style, optional): style. Defaults to Font_Style.REGULAR.
-        align (Union[Align, tuple[Align, Align]], optional): align min, center, or max of object.
-            Defaults to (Align.CENTER, Align.CENTER).
-        path (Union[Edge, Wire], optional): path for text to follow. Defaults to None.
+        font (str, optional): font name. Defaults to "Arial"
+        font_path (str, optional): system path to font file. Defaults to None
+        font_style (Font_Style, optional): font style, REGULAR, BOLD, or ITALIC.
+            Defaults to Font_Style.REGULAR
+        align (Align | tuple[Align, Align], optional): align MIN, CENTER, or MAX of object.
+            Defaults to (Align.CENTER, Align.CENTER)
+        path (Edge | Wire, optional): path for text to follow. Defaults to None
         position_on_path (float, optional): the relative location on path to position the
-            text, values must be between 0.0 and 1.0. Defaults to 0.0.
-        rotation (float, optional): angles to rotate objects. Defaults to 0.
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+            text, values must be between 0.0 and 1.0. Defaults to 0.0
+        rotation (float, optional): angle to rotate object. Defaults to 0
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
     """
 
     # pylint: disable=too-many-instance-attributes
@@ -604,18 +603,18 @@ class Text(BaseSketchObject):
 class Trapezoid(BaseSketchObject):
     """Sketch Object: Trapezoid
 
-    Add trapezoid(s) to the sketch.
+    Add trapezoid defined by major width, height, and interior angle(s).
 
     Args:
-        width (float): horizontal width
-        height (float): vertical height
+        width (float): trapezoid major width
+        height (float): trapezoid height
         left_side_angle (float): bottom left interior angle
         right_side_angle (float, optional): bottom right interior angle. If not provided,
-            the trapezoid will be symmetric. Defaults to None.
-        rotation (float, optional): angles to rotate objects. Defaults to 0.
-        align (Union[Align, tuple[Align, Align]], optional): align min, center, or max of object.
-            Defaults to (Align.CENTER, Align.CENTER).
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+            the trapezoid will be symmetric. Defaults to None
+        rotation (float, optional): angle to rotate object. Defaults to 0
+        align (Align | tuple[Align, Align], optional): align MIN, CENTER, or MAX of object.
+            Defaults to (Align.CENTER, Align.CENTER)
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
 
     Raises:
         ValueError: Give angles result in an invalid trapezoid
@@ -685,21 +684,22 @@ class Trapezoid(BaseSketchObject):
 class Triangle(BaseSketchObject):
     """Sketch Object: Triangle
 
-    Add any triangle to the sketch by specifying the length of any side and any
-    two other side lengths or interior angles. Note that the interior angles are
-    opposite the side with the same designation (i.e. side 'a' is opposite angle 'A').
+    Add a triangle defined by one side length and any of two other side lengths or interior
+    angles. The interior angles are opposite the side with the same designation
+    (i.e. side 'a' is opposite angle 'A'). Side 'a' is the bottom side, followed by 'b'
+    on the right, going counter-clockwise.
 
     Args:
-        a (float, optional): side 'a' length. Defaults to None.
-        b (float, optional): side 'b' length. Defaults to None.
-        c (float, optional): side 'c' length. Defaults to None.
-        A (float, optional): interior angle 'A' in degrees. Defaults to None.
-        B (float, optional): interior angle 'B' in degrees. Defaults to None.
-        C (float, optional): interior angle 'C' in degrees. Defaults to None.
-        rotation (float, optional): angles to rotate objects. Defaults to 0.
-        align (Union[Align, tuple[Align, Align]], optional): align min, center, or max of object.
-            Defaults to None.
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        a (float, optional): side 'a' length. Defaults to None
+        b (float, optional): side 'b' length. Defaults to None
+        c (float, optional): side 'c' length. Defaults to None
+        A (float, optional): interior angle 'A'. Defaults to None
+        B (float, optional): interior angle 'B'. Defaults to None
+        C (float, optional): interior angle 'C'. Defaults to None
+        rotation (float, optional): angle to rotate object. Defaults to 0
+        align (Align | tuple[Align, Align], optional): align MIN, CENTER, or MAX of object.
+            Defaults to None
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
 
     Raises:
         ValueError: One length and two other values were not provided

--- a/src/build123d/objects_sketch.py
+++ b/src/build123d/objects_sketch.py
@@ -109,7 +109,7 @@ class BaseSketchObject(Sketch):
 class Circle(BaseSketchObject):
     """Sketch Object: Circle
 
-    Add circle defined by radius.
+    Create a circle defined by radius.
 
     Args:
         radius (float): circle radius
@@ -139,7 +139,7 @@ class Circle(BaseSketchObject):
 class Ellipse(BaseSketchObject):
     """Sketch Object: Ellipse
 
-    Add ellipse defined by x- and y- radii.
+    Create an ellipse defined by x- and y- radii.
 
     Args:
         x_radius (float): x radius of the ellipse (along the x-axis of plane)
@@ -174,7 +174,7 @@ class Ellipse(BaseSketchObject):
 class Polygon(BaseSketchObject):
     """Sketch Object: Polygon
 
-    Add polygon defined by given sequence of points.
+    Create a polygon defined by given sequence of points.
 
     Note: the order of the points defines the resulting normal of the Face in Algebra
     mode, where counter-clockwise order creates an upward normal while clockwise order
@@ -213,7 +213,7 @@ class Polygon(BaseSketchObject):
 class Rectangle(BaseSketchObject):
     """Sketch Object: Rectangle
 
-    Add rectangle defined by width and height.
+    Create a rectangle defined by width and height.
 
     Args:
         width (float): rectangle width
@@ -248,7 +248,7 @@ class Rectangle(BaseSketchObject):
 class RectangleRounded(BaseSketchObject):
     """Sketch Object: Rectangle Rounded
 
-    Add rectangle defined by width and height with filleted corners.
+    Create a rectangle defined by width and height with filleted corners.
 
     Args:
         width (float): rectangle width
@@ -289,7 +289,7 @@ class RectangleRounded(BaseSketchObject):
 class RegularPolygon(BaseSketchObject):
     """Sketch Object: Regular Polygon
 
-    Add regular polygon defined by radius and side count. Use major_radius to define whether
+    Create a regular polygon defined by radius and side count. Use major_radius to define whether
     the polygon circumscribes (along the vertices) or inscribes (along the sides) the radius circle.
 
     Args:
@@ -361,7 +361,7 @@ class RegularPolygon(BaseSketchObject):
 class SlotArc(BaseSketchObject):
     """Sketch Object: Slot Arc
 
-    Add slot defined by a line and height. May be an arc, stright line, spline, etc.
+    Create a slot defined by a line and height. May be an arc, stright line, spline, etc.
 
     Args:
         arc (Edge | Wire): center line of slot
@@ -393,7 +393,7 @@ class SlotArc(BaseSketchObject):
 class SlotCenterPoint(BaseSketchObject):
     """Sketch Object: Slot Center Point
 
-    Add a slot defined by the center of the slot and the center of one end arc.
+    Create a slot defined by the center of the slot and the center of one end arc.
     The slot will be symmetric about the center point.
 
     Args:
@@ -445,7 +445,7 @@ class SlotCenterPoint(BaseSketchObject):
 class SlotCenterToCenter(BaseSketchObject):
     """Sketch Object: Slot Center To Center
 
-    Add slot defined by the distance between the centers of the two end arcs.
+    Create a slot defined by the distance between the centers of the two end arcs.
 
     Args:
         center_separation (float): distance between arc centers
@@ -488,7 +488,7 @@ class SlotCenterToCenter(BaseSketchObject):
 class SlotOverall(BaseSketchObject):
     """Sketch Object: Slot Overall
 
-    Add slot defined by the overall width and height.
+    Create a slot defined by the overall width and height.
 
     Args:
         width (float): overall width of slot
@@ -537,7 +537,7 @@ class SlotOverall(BaseSketchObject):
 class Text(BaseSketchObject):
     """Sketch Object: Text
 
-    Add text defined by text string and font size.
+    Create text defined by text string and font size.
     May have difficulty finding non-system fonts depending on platform and render default.
     font_path defines an exact path to a font file and overrides font.
 
@@ -603,7 +603,7 @@ class Text(BaseSketchObject):
 class Trapezoid(BaseSketchObject):
     """Sketch Object: Trapezoid
 
-    Add trapezoid defined by major width, height, and interior angle(s).
+    Create a trapezoid defined by major width, height, and interior angle(s).
 
     Args:
         width (float): trapezoid major width
@@ -684,7 +684,7 @@ class Trapezoid(BaseSketchObject):
 class Triangle(BaseSketchObject):
     """Sketch Object: Triangle
 
-    Add a triangle defined by one side length and any of two other side lengths or interior
+    Create a triangle defined by one side length and any of two other side lengths or interior
     angles. The interior angles are opposite the side with the same designation
     (i.e. side 'a' is opposite angle 'A'). Side 'a' is the bottom side, followed by 'b'
     on the right, going counter-clockwise.


### PR DESCRIPTION
Update object_*.py docstrings for more consistency. Clarify how parameters work and objects are constructed.

General improvements:
- follow a similar opening description: `Add/subtract a {object} defined by...` with more explicit behavior
- update union type declarations in string
- remove plurality references (sketch, part). Methods to create multiple parts/sketches occur outside the objects
- remove angles plurality from 1d and 2d objects
- remove hanging end stops (.) from lists
- try to make arg descriptions more consistent and descriptive
- try to specify viable enums if mentioned and CAPITALIZE
- other editing for wordiness