### PR TITLE
Use lazy imports in topology to speed up library import.

### DIFF
--- a/src/build123d/exporters.py
+++ b/src/build123d/exporters.py
@@ -71,7 +71,7 @@ from build123d.topology import (
 from build123d.build_common import UNITS_PER_METER
 
 if TYPE_CHECKING:
-    import svgpathtools as PT
+    import svgpathtools as PT  # pylint: disable=C0415
     PathSegment: TypeAlias = PT.Line | PT.Arc | PT.QuadraticBezier | PT.CubicBezier
     """A type alias for the various path segment types in the svgpathtools library."""
 

--- a/src/build123d/exporters.py
+++ b/src/build123d/exporters.py
@@ -30,6 +30,8 @@ license:
 # pylint: disable=no-name-in-module, import-error
 # pylint: disable=too-many-lines
 
+from __future__ import annotations
+from typing import TYPE_CHECKING
 import math
 import xml.etree.ElementTree as ET
 from copy import copy
@@ -41,7 +43,6 @@ from warnings import warn
 from collections.abc import Callable, Iterable
 
 import ezdxf
-import svgpathtools as PT
 from ezdxf import zoom
 from ezdxf.colors import RGB, aci2rgb
 from ezdxf.math import Vec2
@@ -69,8 +70,10 @@ from build123d.topology import (
 )
 from build123d.build_common import UNITS_PER_METER
 
-PathSegment: TypeAlias = PT.Line | PT.Arc | PT.QuadraticBezier | PT.CubicBezier
-"""A type alias for the various path segment types in the svgpathtools library."""
+if TYPE_CHECKING:
+    import svgpathtools as PT
+    PathSegment: TypeAlias = PT.Line | PT.Arc | PT.QuadraticBezier | PT.CubicBezier
+    """A type alias for the various path segment types in the svgpathtools library."""
 
 # ---------------------------------------------------------------------------
 # ---------------------------------------------------------------------------

--- a/src/build123d/importers.py
+++ b/src/build123d/importers.py
@@ -67,8 +67,6 @@ from OCP.XCAFDoc import (
     XCAFDoc_ColorSurf,
     XCAFDoc_DocumentTool,
 )
-from ocpsvg import ColorAndLabel, import_svg_document
-from svgpathtools import svg2paths
 
 from build123d.build_enums import Align
 from build123d.geometry import Color, Location, Vector, to_align_offset
@@ -270,6 +268,7 @@ def import_svg_as_buildline_code(
     Returns:
         tuple[str, str]: code, builder instance name
     """
+    from svgpathtools import svg2paths
 
     translator = {
         "Line": ["Line", "start", "end"],
@@ -361,6 +360,8 @@ def import_svg(
     Returns:
         ShapeList[Union[Wire, Face]]: objects contained in svg
     """
+    from ocpsvg import ColorAndLabel, import_svg_document
+
     if is_inkscape_label is not None:  # TODO remove for `1.0` release
         msg = "`is_inkscape_label` parameter is deprecated"
         if is_inkscape_label:

--- a/src/build123d/importers.py
+++ b/src/build123d/importers.py
@@ -268,7 +268,7 @@ def import_svg_as_buildline_code(
     Returns:
         tuple[str, str]: code, builder instance name
     """
-    from svgpathtools import svg2paths
+    from svgpathtools import svg2paths  # pylint: disable=C0415
 
     translator = {
         "Line": ["Line", "start", "end"],
@@ -360,7 +360,7 @@ def import_svg(
     Returns:
         ShapeList[Union[Wire, Face]]: objects contained in svg
     """
-    from ocpsvg import ColorAndLabel, import_svg_document
+    from ocpsvg import ColorAndLabel, import_svg_document  # pylint: disable=C0415
 
     if is_inkscape_label is not None:  # TODO remove for `1.0` release
         msg = "`is_inkscape_label` parameter is deprecated"

--- a/src/build123d/objects_curve.py
+++ b/src/build123d/objects_curve.py
@@ -203,7 +203,7 @@ class DoubleTangentArc(BaseEdgeObject):
         keep: Keep = Keep.TOP,
         mode: Mode = Mode.ADD,
     ):
-        from scipy.optimize import minimize
+        from scipy.optimize import minimize  # pylint: disable=C0415
 
         context: BuildLine | None = BuildLine._get_context(self)
         validate_inputs(context, self)

--- a/src/build123d/objects_curve.py
+++ b/src/build123d/objects_curve.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 
 import copy as copy_module
 from math import copysign, cos, radians, sin, sqrt
-from scipy.optimize import minimize
 
 from collections.abc import Iterable
 
@@ -204,6 +203,8 @@ class DoubleTangentArc(BaseEdgeObject):
         keep: Keep = Keep.TOP,
         mode: Mode = Mode.ADD,
     ):
+        from scipy.optimize import minimize
+
         context: BuildLine | None = BuildLine._get_context(self)
         validate_inputs(context, self)
 

--- a/src/build123d/operations_sketch.py
+++ b/src/build123d/operations_sketch.py
@@ -75,7 +75,7 @@ def full_round(
         geometric center of the arc, and the third the radius of the arc
 
     """
-    from scipy.spatial import Voronoi
+    from scipy.spatial import Voronoi  # pylint: disable=C0415
 
     context: BuildSketch | None = BuildSketch._get_context("full_round")
 

--- a/src/build123d/operations_sketch.py
+++ b/src/build123d/operations_sketch.py
@@ -30,7 +30,6 @@ license:
 from __future__ import annotations
 
 from collections.abc import Iterable
-from scipy.spatial import Voronoi
 from build123d.build_enums import Mode, SortBy
 from build123d.topology import (
     Compound,
@@ -76,6 +75,8 @@ def full_round(
         geometric center of the arc, and the third the radius of the arc
 
     """
+    from scipy.spatial import Voronoi
+
     context: BuildSketch | None = BuildSketch._get_context("full_round")
 
     if not isinstance(edge, Edge):

--- a/src/build123d/topology/one_d.py
+++ b/src/build123d/topology/one_d.py
@@ -60,8 +60,6 @@ from math import radians, inf, pi, cos, copysign, ceil, floor
 from typing import Literal, overload, TYPE_CHECKING
 from typing_extensions import Self
 from numpy import ndarray
-from scipy.optimize import minimize
-from scipy.spatial import ConvexHull
 
 import OCP.TopAbs as ta
 from OCP.BRep import BRep_Tool
@@ -1972,6 +1970,8 @@ class Edge(Mixin1D, Shape[TopoDS_Edge]):
     def param_at_point(self, point: VectorLike) -> float:
         """Normalized parameter at point along Edge"""
 
+        from scipy.optimize import minimize
+
         # Note that this search algorithm would ideally be replaced with
         # an OCP based solution, something like that which is shown below.
         # However, there are known issues with the OCP methods for some
@@ -2438,6 +2438,8 @@ class Wire(Mixin1D, Shape[TopoDS_Wire]):
         Returns:
             Wire: convex hull perimeter
         """
+        from scipy.spatial import ConvexHull
+
         # pylint: disable=too-many-branches, too-many-locals
         # Algorithm:
         # 1) create a cloud of points along all edges

--- a/src/build123d/topology/one_d.py
+++ b/src/build123d/topology/one_d.py
@@ -1970,7 +1970,7 @@ class Edge(Mixin1D, Shape[TopoDS_Edge]):
     def param_at_point(self, point: VectorLike) -> float:
         """Normalized parameter at point along Edge"""
 
-        from scipy.optimize import minimize
+        from scipy.optimize import minimize  # pylint: disable=C0415
 
         # Note that this search algorithm would ideally be replaced with
         # an OCP based solution, something like that which is shown below.
@@ -2438,7 +2438,7 @@ class Wire(Mixin1D, Shape[TopoDS_Wire]):
         Returns:
             Wire: convex hull perimeter
         """
-        from scipy.spatial import ConvexHull
+        from scipy.spatial import ConvexHull  # pylint: disable=C0415
 
         # pylint: disable=too-many-branches, too-many-locals
         # Algorithm:

--- a/src/build123d/topology/shape_core.py
+++ b/src/build123d/topology/shape_core.py
@@ -60,8 +60,10 @@ from typing import (
     TypeVar,
     Union,
     overload,
+    Literal,
     TYPE_CHECKING,
 )
+from typing_extensions import Self
 
 from collections.abc import Callable, Iterable, Iterator
 
@@ -144,10 +146,6 @@ from build123d.geometry import (
     VectorLike,
     logger,
 )
-from typing_extensions import Self
-
-from typing import Literal
-
 
 if TYPE_CHECKING:  # pragma: no cover
     from .zero_d import Vertex  # pylint: disable=R0801
@@ -2266,7 +2264,7 @@ class GroupBy(Generic[T, K]):
         return repr(ShapeList(self))
 
     def __str__(self):
-        from IPython.lib.pretty import pretty
+        from IPython.lib.pretty import pretty  # pylint: disable=C0415
 
         return pretty(self)
 

--- a/src/build123d/topology/shape_core.py
+++ b/src/build123d/topology/shape_core.py
@@ -67,7 +67,6 @@ from collections.abc import Callable, Iterable, Iterator
 
 import OCP.GeomAbs as ga
 import OCP.TopAbs as ta
-from IPython.lib.pretty import pretty, RepresentationPrinter
 from OCP.BOPAlgo import BOPAlgo_GlueEnum
 from OCP.BRep import BRep_Tool
 from OCP.BRepAdaptor import BRepAdaptor_Curve, BRepAdaptor_Surface
@@ -157,6 +156,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from .three_d import Solid  # pylint: disable=R0801
     from .composite import Compound  # pylint: disable=R0801
     from build123d.build_part import BuildPart  # pylint: disable=R0801
+    from IPython.lib.pretty import RepresentationPrinter
 
 Shapes = Literal["Vertex", "Edge", "Wire", "Face", "Shell", "Solid", "Compound"]
 TrimmingTool = Union[Plane, "Shell", "Face"]
@@ -2266,6 +2266,8 @@ class GroupBy(Generic[T, K]):
         return repr(ShapeList(self))
 
     def __str__(self):
+        from IPython.lib.pretty import pretty
+
         return pretty(self)
 
     def group(self, key: K):


### PR DESCRIPTION
Loads IPython and scipy only when actually needed. Made build123d load about 1 second (on average) faster on my machine. Python caches modules so all in all this should only be a net benefit.

This is nice when needing to restart the jupyter kernel and having to not wait as long for the library to import.
It would be even better if we could perhaps split the exporters and importers into seperate submodules, and require the user to be explicit about importing them. This would allow ezdxf and svgpathtools to be lazily imported, allowing for about half a second speed up (theoretically).
