### PR TITLE
.readthedocs.yaml -> fix tab title version on dev version builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,10 @@ build:
     python: "3.10"
   apt_packages:
     - graphviz
+  jobs:
+    post_checkout:
+      # necessary to ensure that the development builds get a correct version tag
+      - git fetch --unshallow || true
 
 # Build from the docs/ directory with Sphinx
 sphinx:
@@ -21,8 +25,3 @@ python:
       path: .
       extra_requirements:
         - docs
-
-# Explicitly set the version of Python and its requirements
-# python:
-#   install:
-#     - requirements: docs/requirements.txt


### PR DESCRIPTION
Currently the tab title is incorrect for dev (aka "latest") version builds. It shows the correct "hash fragment" but an incorrect build123d version. This is NOT an issue for the stable builds. This PR converts the origin git clone into an unshallow one that will enable setuptools_scm to properly return the development version of build123d that was used to create these docs.

<img width="317" height="143" alt="image" src="https://github.com/user-attachments/assets/a6c18d81-35a6-4f20-9aaa-65e7979cbb27" />

I also took the opportunity to remove some commented code that hadn't been used since the last cleanup of CI / RTD.

ref: https://docs.readthedocs.com/platform/stable/build-customization.html#unshallow-git-clone