### PR TITLE
Add `Face.make_surface_patch` constrained surface modeling method

### DIFF
--- a/src/build123d/topology/two_d.py
+++ b/src/build123d/topology/two_d.py
@@ -82,7 +82,7 @@ from OCP.BRepPrimAPI import BRepPrimAPI_MakeRevol
 from OCP.BRepTools import BRepTools, BRepTools_ReShape
 from OCP.gce import gce_MakeLin
 from OCP.Geom import Geom_BezierSurface, Geom_RectangularTrimmedSurface, Geom_Surface
-from OCP.GeomAbs import GeomAbs_C0
+from OCP.GeomAbs import GeomAbs_C0, GeomAbs_G1, GeomAbs_G2
 from OCP.GeomAPI import (
     GeomAPI_ExtremaCurveCurve,
     GeomAPI_PointsToBSplineSurface,
@@ -106,7 +106,14 @@ from OCP.TopoDS import TopoDS, TopoDS_Face, TopoDS_Shape, TopoDS_Shell, TopoDS_S
 from OCP.TopTools import TopTools_IndexedDataMapOfShapeListOfShape, TopTools_ListOfShape
 from typing_extensions import Self
 
-from build123d.build_enums import CenterOf, GeomType, Keep, SortBy, Transition
+from build123d.build_enums import (
+    CenterOf,
+    ContinuityLevel,
+    GeomType,
+    Keep,
+    SortBy,
+    Transition,
+)
 from build123d.geometry import (
     DEG2RAD,
     TOLERANCE,
@@ -1158,6 +1165,37 @@ class Face(Mixin2D, Shape[TopoDS_Face]):
         else:
             return_value = cls.cast(BRepFill.Face_s(curve1.wrapped, curve2.wrapped))
         return return_value
+
+    @classmethod
+    def make_surface_patch(
+        cls,
+        constraints: Iterable[tuple[Edge, Face, ContinuityLevel] | Edge | VectorLike],
+    ) -> Face:
+        continuity_dict = {
+            ContinuityLevel.C0: GeomAbs_C0,
+            ContinuityLevel.C1: GeomAbs_G1,
+            ContinuityLevel.C2: GeomAbs_G2,
+        }
+        patch = BRepOffsetAPI_MakeFilling()
+        for constraint in constraints:
+            if isinstance(constraint, (Vector, Sequence)) and not isinstance(
+                constraint, tuple
+            ):
+                patch.Add(gp_Pnt(*constraint))
+            elif isinstance(constraint, Edge):
+                patch.Add(constraint.wrapped, continuity_dict[ContinuityLevel.C0])
+            elif len(constraint) == 3:
+                patch.Add(
+                    constraint[0].wrapped,
+                    constraint[1].wrapped,
+                    continuity_dict[constraint[2]],
+                )
+            else:
+                raise ValueError(f"Provided {constraint} is not an allowed constraint")
+        patch.Build()
+        result = patch.Shape()
+
+        return cls(result)
 
     @classmethod
     def revolve(

--- a/src/build123d/topology/two_d.py
+++ b/src/build123d/topology/two_d.py
@@ -1169,7 +1169,11 @@ class Face(Mixin2D, Shape[TopoDS_Face]):
     @classmethod
     def make_surface_patch(
         cls,
-        constraints: Iterable[tuple[Edge, Face, ContinuityLevel] | Edge | VectorLike],
+        edge_face_constraints: (
+            Iterable[tuple[Edge, Face, ContinuityLevel]] | None
+        ) = None,
+        edge_constraints: Iterable[Edge] | None = None,
+        point_constraints: Iterable[VectorLike] | None = None,
     ) -> Face:
         continuity_dict = {
             ContinuityLevel.C0: GeomAbs_C0,
@@ -1177,21 +1181,22 @@ class Face(Mixin2D, Shape[TopoDS_Face]):
             ContinuityLevel.C2: GeomAbs_G2,
         }
         patch = BRepOffsetAPI_MakeFilling()
-        for constraint in constraints:
-            if isinstance(constraint, (Vector, Sequence)) and not isinstance(
-                constraint, tuple
-            ):
-                patch.Add(gp_Pnt(*constraint))
-            elif isinstance(constraint, Edge):
-                patch.Add(constraint.wrapped, continuity_dict[ContinuityLevel.C0])
-            elif len(constraint) == 3:
+
+        if edge_face_constraints:
+            for constraint in edge_face_constraints:
                 patch.Add(
                     constraint[0].wrapped,
                     constraint[1].wrapped,
                     continuity_dict[constraint[2]],
                 )
-            else:
-                raise ValueError(f"Provided {constraint} is not an allowed constraint")
+        if edge_constraints:
+            for edge in edge_constraints:
+                patch.Add(edge.wrapped, continuity_dict[ContinuityLevel.C0])
+
+        if point_constraints:
+            for point in point_constraints:
+                patch.Add(gp_Pnt(*point))
+
         patch.Build()
         result = patch.Shape()
 

--- a/tests/test_direct_api/test_face.py
+++ b/tests/test_direct_api/test_face.py
@@ -35,7 +35,7 @@ import unittest
 from unittest.mock import patch, PropertyMock
 from OCP.Geom import Geom_RectangularTrimmedSurface
 from build123d.build_common import Locations, PolarLocations
-from build123d.build_enums import Align, CenterOf, GeomType
+from build123d.build_enums import Align, CenterOf, ContinuityLevel, GeomType
 from build123d.build_line import BuildLine
 from build123d.build_part import BuildPart
 from build123d.build_sketch import BuildSketch
@@ -429,6 +429,63 @@ class TestFace(unittest.TestCase):
         self.assertAlmostEqual(circle_with_hole.area, math.pi * (2**2 - 1**1), 5)
         with self.assertRaises(ValueError):
             Face.sweep(edge, Polyline((0, 0), (0.1, 0), (0.2, 0.1)))
+
+    def test_make_surface_patch(self):
+        m1 = Spline((0, 0), (1, 0), (10, 0, -10))
+        m2 = Spline((0, 0), (0, 1), (0, 10, -10))
+        m3 = Spline(m1 @ 1, (7, 7, -10), m2 @ 1)
+
+        patch = Face.make_surface_patch(
+            edge_constraints=[
+                m1.edge(),
+                m2.edge(),
+                m3.edge(),
+            ]
+        )
+        self.assertAlmostEqual(patch.area, 157.186, 3)
+
+        f1 = Face.extrude(m1.edge(), (0, -1, 0))
+        f2 = Face.extrude(m2.edge(), (-1, 0, 0))
+        f3 = Face.extrude(m3.edge(), (0, 0, -1))
+
+        patch2 = Face.make_surface_patch(
+            edge_face_constraints=[
+                (m1.edge(), f1, ContinuityLevel.C1),
+                (m2.edge(), f2, ContinuityLevel.C1),
+                (m3.edge(), f3, ContinuityLevel.C1),
+            ]
+        )
+
+        self.assertAlmostEqual(patch2.area, 152.670, 3)
+
+        mid_edge = Spline(m1 @ 0.5, (5, 5, -3), m2 @ 0.5)
+
+        patch3 = -Face.make_surface_patch(
+            edge_face_constraints=[
+                (m1.edge(), f1, ContinuityLevel.C1),
+                (m2.edge(), f2, ContinuityLevel.C1),
+                (m3.edge(), f3, ContinuityLevel.C1),
+            ],
+            edge_constraints=[
+                mid_edge.edge(),
+            ],
+        )
+
+        self.assertAlmostEqual(patch3.area, 152.643, 3)
+
+        point = patch.position_at(0.5, 0.5) + (0.5, 0.5)
+        patch4 = -Face.make_surface_patch(
+            edge_constraints=[
+                m1.edge(),
+                m2.edge(),
+                m3.edge(),
+            ],
+            point_constraints=[
+                point,
+            ],
+        )
+
+        self.assertAlmostEqual(patch4.area, 164.618, 3)
 
     # def test_to_arcs(self):
     #     with BuildSketch() as bs:


### PR DESCRIPTION
This is a PR to finally resolve issue https://github.com/gumyr/build123d/issues/654

I have changed a few things since the discussion was last active including changing the interface to separate out the 3 input types (edge/face/continuity constraints, edge constraints, and point constraints). The reason for this change was to simplify mypy type checking. I also switched to `BRepOffsetAPI_MakeFilling` which appears to be the method that OCCT created as the user-facing side of this, and it has almost the same API as the method in the linked issue above.

As discussed at the issue above, edge constraints no longer have the ability to specify continuity as OCCT seems to ignore anything other than C0. I also added several tests which provide some basic usage examples as well.

Example screenshot with result:
<img width="629" height="561" alt="image" src="https://github.com/user-attachments/assets/c93c1758-bd96-47bb-ab6d-f9517d25e83a" />
