### PR TITLE
fix: in tests use `open()` with explicit `utf-8` to avoid `cp1252` on windows

### DIFF
--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -4,6 +4,7 @@ from build123d import *
 from pathlib import Path
 
 from unittest.mock import Mock
+
 mock_module = Mock()
 mock_module.show = Mock()
 mock_module.show_object = Mock()
@@ -17,85 +18,99 @@ def _read_docs_ttt_code(name):
     checkout_dir = Path(__file__).parent.parent
     ttt_dir = checkout_dir / "docs/assets/ttt"
     name = "ttt-" + name + ".py"
-    with open(ttt_dir / name, "r") as f:
+    with open(ttt_dir / name, "r", encoding="utf-8") as f:
         return f.read()
 
 
 def test_ppp_0101(benchmark):
     def model():
         exec(_read_docs_ttt_code("ppp0101"))
+
     benchmark(model)
 
 
 def test_ppp_0102(benchmark):
     def model():
         exec(_read_docs_ttt_code("ppp0102"))
+
     benchmark(model)
 
 
 def test_ppp_0103(benchmark):
     def model():
         exec(_read_docs_ttt_code("ppp0103"))
+
     benchmark(model)
 
 
 def test_ppp_0104(benchmark):
     def model():
         exec(_read_docs_ttt_code("ppp0104"))
+
     benchmark(model)
 
 
 def test_ppp_0105(benchmark):
     def model():
         exec(_read_docs_ttt_code("ppp0105"))
+
     benchmark(model)
 
 
 def test_ppp_0106(benchmark):
     def model():
         exec(_read_docs_ttt_code("ppp0106"))
+
     benchmark(model)
 
 
 def test_ppp_0107(benchmark):
     def model():
         exec(_read_docs_ttt_code("ppp0107"))
+
     benchmark(model)
 
 
 def test_ppp_0108(benchmark):
     def model():
         exec(_read_docs_ttt_code("ppp0108"))
+
     benchmark(model)
 
 
 def test_ppp_0109(benchmark):
     def model():
         exec(_read_docs_ttt_code("ppp0109"))
+
     benchmark(model)
 
 
 def test_ppp_0110(benchmark):
     def model():
         exec(_read_docs_ttt_code("ppp0110"))
+
     benchmark(model)
 
 
 def test_ttt_23_02_02(benchmark):
     def model():
         exec(_read_docs_ttt_code("23-02-02-sm_hanger"))
+
     benchmark(model)
+
 
 def test_ttt_23_T_24(benchmark):
     def model():
         exec(_read_docs_ttt_code("23-t-24-curved_support"))
+
     benchmark(model)
+
 
 def test_ttt_24_SPO_06(benchmark):
     def model():
         exec(_read_docs_ttt_code("24-SPO-06-Buffer_Stand"))
-    benchmark(model)
 
+    benchmark(model)
 
 
 @pytest.mark.parametrize("test_input", [100, 1000, 10000, 100000])

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -49,16 +49,16 @@ def generate_example_test(path: Path):
             # directory, use that.  If an example is added in the
             # future that wants to both read assets from the examples
             # directory and write output files, deal with it then.
-            cwd = tmpdir if 'benchy' not in path.name else _examples_dir
+            cwd = tmpdir if "benchy" not in path.name else _examples_dir
             mock_ocp_vscode = Path(tmpdir) / "_mock_ocp_vscode.py"
             with open(mock_ocp_vscode, "w", encoding="utf-8") as f:
                 f.write(_MOCK_OCP_VSCODE_CONTENTS)
+            cmd = (
+                f"exec(open(r'{mock_ocp_vscode}', encoding='utf-8').read()); "
+                f"exec(open(r'{path}', encoding='utf-8').read())"
+            )
             got = subprocess.run(
-                [
-                    sys.executable,
-                    "-c",
-                    f"exec(open(r'{mock_ocp_vscode}').read()); exec(open(r'{path}').read())",
-                ],
+                [sys.executable, "-c", cmd],
                 capture_output=True,
                 cwd=cwd,
                 check=False,
@@ -72,6 +72,7 @@ def generate_example_test(path: Path):
 
 class TestExamples(unittest.TestCase):
     """Tests build123d examples."""
+
 
 for example in sorted(list(_examples_dir.iterdir()) + list(_ttt_dir.iterdir())):
     if example.name.startswith("_") or not example.name.endswith(".py"):


### PR DESCRIPTION
With a recent addition of an example there was a case of windows runners failing to execute them in tests correctly. Ultimately the cause of this issue was defaulting to `cp1252` in the `open` method of python on windows instead of `utf-8`. This PR makes an explicit choice of `utf-8` to avoid these issues in the future. The same issue also applied to `test_benchmarks.py` so I made the same adjustment there too.

black also changed some formatting in these files.