### PR TITLE
Use normal.cross(Vector(0,0,-1)) for Plane(face) x_dir to ensure consistent orientation

### DIFF
--- a/docs/assets/ttt/ttt-ppp0101.py
+++ b/docs/assets/ttt/ttt-ppp0101.py
@@ -25,7 +25,7 @@ with BuildPart() as p:
     fillet(edgs, 9)
 
     with Locations(zz.faces().sort_by(Axis.Y)[0]):
-        with Locations((42 / 2 + 6, 0)):
+        with Locations((0, 42 / 2 + 6)):
             CounterBoreHole(24 / 2, 34 / 2, 4)
     mirror(about=Plane.XZ)
 

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -2814,13 +2814,11 @@ class Plane(metaclass=PlaneMeta):
                 raise ValueError("Planes can only be created from planar faces")
             face_normal = Plane.get_topods_face_normal(arg_face.wrapped)
             face_z_dir = Vector(face_normal).normalized()
-
-            z_threshold = 1 - TOLERANCE
-            if abs(face_z_dir.Z) > z_threshold:
+            candidate = face_z_dir.cross(Vector(0, 0, -1))
+            if candidate.length < TOLERANCE:
                 face_x_dir = Vector(1, 0, 0)
             else:
-                face_x_dir = face_z_dir.cross(Vector(0, 0, -1)).normalized()
-
+                face_x_dir = candidate.normalized()
             self._origin = arg_face.center()
             self.x_dir = Vector(arg_x_dir) if arg_x_dir else Vector(face_x_dir)
             self.x_dir = Vector(round(i, 14) for i in self.x_dir)

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -2719,25 +2719,21 @@ class Plane(metaclass=PlaneMeta):
         if arg_plane:
             self.wrapped = arg_plane
         elif arg_face:
-            surface = BRep_Tool.Surface_s(arg_face.wrapped)
             if not arg_face.is_planar:
                 raise ValueError("Planes can only be created from planar faces")
-            properties = GProp_GProps()
-            BRepGProp.SurfaceProperties_s(arg_face.wrapped, properties)
-            self._origin = Vector(properties.CentreOfMass())
+            face_normal = Plane.get_topods_face_normal(arg_face.wrapped)
+            face_z_dir = Vector(face_normal).normalized()
 
-            if isinstance(surface, Geom_BoundedSurface):
-                point = gp_Pnt()
-                face_x_dir = gp_Vec()
-                tangent_v = gp_Vec()
-                surface.D1(0.5, 0.5, point, face_x_dir, tangent_v)
+            z_threshold = 1 - TOLERANCE
+            if abs(face_z_dir.Z) > z_threshold:
+                face_x_dir = Vector(1, 0, 0)
             else:
-                face_x_dir = surface.Position().XDirection()
+                face_x_dir = face_z_dir.cross(Vector(0, 0, -1)).normalized()
 
+            self._origin = arg_face.center()
             self.x_dir = Vector(arg_x_dir) if arg_x_dir else Vector(face_x_dir)
             self.x_dir = Vector(round(i, 14) for i in self.x_dir)
-            self.z_dir = Plane.get_topods_face_normal(arg_face.wrapped)
-            self.z_dir = Vector(round(i, 14) for i in self.z_dir)
+            self.z_dir = Vector(round(i, 14) for i in face_z_dir)
         elif arg_location:
             topo_face = BRepBuilderAPI_MakeFace(
                 Plane.XY.wrapped, -1.0, 1.0, -1.0, 1.0

--- a/tests/test_direct_api/test_plane.py
+++ b/tests/test_direct_api/test_plane.py
@@ -160,7 +160,7 @@ class TestPlane(unittest.TestCase):
             self.assertAlmostEqual(p.y_dir, (0, 0.7071067811865, 0.7071067811865), 6)
             self.assertAlmostEqual(p.z_dir, (0, -0.7071067811865, 0.7071067811865), 6)
             self.assertAlmostEqual(f.location.position, p.location.position, 6)
-            self.assertAlmostEqual(f.location.orientation, p.location.orientation, 6)
+            self.assertAlmostEqual((45, 0, 0), p.location.orientation, 6)
 
         # from a face with x_dir
         f = Face.make_rect(1, 2)

--- a/tests/test_direct_api/test_plane.py
+++ b/tests/test_direct_api/test_plane.py
@@ -160,7 +160,7 @@ class TestPlane(unittest.TestCase):
             self.assertAlmostEqual(p.y_dir, (0, 0.7071067811865, 0.7071067811865), 6)
             self.assertAlmostEqual(p.z_dir, (0, -0.7071067811865, 0.7071067811865), 6)
             self.assertAlmostEqual(f.location.position, p.location.position, 6)
-            self.assertAlmostEqual((45, 0, 0), p.location.orientation, 6)
+            self.assertAlmostEqual(Vector(45, 0, 0), p.location.orientation, 6)
 
         # from a face with x_dir
         f = Face.make_rect(1, 2)

--- a/tests/test_direct_api/test_plane.py
+++ b/tests/test_direct_api/test_plane.py
@@ -156,9 +156,9 @@ class TestPlane(unittest.TestCase):
         p_deep_copy = copy.deepcopy(p_from_face)
         for p in [p_from_face, p_from_named_face, plane_from_gp_pln, p_deep_copy]:
             self.assertAlmostEqual(p.origin, (1, 2, 3), 6)
-            self.assertAlmostEqual(p.x_dir, (math.sqrt(2) / 2, 0.5, 0.5), 6)
-            self.assertAlmostEqual(p.y_dir, (-math.sqrt(2) / 2, 0.5, 0.5), 6)
-            self.assertAlmostEqual(p.z_dir, (0, -math.sqrt(2) / 2, math.sqrt(2) / 2), 6)
+            self.assertAlmostEqual(p.x_dir, (1, 0, 0), 6)
+            self.assertAlmostEqual(p.y_dir, (0, 0.7071067811865, 0.7071067811865), 6)
+            self.assertAlmostEqual(p.z_dir, (0, -0.7071067811865, 0.7071067811865), 6)
             self.assertAlmostEqual(f.location.position, p.location.position, 6)
             self.assertAlmostEqual(f.location.orientation, p.location.orientation, 6)
 
@@ -359,7 +359,7 @@ class TestPlane(unittest.TestCase):
         with BuildPart() as p:
             add(box)
             with BuildSketch(pln):
-                with Locations((-0.5, 0.5)):
+                with Locations((-0.5, -0.5)):
                     Circle(0.5)
             extrude(amount=-1, mode=Mode.SUBTRACT)
         self.assertAlmostEqual(p.part.volume, 1**3 - math.pi * (0.5**2) * 1, 5)


### PR DESCRIPTION
### Summary
Use a consistent geometric rule for determining `x_dir` in `Plane(face)` instead of relying on the face surface’s U-derivative.

### Details
When `Plane` is created from a `Face` without an explicit `x_dir`, the X direction is now computed as:

```python
x_dir = face.normal_at().cross(Vector(0, 0, -1))
```

- For horizontal faces, X aligns with global +X.  
- For vertical/sloped faces, X lies parallel to the global XY plane and points **right** to an observer standing in front of the face.  

This produces predictable, human-intuitive orientations and avoids inconsistent X directions between adjacent faces.