### PR TITLE
allow exporting BREP and STEP to binary file objects

### DIFF
--- a/src/build123d/exporters3d.py
+++ b/src/build123d/exporters3d.py
@@ -33,6 +33,7 @@ from datetime import datetime
 import warnings
 from io import BytesIO
 from os import PathLike, fsdecode, fspath
+from typing import BinaryIO
 
 import OCP.TopAbs as ta
 from anytree import PreOrderIter
@@ -161,7 +162,7 @@ def _create_xde(to_export: Shape, unit: Unit = Unit.MM) -> TDocStd_Document:
 
 def export_brep(
     to_export: Shape,
-    file_path: PathLike | str | bytes | BytesIO,
+    file_path: PathLike | str | bytes | BytesIO | BinaryIO,
 ) -> bool:
     """Export this shape to a BREP file
 
@@ -172,7 +173,7 @@ def export_brep(
     Returns:
         bool: write status
     """
-    if not isinstance(file_path, BytesIO):
+    if isinstance(file_path, (PathLike | str | bytes)):
         file_path = fsdecode(file_path)
 
     return_value = BRepTools.Write_s(to_export.wrapped, file_path)
@@ -262,7 +263,7 @@ def export_gltf(
 
 def export_step(
     to_export: Shape,
-    file_path: PathLike | str | bytes | BytesIO,
+    file_path: PathLike | str | bytes | BytesIO | BinaryIO,
     unit: Unit = Unit.MM,
     write_pcurves: bool = True,
     precision_mode: PrecisionMode = PrecisionMode.AVERAGE,
@@ -326,7 +327,7 @@ def export_step(
     Interface_Static.SetIVal_s("write.precision.mode", precision_mode.value)
     writer.Transfer(doc, STEPControl_StepModelType.STEPControl_AsIs)
 
-    if not isinstance(file_path, BytesIO):
+    if isinstance(file_path, (PathLike, str, bytes)):
         status = (
             writer.Write(fsdecode(file_path)) == IFSelect_ReturnStatus.IFSelect_RetDone
         )

--- a/src/build123d/exporters3d.py
+++ b/src/build123d/exporters3d.py
@@ -33,7 +33,7 @@ from datetime import datetime
 import warnings
 from io import BytesIO
 from os import PathLike, fsdecode, fspath
-from typing import BinaryIO
+from typing import BinaryIO, cast
 
 import OCP.TopAbs as ta
 from anytree import PreOrderIter
@@ -175,7 +175,8 @@ def export_brep(
     """
     if isinstance(file_path, (PathLike | str | bytes)):
         file_path = fsdecode(file_path)
-
+    else:
+        file_path = cast(BytesIO, file_path)
     return_value = BRepTools.Write_s(to_export.wrapped, file_path)
 
     return True if return_value is None else return_value
@@ -328,16 +329,16 @@ def export_step(
     writer.Transfer(doc, STEPControl_StepModelType.STEPControl_AsIs)
 
     if isinstance(file_path, (PathLike, str, bytes)):
-        status = (
-            writer.Write(fsdecode(file_path)) == IFSelect_ReturnStatus.IFSelect_RetDone
-        )
+        status = writer.Write(fsdecode(file_path))
     else:
-        status = writer.WriteStream(file_path) == IFSelect_ReturnStatus.IFSelect_RetDone
+        # need to cast for type checker because BinaryIO is OK but OCP doesn't know
+        status = writer.WriteStream(cast(BytesIO, file_path))
 
-    if not status:
+    success = status == IFSelect_ReturnStatus.IFSelect_RetDone
+    if not success:
         raise RuntimeError("Failed to write STEP file")
 
-    return status
+    return success
 
 
 def export_stl(

--- a/tests/test_exporters3d.py
+++ b/tests/test_exporters3d.py
@@ -29,9 +29,11 @@ import io
 import json
 import os
 import re
+import sys
 import unittest
 from datetime import datetime
 from pathlib import Path
+from tempfile import TemporaryFile
 from typing import Optional
 from zoneinfo import ZoneInfo
 
@@ -211,6 +213,19 @@ def test_exporters_in_memory(exporter):
     buffer = io.BytesIO()
     box = Box(1, 1, 1).locate(Pos(-1, -2, -3))
     exporter(box, buffer)
+
+
+
+@pytest.mark.parametrize("exporter", (export_step, export_brep))
+def test_exporters_to_binary_fileobj(exporter):
+    box = Box(1, 1, 1).locate(Pos(-1, -2, -3))
+    with TemporaryFile('wb') as f:
+        exporter(box, f)
+
+@pytest.mark.parametrize("exporter", (export_step, export_brep))
+def test_exporters_to_stdout(exporter):
+    box = Box(1, 1, 1).locate(Pos(-1, -2, -3))
+    exporter(box, sys.stdout.buffer)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`OCP` is capable of exporting STEP and BREP to binary file-like streams but `build123d` currently does not allow it because of the way it checks if the destination is a stream vs a filename.