### PR TITLE
Use `uv` for setup of github actions workflows

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -8,10 +8,10 @@ runs:
   using: "composite"
   steps:
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: astral-sh/setup-uv@v5
       with:
         python-version: ${{ inputs.python-version }}
     - name: Install Requirements
       shell: bash
       run: |
-        pip install .[development]
+        uv install .[development]

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -14,4 +14,4 @@ runs:
     - name: Install Requirements
       shell: bash
       run: |
-        uv install .[development]
+        uv pip install .[development]

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,6 +10,7 @@ runs:
     - name: Setup Python
       uses: astral-sh/setup-uv@v5
       with:
+        enable-cache: false
         python-version: ${{ inputs.python-version }}
     - name: Install Requirements
       shell: bash


### PR DESCRIPTION
on e.g. py313 + ubuntu it takes setup time from ~33s to ~7s to install `.[development]`

Creating as draft so that I can research caching issues further.