### PR TITLE
Store benchmark results as CSV; artifact and printed to stdout

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,6 +22,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: benchmark
         run: |
-          python -m pytest --benchmark-only --benchmark-save
+          python -m pytest --benchmark-only --benchmark-autosave
           pytest-benchmark compare --csv="results.csv"
           echo results.csv

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,4 +24,4 @@ jobs:
         run: |
           python -m pytest --benchmark-only --benchmark-autosave
           pytest-benchmark compare --csv="results.csv"
-          echo results.csv
+          cat results.csv

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,7 +3,7 @@ name: benchmarks
 on: [push, pull_request, workflow_dispatch]
 jobs:
 
-  tests:
+  benchmarks:
     strategy:
       fail-fast: false
       matrix:
@@ -22,4 +22,5 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: benchmark
         run: |
-          python -m pytest --benchmark-only
+          python -m pytest --benchmark-only --csv="results.csv"
+          echo results.csv

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,5 +22,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: benchmark
         run: |
-          python -m pytest --benchmark-only --csv="results.csv"
+          python -m pytest --benchmark-only --benchmark-save
+          pytest-benchmark compare --csv="results.csv"
           echo results.csv

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,3 +25,7 @@ jobs:
           python -m pytest --benchmark-only --benchmark-autosave
           pytest-benchmark compare --csv="results.csv"
           cat results.csv
+      - uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: results.csv

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,5 +27,5 @@ jobs:
           cat results.csv
       - uses: actions/upload-artifact@v4
         with:
-          name: benchmark-results
+          name: benchmark-results-${{ matrix.os }}
           path: results.csv


### PR DESCRIPTION
This makes manual comparison of the data later easier, as well as storing older results for long term comparison.