### PR TITLE
Fix `revolve` direction and size with negative `revolution_arc`

### DIFF
--- a/src/build123d/operations_part.py
+++ b/src/build123d/operations_part.py
@@ -464,8 +464,9 @@ def revolve(
 
     # Make sure we account for users specifying angles larger than 360 degrees, and
     # for OCCT not assuming that a 0 degree revolve means a 360 degree revolve
-    angle = revolution_arc % 360.0
-    angle = 360.0 if angle == 0 else angle
+    sign = 1 if revolution_arc >= 0 else -1
+    angle = revolution_arc % (sign * 360.0)
+    angle = sign * 360.0 if angle == 0 else angle
 
     if all([s is None for s in profile_list]):
         if context is None or (context is not None and not context.pending_faces):

--- a/tests/test_build_part.py
+++ b/tests/test_build_part.py
@@ -412,6 +412,25 @@ class TestRevolve(unittest.TestCase):
         self.assertLess(test.part.volume, 244 * pi * 20, 5)
         self.assertGreater(test.part.volume, 100 * pi * 20, 5)
 
+    def test_revolve_size(self):
+        """Verify revolution result matches revolution_arc size and direction"""
+        ax = Axis.X
+        sizes = [30, 90, 150, 180, 200, 360, 500, 720, 750]
+        sizes = [x * -1 for x in sizes[::-1]] + [0] + sizes
+        for size in sizes:
+            profile = RegularPolygon(10, 4, align=(Align.CENTER, Align.MIN))
+            solid = revolve(profile, axis=ax, revolution_arc=size)
+
+            # Find any rotation edge and and the start tangent normal to the profile
+            edge = solid.edges().filter_by(GeomType.CIRCLE).sort_by(Edge.length)[-1]
+            sign = (edge % 0).Z
+
+            expected = size % (sign * 360)
+            expected = sign * 360 if expected == 0 else expected
+            result = edge.length / edge.radius / pi * 180 * sign
+
+            self.assertAlmostEqual(expected, result)
+
     # Invalid test
     # def test_invalid_axis_origin(self):
     #     with BuildPart():


### PR DESCRIPTION
Fix modulo logic for converting negative `revolution_arc` so  `angle == revolution_arc`. I assume this was an oversight as the modulo result will match sign of the modulo divisor. Previously `revolution_arc = -190` corresponded to `angle = 170`.

- Add sign for modulo divisor
- Keep sign for consistency with `angle == 360` case even though solid is the same
- Add new test for range of `revolution_arc` values

### Example

````python
with BuildPart() as part:
    with BuildSketch() as sketch:
        RegularPolygon(10, 5, align=(Align.CENTER, Align.MIN))
    revolve(axis=Axis.X, revolution_arc=-90)
````

Now
![image](https://github.com/user-attachments/assets/08c164b7-22d4-4c61-8f3e-d945961f06e5)

Previously
![image](https://github.com/user-attachments/assets/6b13a5ac-e2e6-4d54-ba79-4d6ac8eb79e9)
