### PR TITLE
feature: allow adding invalid meshes to Mesher

### DIFF
--- a/src/build123d/mesher.py
+++ b/src/build123d/mesher.py
@@ -370,6 +370,7 @@ class Mesher:
         mesh_type: MeshType = MeshType.MODEL,
         part_number: str | None = None,
         uuid_value: UUID | None = None,
+        allow_invalid: bool = False,
     ):
         """add_shape
 
@@ -383,6 +384,7 @@ class Mesher:
             mesh_type (MeshType, optional): 3D printing use of mesh. Defaults to MeshType.MODEL.
             part_number (str, optional): part #. Defaults to None.
             uuid_value (uuid, optional): value from uuid package. Defaults to None.
+            allow_invalid (bool, optional): allow adding invalid meshes instead of throwing an error
 
         Raises:
             RuntimeError: 3mf mesh is invalid
@@ -439,7 +441,10 @@ class Mesher:
 
             # Check mesh
             if not mesh_3mf.IsValid():
-                raise RuntimeError("3mf mesh is invalid")
+                msg = "3mf mesh is invalid"
+                if not allow_invalid:
+                    raise RuntimeError(msg)
+                warnings.warn(msg, stacklevel=2)
             if not mesh_3mf.IsManifoldAndOriented():
                 warnings.warn("3mf mesh is not manifold", stacklevel=2)
 


### PR DESCRIPTION
It's somewhat annoying that Mesher will sometimes prevent me from adding an invalid shape.
IMO it should be on the user to check if the mesh is valid if they absolutely need to guarantee that.

I've also noticed that these checks will report meshes are invalid even when they work fine.

Here are some files exported from b3d that throw both validity/manifold warnings (after this patch):
[export.zip](https://github.com/user-attachments/files/24372783/export.zip)
```
$ python export.py -f action_quick_release_protector.py
Cleaning export folder
Exporting sequentially
Importing action_quick_release_protector
Exporting build123d part to export/action_quick_release_protector-female.stl
/home/jasper/repos/objects/export.py:33: UserWarning: 3mf mesh is invalid
  exporter.add_shape(result)
/home/jasper/repos/objects/export.py:33: UserWarning: 3mf mesh is not manifold
  exporter.add_shape(result)
Exporting build123d part to export/action_quick_release_protector-female.step
Exporting build123d part to export/action_quick_release_protector-female.3mf
Exporting build123d part to export/action_quick_release_protector-female.brep
```

Build123d script for this part is at https://github.com/Gigahawk/objects/blob/6964d0eade729934548602dc91c04e8a2c799537/action_quick_release_protector.py

Yes I know that `add`ing the thread to the part is not recommended but I am just using this as a demonstration of a case where the outputs seem to be fine but the export will fail anyways due to the validity check failing.