### PR TITLE
fix: Add tuple[int, int, int] to ExportSVG color type annotations

### DIFF
--- a/src/build123d/exporters.py
+++ b/src/build123d/exporters.py
@@ -882,13 +882,13 @@ class ExportSVG(Export2D):
         def __init__(
             self,
             name: str,
-            fill_color: ColorIndex | RGB | Color | None,
-            line_color: ColorIndex | RGB | Color | None,
+            fill_color: ColorIndex | RGB | Color | tuple[int, int, int] | None,
+            line_color: ColorIndex | RGB | Color | tuple[int, int, int] | None,
             line_weight: float,
             line_type: LineType,
         ):
             def convert_color(
-                input_color: ColorIndex | RGB | Color | tuple | None,
+                input_color: ColorIndex | RGB | Color | tuple[int, int, int] | None,
             ) -> Color | None:
                 """
                 Convert various color representations into a `Color` object.
@@ -965,8 +965,10 @@ class ExportSVG(Export2D):
         margin: float = 0,
         fit_to_stroke: bool = True,
         precision: int = 6,
-        fill_color: ColorIndex | RGB | Color | None = None,
-        line_color: ColorIndex | RGB | Color | None = Export2D.DEFAULT_COLOR_INDEX,
+        fill_color: ColorIndex | RGB | Color | tuple[int, int, int] | None = None,
+        line_color: (
+            ColorIndex | RGB | Color | tuple[int, int, int] | None
+        ) = Export2D.DEFAULT_COLOR_INDEX,
         line_weight: float = Export2D.DEFAULT_LINE_WEIGHT,  # in millimeters
         line_type: LineType = Export2D.DEFAULT_LINE_TYPE,
         dot_length: DotLength | float = DotLength.INKSCAPE_COMPAT,
@@ -1001,8 +1003,10 @@ class ExportSVG(Export2D):
         self,
         name: str,
         *,
-        fill_color: ColorIndex | RGB | Color | None = None,
-        line_color: ColorIndex | RGB | Color | None = Export2D.DEFAULT_COLOR_INDEX,
+        fill_color: ColorIndex | RGB | Color | tuple[int, int, int] | None = None,
+        line_color: (
+            ColorIndex | RGB | Color | tuple[int, int, int] | None
+        ) = Export2D.DEFAULT_COLOR_INDEX,
         line_weight: float = Export2D.DEFAULT_LINE_WEIGHT,  # in millimeters
         line_type: LineType = Export2D.DEFAULT_LINE_TYPE,
     ) -> Self:
@@ -1012,12 +1016,13 @@ class ExportSVG(Export2D):
 
         Args:
             name (str): The name of the layer. Must be unique among all layers.
-            fill_color (ColorIndex |  RGB |  Color |  None, optional): The fill color for shapes
-                on this layer. It can be specified as a ColorIndex, an RGB tuple,
-                a Color, or None.  Defaults to None.
-            line_color (ColorIndex |  RGB |  Color |  None, optional): The line color for shapes on
-                this layer. It can be specified as a ColorIndex or an RGB tuple,
-                a Color, or None.  Defaults to Export2D.DEFAULT_COLOR_INDEX.
+            fill_color (ColorIndex | RGB | Color | tuple[int, int, int] | None, optional):
+                The fill color for shapes on this layer. It can be specified as a
+                ColorIndex, an RGB tuple, a Color, or None.  Defaults to None.
+            line_color (ColorIndex | RGB | Color | tuple[int, int, int] | None, optional):
+                The line color for shapes on this layer. It can be specified as a
+                ColorIndex or an RGB tuple, a Color, or None.
+                Defaults to Export2D.DEFAULT_COLOR_INDEX.
             line_weight (float, optional): The line weight (stroke width) for shapes on
                 this layer, in millimeters. Defaults to Export2D.DEFAULT_LINE_WEIGHT.
             line_type (LineType, optional): The line type for shapes on this layer.


### PR DESCRIPTION
## Summary

The `ExportSVG.add_layer()` method and `ExportSVG.__init__()` accept RGB tuples for `fill_color` and `line_color` parameters. This is documented in the docstrings and correctly handled by the internal `convert_color()` function:

```python
case tuple() as color_tuple:
    rgb_color = RGB(*color_tuple)
```

However, the public type annotations didn't include `tuple[int, int, int]`, causing type checkers to report errors for valid code like:

```python
exporter.add_layer("Hidden", line_color=(99, 99, 99), line_type=bd.LineType.ISO_DOT)
```

## How this was found

This discrepancy was discovered using [ty](https://astral.sh/blog/ty), Astral's new Python type checker (just released in beta). When type-checking code that passes RGB tuples, ty correctly reported:

```
error[invalid-argument-type]: Expected `ColorIndex | RGB | Color | None`, found `tuple[Literal[99], Literal[99], Literal[99]]`
```

## Changes

- Add `tuple[int, int, int]` to `fill_color` and `line_color` type annotations in:
  - `ExportSVG._Layer.__init__()`
  - `ExportSVG.__init__()`
  - `ExportSVG.add_layer()`
- Update internal `convert_color()` to use `tuple[int, int, int]` instead of bare `tuple` for consistency
- Update docstrings to reflect the full type union
- Reformatted with `black` per contribution guidelines

## Verification

- Ran `black --config pyproject.toml` ✓
- Ran `pylint` - score improved from 9.86 to 9.89 (fixed docstring line lengths)
- ty now reports "All checks passed!" for code using RGB tuples