### PR TITLE
Add link to bd_beams_and_bars to external tools

### DIFF
--- a/docs/external.rst
+++ b/docs/external.rst
@@ -72,6 +72,13 @@ Parts available include:
 
 See: `bd_warehouse <https://bd-warehouse.readthedocs.io/en/latest/index.html>`_
 
+bd_beams_and_bars
+=================
+
+2D sections and 3D beams generation (UPN, IPN, UPE, flat bars, ...)
+
+See: `bd_beams_and_bars <https://bd-beams-and-bars.3d.experimentslabs.com/>_`
+
 Superellipses & Superellipsoids
 ===============================
 


### PR DESCRIPTION
Hi!

As discussed on Discord, here is the change to include the link to bd_beams_and_bars.