### PR TITLE
Add bd-vslot to the build123d docs

### DIFF
--- a/docs/external.rst
+++ b/docs/external.rst
@@ -115,6 +115,13 @@ A gear generation framework that allows easy creation of a wide range of gears a
 
 See `gggears <https://github.com/GarryBGoode/gggears>`_
 
+bd_vslot
+=================
+
+A library of V-Slot linear rail components, including V-Slot rails.
+
+See: `bd_vslot <https://bd-vslot.readthedocs.io>`_
+
 *****
 Tools
 *****


### PR DESCRIPTION
Hi @gumyr!

This PR adds bd-vslot to the build123d docs.

The bd-vslot project provides a handful of parts but most importantly a model of a 2020 V-Slot rail. The rail profile is initialized from an arbitrary boolean grid (see [docs](https://bd-vslot.readthedocs.io/en/latest/rails.html#bd_vslot.rails.VSlot2020RailProfile)), allowing for the construction of 1xN, 2x2 beams, C-shaped beams, etc:

<img width="256" alt="image" src="https://github.com/user-attachments/assets/f812c8a3-c4e4-4b7c-898f-e08516d96e3c" />
<img width="256" alt="image" src="https://github.com/user-attachments/assets/2a52ece8-9337-4d04-b7dc-ecd4c9f8a890" />
<img width="256" alt="image" src="https://github.com/user-attachments/assets/c9275569-2e1a-433d-81ef-90e0089c82fb" />

<img width="1900" height="923" alt="image" src="https://github.com/user-attachments/assets/aed011db-ba6e-46d8-8b30-2e54a526731a" />
<img width="1900" height="923" alt="image" src="https://github.com/user-attachments/assets/918c1d13-d363-4949-86c5-1fbc5c684adf" />
<img width="1900" height="923" alt="image" src="https://github.com/user-attachments/assets/0158f29f-aaa8-4b5a-b62f-d86d9ca26543" />

---

Sorry for the delay in getting this PR up. I abandoned the bd-vslot project for a while but found it useful again recently.

I hope this is a useful reference of 2020 V-Slot rails for build123d users.

Closes https://github.com/keeeal/bd-vslot/issues/5