### PR TITLE
changes to make development more friendly on MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ venv.bak/
 
 # Profiling debris.
 prof/
+
+# MacOS cruft
+.DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,8 @@ tests, ensure they build and pass, and ensure that `pylint` and `mypy`
 are happy with your code.
 
 - Install `pip` following their [documentation](https://pip.pypa.io/en/stable/installation/).
-- Install development dependencies: `pip install -e .[development]`
-- Install docs dependencies: `pip install -e .[docs]`
+- Install development dependencies: `pip install -e ".[development]"`
+- Install docs dependencies: `pip install -e ".[docs]"`
 - Install `build123d` in editable mode from current dir:  `pip install -e .`
 - Run tests with: `python -m pytest -n auto`
 - Build docs with: `cd docs && make html`


### PR DESCRIPTION
- Adding .DS_Store to .gitignore
- adding quotes to pip commands in the CONTRIBUTING markdown to make them work universally (including on MacOS zshell). you can see [https://github.com/mu-editor/mu/issues/852](https://github.com/mu-editor/mu/issues/852) for a discussion on why this change is needed.