### PR TITLE
Add explicit scipy dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "ocpsvg >= 0.5, < 0.6",
     "trianglesolver",
     "sympy",
+    "scipy",
 ]
 
 [project.urls]


### PR DESCRIPTION
This is used in several places in build123d e.g.

https://github.com/gumyr/build123d/blob/890f1a540b9e78b4b2dcfc802136b1b38ecceb0d/src/build123d/topology/one_d.py#L63-L64

but was previously only being pulled in implicitly via [svgpathtools](https://github.com/mathandy/svgpathtools/blob/fcb648b9bb9591d925876d3b51649fa175b40524/setup.py#L33).