### PR TITLE
Ensure tolerance is passed to wrap_edge function...

### DIFF
--- a/src/build123d/topology/two_d.py
+++ b/src/build123d/topology/two_d.py
@@ -343,7 +343,7 @@ class Mixin2D(Shape):
             # The start point isn't at the surface_loc so wrap a line to find it
             to_start_edge = Edge.make_line((0, 0), planar_edge @ 0)
             wrapped_to_start_edge = self._wrap_edge(
-                to_start_edge, surface_loc, snap_to_face=True
+                to_start_edge, surface_loc, snap_to_face=True, tolerance=tolerance
             )
             start_pnt = wrapped_to_start_edge @ 1
             _, start_normal = _intersect_surface_normal(


### PR DESCRIPTION
In doing some corner-case testing (wrapping a long ellipse around a cylinder), I noticed an exception regarding tolerance came up and was referencing the default tolerance of 0.001 rather than a user-set one. Noticed during debugging two_d.py had a line where the tolerance wasn't actually getting passed. 

Here's a rough test script to see what happens (I expect the `RuntimeError: non planar face is invalid` in this example for now, I don't expect `RuntimeError: Length error of 0.009241 exceeds tolerance 0.001` when I have a (rather extreme) tolerance set of 8.0): 

```
from build123d import *
from ocp_vscode import *

with BuildPart() as cylinder_with_wrap:

    cylinder_radius = 30.0 * MM
    cylinder_height = 100.0 * MM
    my_cylinder = Cylinder(radius=cylinder_radius,
                          height=cylinder_height,
                          rotation=(0,0,180))

    ellipse_x_radius = 48.0 * MM
    ellipse_y_radius = 10.0 * MM
    with BuildSketch() as my_ellipse:
        Ellipse(x_radius=ellipse_x_radius, y_radius=ellipse_y_radius)
        
    my_cylinder_face = my_cylinder.faces().filter_by(GeomType.CYLINDER)[0]
    my_ellipse_face = my_ellipse.face()

    target = my_cylinder_face.location_at(
        u=0.5, 
        v=0.5,
        x_dir=(-1.0, 0.0, 0.0))
    my_ellipse_wrap = my_cylinder_face.wrap(
        planar_shape=my_ellipse_face,
        surface_loc=target,
        tolerance=8.0
        )    

show(my_cylinder, my_ellipse_wrap, target)
```

