### PR TITLE
Move from macos-13 (x86_64) to macos-15-intel (also x86_64) for relevant workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,7 +12,7 @@ jobs:
           # "3.11",
           "3.12",
           ]
-        os: [macos-13, macos-14, ubuntu-latest, windows-latest]
+        os: [macos-15-intel, macos-14, ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
           # "3.12",
           "3.13",
           ]
-        os: [macos-13, macos-14, ubuntu-latest, windows-latest]
+        os: [macos-15-intel, macos-14, ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
macos-13 will be removed in early December 2025, this PR moves the relevant build123d workflows to macos-15-intel which will be supported for about 2 more years (at which point we will likely drop testing anyway).

I am glad GitHub finally came to their senses and included some architecture information in the runner name, as they should have done when the macos arm64 runners became available.

EDIT: announcement link here https://github.com/actions/runner-images/issues/13046