### PR TITLE
PolarLine() make localized direction a unit vector to only scale by length

### DIFF
--- a/src/build123d/objects_curve.py
+++ b/src/build123d/objects_curve.py
@@ -711,10 +711,11 @@ class PolarLine(BaseEdgeObject):
     Args:
         start (VectorLike): start point
         length (float): line length
-        angle (float): angle from the local "X" axis.
+        angle (float, optional): angle from the local "X" axis
+        direction (VectorLike, optional): point to determine angle
         length_mode (LengthMode, optional): length value specifies a diagonal, horizontal
             or vertical value. Defaults to LengthMode.DIAGONAL
-        mode (Mode, optional): combination mode. Defaults to Mode.ADD.
+        mode (Mode, optional): combination mode. Defaults to Mode.ADD
 
     Raises:
         ValueError: Either angle or direction must be provided
@@ -743,7 +744,7 @@ class PolarLine(BaseEdgeObject):
             )
 
         if direction is not None:
-            direction_localized = WorkplaneList.localize(direction)
+            direction_localized = WorkplaneList.localize(direction).normalized()
             angle = Vector(1, 0, 0).get_angle(direction_localized)
         elif angle is not None:
             direction_localized = polar_workplane.x_dir.rotate(

--- a/src/build123d/objects_curve.py
+++ b/src/build123d/objects_curve.py
@@ -706,13 +706,13 @@ class IntersectingLine(BaseEdgeObject):
 class PolarLine(BaseEdgeObject):
     """Line Object: Polar Line
 
-    Add line defined by a start point, length and angle.
+    Add line defined by a start point, length and angle or direction.
 
     Args:
         start (VectorLike): start point
         length (float): line length
         angle (float, optional): angle from the local "X" axis
-        direction (VectorLike, optional): point to determine angle
+        direction (VectorLike, optional): vector direction to determine angle
         length_mode (LengthMode, optional): length value specifies a diagonal, horizontal
             or vertical value. Defaults to LengthMode.DIAGONAL
         mode (Mode, optional): combination mode. Defaults to Mode.ADD

--- a/tests/test_build_line.py
+++ b/tests/test_build_line.py
@@ -247,35 +247,37 @@ class BuildLineTests(unittest.TestCase):
 
     def test_polar_line(self):
         """Test 2D and 3D polar lines"""
-        with BuildLine() as bl:
-            PolarLine((0, 0), sqrt(2), 45)
-        self.assertTupleAlmostEquals((bl.edges()[0] @ 1).to_tuple(), (1, 1, 0), 5)
+        with BuildLine():
+            a1 = PolarLine((0, 0), sqrt(2), 45)
+            d1 = PolarLine((0, 0), sqrt(2), direction=(1, 1))
+        self.assertTupleAlmostEquals((a1 @ 1).to_tuple(), (1, 1, 0), 5)
+        self.assertTupleAlmostEquals((a1 @ 1).to_tuple(), (d1 @ 1).to_tuple(), 5)
+        self.assertTrue(isinstance(a1, Edge))
+        self.assertTrue(isinstance(d1, Edge))
 
-        with BuildLine() as bl:
-            PolarLine((0, 0), 1, 30)
-        self.assertTupleAlmostEquals(
-            (bl.edges()[0] @ 1).to_tuple(), (sqrt(3) / 2, 0.5, 0), 5
-        )
+        with BuildLine():
+            a2 = PolarLine((0, 0), 1, 30)
+            d2 = PolarLine((0, 0), 1, direction=(sqrt(3), 1))
+        self.assertTupleAlmostEquals((a2 @ 1).to_tuple(), (sqrt(3) / 2, 0.5, 0), 5)
+        self.assertTupleAlmostEquals((a2 @ 1).to_tuple(), (d2 @ 1).to_tuple(), 5)
 
-        with BuildLine() as bl:
-            PolarLine((0, 0), 1, 150)
-        self.assertTupleAlmostEquals(
-            (bl.edges()[0] @ 1).to_tuple(), (-sqrt(3) / 2, 0.5, 0), 5
-        )
+        with BuildLine():
+            a3 = PolarLine((0, 0), 1, 150)
+            d3 = PolarLine((0, 0), 1, direction=(-sqrt(3), 1))
+        self.assertTupleAlmostEquals((a3 @ 1).to_tuple(), (-sqrt(3) / 2, 0.5, 0), 5)
+        self.assertTupleAlmostEquals((a3 @ 1).to_tuple(), (d3 @ 1).to_tuple(), 5)
 
-        with BuildLine() as bl:
-            PolarLine((0, 0), 1, angle=30, length_mode=LengthMode.HORIZONTAL)
-        self.assertTupleAlmostEquals(
-            (bl.edges()[0] @ 1).to_tuple(), (1, 1 / sqrt(3), 0), 5
-        )
+        with BuildLine():
+            a4 = PolarLine((0, 0), 1, angle=30, length_mode=LengthMode.HORIZONTAL)
+            d4 = PolarLine((0, 0), 1, direction=(sqrt(3), 1), length_mode=LengthMode.HORIZONTAL)
+        self.assertTupleAlmostEquals((a4 @ 1).to_tuple(), (1, 1 / sqrt(3), 0), 5)
+        self.assertTupleAlmostEquals((a4 @ 1).to_tuple(), (d4 @ 1).to_tuple(), 5)
 
-        with BuildLine(Plane.XZ) as bl:
-            PolarLine((0, 0), 1, angle=30, length_mode=LengthMode.VERTICAL)
-        self.assertTupleAlmostEquals((bl.edges()[0] @ 1).to_tuple(), (sqrt(3), 0, 1), 5)
-
-        l1 = PolarLine((0, 0), 10, direction=(1, 1))
-        self.assertTupleAlmostEquals((l1 @ 1).to_tuple(), (10, 10, 0), 5)
-        self.assertTrue(isinstance(l1, Edge))
+        with BuildLine(Plane.XZ):
+            a5 = PolarLine((0, 0), 1, angle=30, length_mode=LengthMode.VERTICAL)
+            d5 = PolarLine((0, 0), 1, direction=(sqrt(3), 1), length_mode=LengthMode.VERTICAL)
+        self.assertTupleAlmostEquals((a5 @ 1).to_tuple(), (sqrt(3), 0, 1), 5)
+        self.assertTupleAlmostEquals((a5 @ 1).to_tuple(), (d5 @ 1).to_tuple(), 5)
 
         with self.assertRaises(ValueError):
             PolarLine((0, 0), 1)


### PR DESCRIPTION
Update `PolarLine()` with potentially breaking change to `direction` kwarg
- Add direction to docstring 
- Make localized direction unit vector with `normalize()`
- Update tests for angle/direction parity

Currently, when `PolarLine()` is defined by `direction` the result is a line made by `direction` using the vector magnitude and then scaling by `length`. This is unexpected behavior based on how `length` + `angle` works; **only `length` should scale the resulting line**.

This change normalizes the localized direction so e.g. `PolarLine((0,0), 3, angle=45)`  and `PolarLine((0,0), 3, direction=(1,1))` produce the same result.

### Justification for acceptable breakage
Most people are probably giving `direction` a unit vector already through `%`

### Uses within the codebase
Affected:
- `/docs/objects_1d.py` Shortens JernArc svg dashed tangent line by ~.06. Cosmetic, not fixing or rebuilding docs

Unaffected unit vectors:
- `/docs/objects_1d.py` 2 other places
- `/examples/pegboard_j_hook_algebra.py` 3 places
- `/examples/pegboard_j_hook.py` 3 places
- `/docs/assets/ttt/ttt-23-02-02-sm_hanger.py` 2 places