### PR TITLE
Add method to list available system font names and FontStyles

### DIFF
--- a/src/build123d/__init__.py
+++ b/src/build123d/__init__.py
@@ -21,6 +21,7 @@ from build123d.topology import *
 from build123d.drafting import *
 from build123d.persistence import modify_copyreg
 from build123d.exporters3d import *
+from build123d.utils import available_fonts
 
 from .version import version as __version__
 
@@ -183,6 +184,7 @@ __all__ = [
     "new_edges",
     "pack",
     "polar",
+    "available_fonts",
     # Context aware selectors
     "solids",
     "faces",

--- a/src/build123d/objects_sketch.py
+++ b/src/build123d/objects_sketch.py
@@ -549,7 +549,9 @@ class Text(BaseSketchObject):
     subfamilies not in FontStyle should be specified with the subfamily name, e.g.
     "Arial Black". Alternatively, a specific font file can be specified with font_path.
 
-    Note: Windows 10+ users must "Install for all users" for fonts to be found by name.
+    Use `available_fonts()` to list available font names for `font` and FontStyles.
+    Note: on Windows, fonts must be installed with "Install for all users" to be found 
+    by name.
 
     Not all fonts have every FontStyle available, however ITALIC and BOLDITALIC will
     still italicize the font if the respective font file is not available.

--- a/src/build123d/utils.py
+++ b/src/build123d/utils.py
@@ -1,0 +1,57 @@
+"""
+Helper Utilities
+
+name: utils.py
+by:   jwagenet
+date: July 28th 2025
+
+desc:
+    This python module contains helper utilities not related to object creation.
+
+"""
+
+from dataclasses import dataclass
+
+from build123d.build_enums import FontStyle
+from OCP.Font import (
+    Font_FA_Bold,
+    Font_FA_BoldItalic,
+    Font_FA_Italic,
+    Font_FA_Regular,
+    Font_FontMgr,
+)
+
+
+@dataclass(frozen=True)
+class FontInfo:
+    name: str
+    styles: tuple[FontStyle, ...]
+
+    def __repr__(self) -> str:
+        style_names = tuple(s.name for s in self.styles)
+        return f"Font(name={self.name!r}, styles={style_names})"
+
+
+def available_fonts() -> list[FontInfo]:
+    """Get list of available fonts by name and available styles (also called aspects).
+    Note: on Windows, fonts must be installed with "Install for all users" to be found.
+    """
+
+    font_aspects = {
+        "REGULAR": Font_FA_Regular,
+        "BOLD": Font_FA_Bold,
+        "BOLDITALIC": Font_FA_BoldItalic,
+        "ITALIC": Font_FA_Italic,
+    }
+
+    manager = Font_FontMgr.GetInstance_s()
+    font_list = []
+    for f in manager.GetAvailableFonts():
+        avail_aspects = tuple(
+            FontStyle[n] for n, a in font_aspects.items() if f.HasFontAspect(a)
+        )
+        font_list.append(FontInfo(f.FontName().ToCString(), avail_aspects))
+
+    font_list.sort(key=lambda x: x.name)
+
+    return font_list

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,6 +17,16 @@ from build123d.utils import FontInfo
 class TestFontHelpers(unittest.TestCase):
     """Tests for font helpers."""
 
+    def test_font_info(self):
+        """Test expected FontInfo repr."""
+        name = "Arial"
+        styles = tuple(member for member in FontStyle)
+        font = FontInfo(name, styles)
+
+        self.assertEqual(
+            repr(font), f"Font(name={name!r}, styles={tuple(s.name for s in styles)})"
+        )
+
     def test_available_fonts(self):
         """Test expected output for available fonts."""
         fonts = available_fonts()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,36 @@
+"""
+build123d Helper Utilities tests
+
+name: test_utils.py
+by:   jwagenet
+date: July 28th 2025
+
+desc: Unit tests for the build123d helper utilities module
+"""
+
+import unittest
+
+from build123d import *
+from build123d.utils import FontInfo
+
+
+class TestFontHelpers(unittest.TestCase):
+    """Tests for font helpers."""
+
+    def test_available_fonts(self):
+        """Test expected output for available fonts."""
+        fonts = available_fonts()
+        self.assertIsInstance(fonts, list)
+        for font in fonts:
+            self.assertIsInstance(font, FontInfo)
+            self.assertIsInstance(font.name, str)
+            self.assertIsInstance(font.styles, tuple)
+            for style in font.styles:
+                self.assertIsInstance(style, FontStyle)
+
+        names = [font.name for font in fonts]
+        self.assertEqual(names, sorted(names))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
 I've been sitting on this for a while and #364 was referenced by @jdegenstein on discord, so figured I should share it.

* Adds public `available_fonts()`
* Returns list of objects sorted by name (which `GetAvailableFonts()` doesn't do)
* Didn't find a suitable module for this so made a new root module `utils.py` for non-geometry related helper functions
* Resolves #364

I'm open to changing pretty much anything about this including output format and location.

Best viewed with pprint:
```py
from pprint import pprint
pprint(available_fonts())
pprint([font.name for font in available_fonts()])
pprint([font.name for font in available_fonts() if FontStyle.BOLDITALIC in font.styles])

Output:
[Font(name='Agency FB', styles=('REGULAR', 'BOLD')),
 Font(name='Algerian', styles=('REGULAR',)),
 Font(name='Arial', styles=('REGULAR', 'BOLD', 'BOLDITALIC', 'ITALIC')),
 ...
 ]

['Agency FB',
 'Algerian',
 'Arial',
...]

['Arial',
 'Arial Narrow',
 'Bodoni MT',
...]
```