### PR TITLE
Fix for non-associative multiplications when using GridLocations

### DIFF
--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -1705,9 +1705,12 @@ class Location:
     @overload
     def __mul__(self, other: Iterable[Location]) -> list[Location]: ...
 
+    @overload
+    def __mul__(self, other: Iterable[Shape]) -> list[Shape]: ...
+
     def __mul__(
         self, other: Shape | Location | Iterable[Location | Shape | Iterable]
-    ) -> Shape | Location | list[Location | Shape | list]:
+    ) -> Shape | Location | list[Location] | list[Shape]:
         """Combine locations"""
         if self.wrapped is None:
             raise ValueError("Cannot move a shape at an empty location")

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -1706,8 +1706,8 @@ class Location:
     def __mul__(self, other: Iterable[Location]) -> list[Location]: ...
 
     def __mul__(
-        self, other: Shape | Location | Iterable[Location]
-    ) -> Shape | Location | list[Location]:
+        self, other: Shape | Location | Iterable[Location | Shape | Iterable]
+    ) -> Shape | Location | list[Location | Shape | list]:
         """Combine locations"""
         if self.wrapped is None:
             raise ValueError("Cannot move a shape at an empty location")
@@ -1742,14 +1742,10 @@ class Location:
                 raise ValueError("Can't multiply by empty location")
             return Location(self.wrapped * other.wrapped)
 
-        # other is a list of Locations
+        # other is a list
         if isinstance(other, Iterable):
             others = list(other)
-            if not all(isinstance(o, Location) for o in others):
-                raise ValueError("other must be a list of Locations")
-            if any(o.wrapped is None for o in others):
-                raise ValueError("Can't multiple by empty Locations")
-            return [Location(self.wrapped * loc.wrapped) for loc in others]
+            return [self * loc for loc in others]
 
         raise ValueError(f"Invalid input {other}")
 

--- a/tests/test_algebra.py
+++ b/tests/test_algebra.py
@@ -795,6 +795,10 @@ class AlgebraTests(unittest.TestCase):
 
 
 class LocationTests(unittest.TestCase):
+    def test_list_mul(self):
+        a = Rot(45) * (GridLocations(10, 10, 2, 2) * Cylinder(2, 3))
+        self.assertEqual(len(a), 4)
+
     def test_wheel(self):
         plane = Plane.ZX
 


### PR DESCRIPTION
Currently, build123d multiplication is unexpectedly non ~~commutative~~ associative when using lists like GridLocations: 

`(Rot(45) * GridLocations(10, 10, 2, 2)) * Cylinder(2, 3)` works but `Rot(45) * (GridLocations(10, 10, 2, 2) * Cylinder(2, 3))` throws an exception.

I'm not entirely sure how best to do the type hints for new multiplication, though, since the changed code would also accept nested iterables.