### PR TITLE
fix PolarLine with angles that make the length negative

### DIFF
--- a/src/build123d/objects_curve.py
+++ b/src/build123d/objects_curve.py
@@ -779,9 +779,9 @@ class PolarLine(BaseEdgeObject):
         if length_mode == LengthMode.DIAGONAL:
             length_vector = direction_localized * length
         elif length_mode == LengthMode.HORIZONTAL:
-            length_vector = direction_localized * (length / cos(radians(angle)))
+            length_vector = direction_localized * abs(length / cos(radians(angle)))
         elif length_mode == LengthMode.VERTICAL:
-            length_vector = direction_localized * (length / sin(radians(angle)))
+            length_vector = direction_localized * abs(length / sin(radians(angle)))
 
         new_edge = Edge.make_line(start, start + length_vector)
 


### PR DESCRIPTION
Without this patch `PolarLine((0,0,0), 10, -90, length_mode=LengthMode.VERTICAL).position_at(1)` yields `(0,10,0)` which is incorrect because it should give `(0,-10,0)`.

`LengthMode.HORIZONTAL` has the same issue.

Closes https://github.com/gumyr/build123d/issues/1041