### PR TITLE
README.md -> use an absolute image link to fix logo on pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img alt="build123d logo" src="docs/assets/build123d_logo/logo-banner.svg">
+    <img alt="build123d logo" src="https://github.com/gumyr/build123d/raw/dev/docs/assets/build123d_logo/logo-banner.svg">
 </p>
 
 [![Documentation Status](https://readthedocs.org/projects/build123d/badge/?version=latest)](https://build123d.readthedocs.io/en/latest/?badge=latest)


### PR DESCRIPTION
<img width="925" height="305" alt="image" src="https://github.com/user-attachments/assets/0f983cba-3aca-4c4d-9bcf-cfa570009c8e" />

closes https://github.com/gumyr/build123d/issues/1098

it appears the docs logo fixed itself