### PR TITLE
pyproject.toml -> pin to pytest==8.4.2 per pytest-dev/pytest-xdist/issues/1273

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ development = [
     "black",
     "mypy",
     "pylint",
-    "pytest",
+    "pytest==8.4.2", # TODO: unpin on resolution of pytest-dev/pytest-xdist/issues/1273
     "pytest-benchmark",
     "pytest-cov",
     "pytest-xdist",


### PR DESCRIPTION
Pin to pytest==8.4.2 until resolution of referenced issue related to changes introduced in pytest==9.0.0 regarding subtests. Long term fix may require changes to the underlying build123d tests depending on approach taken in pytest and pytest-xdist.