### PR TITLE
Replace `Face.make_plane()` with `Face(Plane)`

### DIFF
--- a/src/build123d/topology/two_d.py
+++ b/src/build123d/topology/two_d.py
@@ -449,7 +449,7 @@ class Face(Mixin2D, Shape[TopoDS_Face]):
     @overload
     def __init__(
         self,
-        obj: TopoDS_Face,
+        obj: TopoDS_Face | Plane,
         label: str = "",
         color: Color | None = None,
         parent: Compound | None = None,
@@ -457,7 +457,7 @@ class Face(Mixin2D, Shape[TopoDS_Face]):
         """Build a Face from an OCCT TopoDS_Shape/TopoDS_Face
 
         Args:
-            obj (TopoDS_Shape, optional): OCCT Face.
+            obj (TopoDS_Shape | Plane, optional): OCCT Face or Plane.
             label (str, optional): Defaults to ''.
             color (Color, optional): Defaults to None.
             parent (Compound, optional): assembly parent. Defaults to None.
@@ -487,7 +487,9 @@ class Face(Mixin2D, Shape[TopoDS_Face]):
 
         if args:
             l_a = len(args)
-            if isinstance(args[0], TopoDS_Shape):
+            if isinstance(args[0], Plane):
+                obj = args[0]
+            elif isinstance(args[0], TopoDS_Shape):
                 obj, label, color, parent = args[:4] + (None,) * (4 - l_a)
             elif isinstance(args[0], Wire):
                 outer_wire, inner_wires, label, color, parent = args[:5] + (None,) * (
@@ -515,6 +517,9 @@ class Face(Mixin2D, Shape[TopoDS_Face]):
         label = kwargs.get("label", label)
         color = kwargs.get("color", color)
         parent = kwargs.get("parent", parent)
+
+        if isinstance(obj, Plane):
+            obj = BRepBuilderAPI_MakeFace(obj.wrapped).Face()
 
         if outer_wire is not None:
             inner_topods_wires = (
@@ -1008,15 +1013,6 @@ class Face(Mixin2D, Shape[TopoDS_Face]):
                 gordon_bspline_surface, Precision.Confusion_s()
             ).Face()
         )
-
-    @classmethod
-    def make_plane(
-        cls,
-        plane: Plane = Plane.XY,
-    ) -> Face:
-        """Create a unlimited size Face aligned with plane"""
-        pln_shape = BRepBuilderAPI_MakeFace(plane.wrapped).Face()
-        return cls(pln_shape)
 
     @classmethod
     def make_rect(cls, width: float, height: float, plane: Plane = Plane.XY) -> Face:

--- a/src/build123d/topology/two_d.py
+++ b/src/build123d/topology/two_d.py
@@ -1015,6 +1015,21 @@ class Face(Mixin2D, Shape[TopoDS_Face]):
         )
 
     @classmethod
+    def make_plane(
+        cls,
+        plane: Plane = Plane.XY,
+    ) -> Face:
+        """Create a unlimited size Face aligned with plane"""
+        warnings.warn(
+            "The 'make_plane' method is deprecated and will be removed in a future version.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        pln_shape = BRepBuilderAPI_MakeFace(plane.wrapped).Face()
+        return cls(pln_shape)
+
+    @classmethod
     def make_rect(cls, width: float, height: float, plane: Plane = Plane.XY) -> Face:
         """make_rect
 

--- a/tests/test_direct_api/test_face.py
+++ b/tests/test_direct_api/test_face.py
@@ -130,8 +130,8 @@ class TestFace(unittest.TestCase):
                 distance=1, distance2=2, vertices=[vertex], edge=other_edge
             )
 
-    def test_make_rect(self):
-        test_face = Face.make_plane()
+    def test_plane_as_face(self):
+        test_face = Face(Plane.XY)
         self.assertAlmostEqual(test_face.normal_at(), (0, 0, 1), 5)
 
     def test_length_width(self):

--- a/tests/test_direct_api/test_shape.py
+++ b/tests/test_direct_api/test_shape.py
@@ -475,7 +475,7 @@ class TestShape(unittest.TestCase):
         self.assertAlmostEqual(Vector(verts[0]), (1, 2, 0), 5)
         self.assertListEqual(edges, [])
 
-        verts, edges = Vertex(1, 2, 0)._ocp_section(Face.make_plane(Plane.XY))
+        verts, edges = Vertex(1, 2, 0)._ocp_section(Face(Plane.XY))
         self.assertAlmostEqual(Vector(verts[0]), (1, 2, 0), 5)
         self.assertListEqual(edges, [])
 
@@ -493,7 +493,7 @@ class TestShape(unittest.TestCase):
         self.assertEqual(len(edges1), 1)
         self.assertAlmostEqual(edges1[0].length, 20, 5)
 
-        vertices2, edges2 = cylinder._ocp_section(Face.make_plane(pln))
+        vertices2, edges2 = cylinder._ocp_section(Face(pln))
         self.assertEqual(len(vertices2), 1)
         self.assertEqual(len(edges2), 1)
         self.assertAlmostEqual(Vector(vertices2[0]), (5, 0, 0), 5)


### PR DESCRIPTION
Replace `Face.make_plane()` with `Face(Plane)` to make geometry -> `Shape` conversion consistent with `Vertex(Vector)` and `Edge(Axis)`.