### PR TITLE
Add missing docstring to `Face.make_surface_patch` and enhance error checking / handling and related tests

### DIFF
--- a/src/build123d/topology/two_d.py
+++ b/src/build123d/topology/two_d.py
@@ -1175,6 +1175,28 @@ class Face(Mixin2D, Shape[TopoDS_Face]):
         edge_constraints: Iterable[Edge] | None = None,
         point_constraints: Iterable[VectorLike] | None = None,
     ) -> Face:
+        """make_surface_patch
+
+        Create a potentially non-planar face patch bounded by exterior edges which can
+        be optionally refined using support faces to ensure e.g. tangent surface
+        continuity. Also can optionally refine the surface using surface points.
+
+        Args:
+            edge_face_constraints (list[tuple[Edge, Face, ContinuityLevel]], optional):
+                Edges defining perimeter of face with adjacent support faces subject to
+                ContinuityLevel. Defaults to None.
+            edge_constraints (list[Edge], optional): Edges defining perimeter of face
+                without adjacent support faces. Defaults to None.
+            point_constraints (list[VectorLike], optional): Points on the surface that
+                refine the shape. Defaults to None.
+
+        Raises:
+            RuntimeError: Error building non-planar face with provided constraints
+            RuntimeError: Generated face is invalid
+
+        Returns:
+            Face: Potentially non-planar face
+        """
         continuity_dict = {
             ContinuityLevel.C0: GeomAbs_C0,
             ContinuityLevel.C1: GeomAbs_G1,
@@ -1197,10 +1219,24 @@ class Face(Mixin2D, Shape[TopoDS_Face]):
             for point in point_constraints:
                 patch.Add(gp_Pnt(*point))
 
-        patch.Build()
-        result = patch.Shape()
+        try:
+            patch.Build()
+            result = cls(patch.Shape())
+        except (
+            Standard_Failure,
+            StdFail_NotDone,
+            Standard_NoSuchObject,
+            Standard_ConstructionError,
+        ) as err:
+            raise RuntimeError(
+                "Error building non-planar face with provided constraints"
+            ) from err
 
-        return cls(result)
+        result = result.fix()
+        if not result.is_valid or result.wrapped is None:
+            raise RuntimeError("Non planar face is invalid")
+
+        return result
 
     @classmethod
     def revolve(

--- a/tests/test_direct_api/test_face.py
+++ b/tests/test_direct_api/test_face.py
@@ -487,6 +487,13 @@ class TestFace(unittest.TestCase):
 
         self.assertAlmostEqual(patch4.area, 164.618, 3)
 
+    def test_make_surface_patch_error_checking(self):
+        with self.assertRaises(RuntimeError):
+            Face.make_surface_patch(edge_constraints=[Edge.make_line((0, 0), (1, 0))])
+
+        with self.assertRaises(RuntimeError):
+            Face.make_surface_patch(edge_constraints=[])
+
     # def test_to_arcs(self):
     #     with BuildSketch() as bs:
     #         with BuildLine() as bl:

--- a/tests/test_direct_api/test_face.py
+++ b/tests/test_direct_api/test_face.py
@@ -494,6 +494,14 @@ class TestFace(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             Face.make_surface_patch(edge_constraints=[])
 
+        with self.assertRaises(RuntimeError):
+            Face.make_surface_patch(
+                edge_constraints=[
+                    Edge.make_line((0, 0), (1, 0)),
+                    Edge.make_line((0, 0), (0, 1)),
+                ]
+            )
+
     # def test_to_arcs(self):
     #     with BuildSketch() as bs:
     #         with BuildLine() as bl:


### PR DESCRIPTION
Method was previously missing docstring, I found that the error handling was insufficient for practical use as well especially when the returned result was empty. Enhanced both and added a few basic tests for the error handling.