### PR TITLE
fix: cadquery-ocp-stubs to >=7.9, < 8.0, use e.g. `TopoDS.Vertex_s` to `TopoDS.Vertex` and tcast to appease mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ development = [
 
 # typing stubs for the OCP CAD kernel
 stubs = [
-    "cadquery-ocp-stubs >= 7.8, < 7.9",
+    "cadquery-ocp-stubs >= 7.9, < 8.0",
 ]
 
 # dependencies to build the docs

--- a/src/build123d/exporters.py
+++ b/src/build123d/exporters.py
@@ -1118,7 +1118,7 @@ class ExportSVG(Export2D):
         )
         while explorer.More():
             topo_wire = explorer.Current()
-            loose_wires.append(Wire(TopoDS.Wire_s(topo_wire)))
+            loose_wires.append(Wire(TopoDS.Wire(topo_wire)))
             explorer.Next()
         # print(f"{len(loose_wires)} loose wires")
         for wire in loose_wires:
@@ -1137,7 +1137,7 @@ class ExportSVG(Export2D):
         )
         while explorer.More():
             topo_edge = explorer.Current()
-            loose_edges.append(Edge(TopoDS.Edge_s(topo_edge)))
+            loose_edges.append(Edge(TopoDS.Edge(topo_edge)))
             explorer.Next()
         # print(f"{len(loose_edges)} loose edges")
         loose_edge_elements = [self._edge_element(edge) for edge in loose_edges]

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -1847,13 +1847,13 @@ class Location:
             downcast_lut: dict[
                 TopAbs_ShapeEnum, Callable[[TopoDS_Shape], TopoDS_Shape]
             ] = {
-                TopAbs_ShapeEnum.TopAbs_VERTEX: TopoDS.Vertex_s,
-                TopAbs_ShapeEnum.TopAbs_EDGE: TopoDS.Edge_s,
-                TopAbs_ShapeEnum.TopAbs_WIRE: TopoDS.Wire_s,
-                TopAbs_ShapeEnum.TopAbs_FACE: TopoDS.Face_s,
-                TopAbs_ShapeEnum.TopAbs_SHELL: TopoDS.Shell_s,
-                TopAbs_ShapeEnum.TopAbs_SOLID: TopoDS.Solid_s,
-                TopAbs_ShapeEnum.TopAbs_COMPOUND: TopoDS.Compound_s,
+                TopAbs_ShapeEnum.TopAbs_VERTEX: TopoDS.Vertex,
+                TopAbs_ShapeEnum.TopAbs_EDGE: TopoDS.Edge,
+                TopAbs_ShapeEnum.TopAbs_WIRE: TopoDS.Wire,
+                TopAbs_ShapeEnum.TopAbs_FACE: TopoDS.Face,
+                TopAbs_ShapeEnum.TopAbs_SHELL: TopoDS.Shell,
+                TopAbs_ShapeEnum.TopAbs_SOLID: TopoDS.Solid,
+                TopAbs_ShapeEnum.TopAbs_COMPOUND: TopoDS.Compound,
             }
             assert other.wrapped is not None
             try:
@@ -3180,13 +3180,13 @@ class Plane(metaclass=PlaneMeta):
             downcast_lut: dict[
                 TopAbs_ShapeEnum, Callable[[TopoDS_Shape], TopoDS_Shape]
             ] = {
-                TopAbs_ShapeEnum.TopAbs_VERTEX: TopoDS.Vertex_s,
-                TopAbs_ShapeEnum.TopAbs_EDGE: TopoDS.Edge_s,
-                TopAbs_ShapeEnum.TopAbs_WIRE: TopoDS.Wire_s,
-                TopAbs_ShapeEnum.TopAbs_FACE: TopoDS.Face_s,
-                TopAbs_ShapeEnum.TopAbs_SHELL: TopoDS.Shell_s,
-                TopAbs_ShapeEnum.TopAbs_SOLID: TopoDS.Solid_s,
-                TopAbs_ShapeEnum.TopAbs_COMPOUND: TopoDS.Compound_s,
+                TopAbs_ShapeEnum.TopAbs_VERTEX: TopoDS.Vertex,
+                TopAbs_ShapeEnum.TopAbs_EDGE: TopoDS.Edge,
+                TopAbs_ShapeEnum.TopAbs_WIRE: TopoDS.Wire,
+                TopAbs_ShapeEnum.TopAbs_FACE: TopoDS.Face,
+                TopAbs_ShapeEnum.TopAbs_SHELL: TopoDS.Shell,
+                TopAbs_ShapeEnum.TopAbs_SOLID: TopoDS.Solid,
+                TopAbs_ShapeEnum.TopAbs_COMPOUND: TopoDS.Compound,
             }
             assert obj.wrapped is not None
             try:

--- a/src/build123d/mesher.py
+++ b/src/build123d/mesher.py
@@ -493,7 +493,7 @@ class Mesher:
             explorer = TopExp_Explorer(occ_sewed_shape, TopAbs_ShapeEnum.TopAbs_SHELL)
             while explorer.More():
                 # occ_shells.append(downcast(explorer.Current()))
-                bd_shells.append(Shell(TopoDS.Shell_s(explorer.Current())))
+                bd_shells.append(Shell(TopoDS.Shell(explorer.Current())))
                 explorer.Next()
         else:
             assert isinstance(occ_sewed_shape, TopoDS_Shell)

--- a/src/build123d/topology/composite.py
+++ b/src/build123d/topology/composite.py
@@ -236,7 +236,7 @@ class Compound(Mixin3D[TopoDS_Compound]):
             Edge: extruded shape
         """
         return Compound(
-            TopoDS.Compound_s(_extrude_topods_shape(obj.wrapped, direction))
+            TopoDS.Compound(_extrude_topods_shape(obj.wrapped, direction))
         )
 
     @classmethod
@@ -376,7 +376,7 @@ class Compound(Mixin3D[TopoDS_Compound]):
         )
 
         text_flat = Compound(
-            TopoDS.Compound_s(
+            TopoDS.Compound(
                 builder.Perform(
                     font_i,
                     NCollection_Utf8String(txt),

--- a/src/build123d/topology/constrained_lines.py
+++ b/src/build123d/topology/constrained_lines.py
@@ -678,7 +678,7 @@ def _make_tan_on_rad_arcs(
 
         # Project center onto the (trimmed) 2D locus
         proj = Geom2dAPI_ProjectPointOnCurve(center2d, h_on2d)
-        u_on = proj.Parameter(1)
+        u_on = tcast(float, proj.Parameter(1))
 
         # Respect the trimmed interval (handles periodic curves too)
         if not _param_in_trim(u_on, on_first, on_last, h_on2d):

--- a/src/build123d/topology/one_d.py
+++ b/src/build123d/topology/one_d.py
@@ -1525,7 +1525,7 @@ class Edge(Mixin1D[TopoDS_Edge]):
         """
         if not obj:
             raise ValueError("Can't extrude empty vertex")
-        return Edge(TopoDS.Edge_s(_extrude_topods_shape(obj.wrapped, direction)))
+        return Edge(TopoDS.Edge(_extrude_topods_shape(obj.wrapped, direction)))
 
     @classmethod
     def make_bezier(
@@ -2923,7 +2923,7 @@ class Edge(Mixin1D[TopoDS_Edge]):
             topods_edge = BRepBuilderAPI_MakeEdge(curve.Reversed(), last, first).Edge()
             reversed_edge.wrapped = topods_edge
         else:
-            reversed_edge.wrapped = TopoDS.Edge_s(self.wrapped.Reversed())
+            reversed_edge.wrapped = TopoDS.Edge(self.wrapped.Reversed())
         return reversed_edge
 
     def to_axis(self) -> Axis:
@@ -3615,8 +3615,8 @@ class Wire(Mixin1D[TopoDS_Wire]):
             edge1, edge2 = Wire.order_chamfer_edges(reference_edge, edges)
             if edge1.wrapped is not None and edge2.wrapped is not None:
                 chamfer_builder.AddChamfer(
-                    TopoDS.Edge_s(edge1.wrapped),
-                    TopoDS.Edge_s(edge2.wrapped),
+                    TopoDS.Edge(edge1.wrapped),
+                    TopoDS.Edge(edge2.wrapped),
                     distance,
                     distance2,
                 )
@@ -4006,8 +4006,8 @@ class Wire(Mixin1D[TopoDS_Wire]):
             raise ValueError("Can't stitch empty wires")
 
         wire_builder = BRepBuilderAPI_MakeWire()
-        wire_builder.Add(TopoDS.Wire_s(self.wrapped))
-        wire_builder.Add(TopoDS.Wire_s(other.wrapped))
+        wire_builder.Add(TopoDS.Wire(self.wrapped))
+        wire_builder.Add(TopoDS.Wire(other.wrapped))
         wire_builder.Build()
 
         return self.__class__.cast(wire_builder.Wire())
@@ -4158,7 +4158,7 @@ def edges_to_wires(edges: Iterable[Edge], tol: float = 1e-6) -> ShapeList[Wire]:
     wires: ShapeList[Wire] = ShapeList()
     for i in range(wires_out.Length()):
         # wires.append(Wire(downcast(wires_out.Value(i + 1))))
-        wires.append(Wire(TopoDS.Wire_s(wires_out.Value(i + 1))))
+        wires.append(Wire(TopoDS.Wire(wires_out.Value(i + 1))))
 
     return wires
 
@@ -4263,6 +4263,6 @@ def topo_explore_connected_faces(
         for face in edge_face_map.FindFromKey(edge.wrapped):
             unique_face_map.Add(face)
     for i in range(unique_face_map.Extent()):
-        unique_faces.append(TopoDS.Face_s(unique_face_map(i + 1)))
+        unique_faces.append(TopoDS.Face(unique_face_map(i + 1)))
 
     return unique_faces

--- a/src/build123d/topology/shape_core.py
+++ b/src/build123d/topology/shape_core.py
@@ -212,14 +212,14 @@ class Shape(NodeMixin, Generic[TOPODS]):
     inverse_shape_LUT = {v: k for k, v in shape_LUT.items()}
 
     downcast_LUT = {
-        ta.TopAbs_VERTEX: TopoDS.Vertex_s,
-        ta.TopAbs_EDGE: TopoDS.Edge_s,
-        ta.TopAbs_WIRE: TopoDS.Wire_s,
-        ta.TopAbs_FACE: TopoDS.Face_s,
-        ta.TopAbs_SHELL: TopoDS.Shell_s,
-        ta.TopAbs_SOLID: TopoDS.Solid_s,
-        ta.TopAbs_COMPOUND: TopoDS.Compound_s,
-        ta.TopAbs_COMPSOLID: TopoDS.CompSolid_s,
+        ta.TopAbs_VERTEX: TopoDS.Vertex,
+        ta.TopAbs_EDGE: TopoDS.Edge,
+        ta.TopAbs_WIRE: TopoDS.Wire,
+        ta.TopAbs_FACE: TopoDS.Face,
+        ta.TopAbs_SHELL: TopoDS.Shell,
+        ta.TopAbs_SOLID: TopoDS.Solid,
+        ta.TopAbs_COMPOUND: TopoDS.Compound,
+        ta.TopAbs_COMPSOLID: TopoDS.CompSolid,
     }
 
     geom_LUT_EDGE: dict[ga.GeomAbs_CurveType, GeomType] = {
@@ -418,7 +418,7 @@ class Shape(NodeMixin, Generic[TOPODS]):
             # exactly two faces associated with it.
             for i in range(shape_map.Extent()):
                 # Access each edge in the map sequentially
-                edge = TopoDS.Edge_s(shape_map.FindKey(i + 1))
+                edge = TopoDS.Edge(shape_map.FindKey(i + 1))
 
                 vertex0 = TopoDS_Vertex()
                 vertex1 = TopoDS_Vertex()
@@ -1883,7 +1883,7 @@ class Shape(NodeMixin, Generic[TOPODS]):
             # Get a TopoDS_Face to work with from the tool
             if isinstance(trim_tool, TopoDS_Shell):
                 face_explorer = TopExp_Explorer(trim_tool, ta.TopAbs_FACE)
-                tool_face = TopoDS.Face_s(face_explorer.Current())
+                tool_face = TopoDS.Face(face_explorer.Current())
             else:
                 tool_face = trim_tool
 

--- a/src/build123d/topology/three_d.py
+++ b/src/build123d/topology/three_d.py
@@ -259,7 +259,7 @@ class Mixin3D(Shape[TOPODS]):
                 topo_face = edge_face_map.FindFromKey(native_edge).First()
 
             chamfer_builder.Add(
-                distance1, distance2, native_edge, TopoDS.Face_s(topo_face)
+                distance1, distance2, native_edge, TopoDS.Face(topo_face)
             )  # NB: edge_face_map return a generic TopoDS_Shape
 
         try:
@@ -837,7 +837,7 @@ class Solid(Mixin3D[TopoDS_Solid]):
         Returns:
             Edge: extruded shape
         """
-        return Solid(TopoDS.Solid_s(_extrude_topods_shape(obj.wrapped, direction)))
+        return Solid(TopoDS.Solid(_extrude_topods_shape(obj.wrapped, direction)))
 
     @classmethod
     def extrude_linear_with_rotation(
@@ -924,10 +924,10 @@ class Solid(Mixin3D[TopoDS_Solid]):
 
         # convert to a TopoDS_Solid - might be wrapped in a TopoDS_Compound
         try:
-            result = TopoDS.Solid_s(difference)
+            result = TopoDS.Solid(difference)
         except Standard_TypeMismatch:
-            result = TopoDS.Solid_s(
-                unwrap_topods_compound(TopoDS.Compound_s(difference), True)
+            result = TopoDS.Solid(
+                unwrap_topods_compound(TopoDS.Compound(difference), True)
             )
 
         return Solid(result)
@@ -971,7 +971,7 @@ class Solid(Mixin3D[TopoDS_Solid]):
                 direction.length / cos(radians(taper)),
                 radians(taper),
             )
-            new_solid = Solid(TopoDS.Solid_s(prism_builder.Shape()))
+            new_solid = Solid(TopoDS.Solid(prism_builder.Shape()))
         else:
             # Determine the offset to get the taper
             offset_amt = -direction.length * tan(radians(taper))
@@ -1072,10 +1072,10 @@ class Solid(Mixin3D[TopoDS_Solid]):
         modified_target_faces = []
         face_explorer = TopExp_Explorer(target.wrapped, ta.TopAbs_FACE)
         while face_explorer.More():
-            target_face = TopoDS.Face_s(face_explorer.Current())
+            target_face = TopoDS.Face(face_explorer.Current())
             modified_los: TopTools_ListOfShape = history.Modified(target_face)
             while not modified_los.IsEmpty():
-                modified_face = TopoDS.Face_s(modified_los.First())
+                modified_face = TopoDS.Face(modified_los.First())
                 modified_los.RemoveFirst()
                 modified_target_faces.append(modified_face)
             face_explorer.Next()
@@ -1150,7 +1150,7 @@ class Solid(Mixin3D[TopoDS_Solid]):
             Solid: Box
         """
         return cls(
-            TopoDS.Solid_s(
+            TopoDS.Solid(
                 BRepPrimAPI_MakeBox(
                     plane.to_gp_ax2(),
                     length,
@@ -1184,7 +1184,7 @@ class Solid(Mixin3D[TopoDS_Solid]):
             Solid: Full or partial cone
         """
         return cls(
-            TopoDS.Solid_s(
+            TopoDS.Solid(
                 BRepPrimAPI_MakeCone(
                     plane.to_gp_ax2(),
                     base_radius,
@@ -1217,7 +1217,7 @@ class Solid(Mixin3D[TopoDS_Solid]):
             Solid: Full or partial cylinder
         """
         return cls(
-            TopoDS.Solid_s(
+            TopoDS.Solid(
                 BRepPrimAPI_MakeCylinder(
                     plane.to_gp_ax2(),
                     radius,
@@ -1245,7 +1245,7 @@ class Solid(Mixin3D[TopoDS_Solid]):
         Returns:
             Solid: Lofted object
         """
-        return cls(TopoDS.Solid_s(_make_loft(objs, True, ruled)))
+        return cls(TopoDS.Solid(_make_loft(objs, True, ruled)))
 
     @classmethod
     def make_sphere(
@@ -1271,7 +1271,7 @@ class Solid(Mixin3D[TopoDS_Solid]):
             Solid: sphere
         """
         return cls(
-            TopoDS.Solid_s(
+            TopoDS.Solid(
                 BRepPrimAPI_MakeSphere(
                     plane.to_gp_ax2(),
                     radius,
@@ -1307,7 +1307,7 @@ class Solid(Mixin3D[TopoDS_Solid]):
             Solid: Full or partial torus
         """
         return cls(
-            TopoDS.Solid_s(
+            TopoDS.Solid(
                 BRepPrimAPI_MakeTorus(
                     plane.to_gp_ax2(),
                     major_radius,
@@ -1347,7 +1347,7 @@ class Solid(Mixin3D[TopoDS_Solid]):
             Solid: wedge
         """
         return cls(
-            TopoDS.Solid_s(
+            TopoDS.Solid(
                 BRepPrimAPI_MakeWedge(
                     plane.to_gp_ax2(),
                     delta_x,
@@ -1396,7 +1396,7 @@ class Solid(Mixin3D[TopoDS_Solid]):
             True,
         )
 
-        return cls(TopoDS.Solid_s(revol_builder.Shape()))
+        return cls(TopoDS.Solid(revol_builder.Shape()))
 
     @classmethod
     def sweep(
@@ -1544,7 +1544,7 @@ class Solid(Mixin3D[TopoDS_Solid]):
         if make_solid:
             builder.MakeSolid()
 
-        return cls(TopoDS.Solid_s(builder.Shape()))
+        return cls(TopoDS.Solid(builder.Shape()))
 
     @classmethod
     def thicken(
@@ -1600,7 +1600,7 @@ class Solid(Mixin3D[TopoDS_Solid]):
         )
         offset_builder.MakeOffsetShape()
         try:
-            result = Solid(TopoDS.Solid_s(offset_builder.Shape()))
+            result = Solid(TopoDS.Solid(offset_builder.Shape()))
         except StdFail_NotDone as err:
             raise RuntimeError("Error applying thicken to given surface") from err
 
@@ -1647,7 +1647,7 @@ class Solid(Mixin3D[TopoDS_Solid]):
 
         try:
             draft_angle_builder.Build()
-            result = Solid(TopoDS.Solid_s(draft_angle_builder.Shape()))
+            result = Solid(TopoDS.Solid(draft_angle_builder.Shape()))
         except StdFail_NotDone as err:
             raise DraftAngleError(
                 "Draft build failed on the given solid.",

--- a/src/build123d/topology/two_d.py
+++ b/src/build123d/topology/two_d.py
@@ -1030,7 +1030,7 @@ class Face(Mixin2D[TopoDS_Face]):
         """
         if not obj:
             raise ValueError("Can't extrude empty object")
-        return Face(TopoDS.Face_s(_extrude_topods_shape(obj.wrapped, direction)))
+        return Face(TopoDS.Face(_extrude_topods_shape(obj.wrapped, direction)))
 
     @classmethod
     def make_bezier_surface(
@@ -1480,7 +1480,7 @@ class Face(Mixin2D[TopoDS_Face]):
 
         try:
             patch.Build()
-            result = cls(TopoDS.Face_s(patch.Shape()))
+            result = cls(TopoDS.Face(patch.Shape()))
         except (
             Standard_Failure,
             StdFail_NotDone,
@@ -1686,15 +1686,15 @@ class Face(Mixin2D[TopoDS_Face]):
             # Index or iterator access to OCP.TopTools.TopTools_ListOfShape is slow on M1 macs
             # Using First() and Last() to omit
             edges = (
-                Edge(TopoDS.Edge_s(edge_list.First())),
-                Edge(TopoDS.Edge_s(edge_list.Last())),
+                Edge(TopoDS.Edge(edge_list.First())),
+                Edge(TopoDS.Edge(edge_list.Last())),
             )
 
             edge1, edge2 = Wire.order_chamfer_edges(reference_edge, edges)
 
             chamfer_builder.AddChamfer(
-                TopoDS.Edge_s(edge1.wrapped),
-                TopoDS.Edge_s(edge2.wrapped),
+                TopoDS.Edge(edge1.wrapped),
+                TopoDS.Edge(edge2.wrapped),
                 distance,
                 distance2,
             )
@@ -2078,7 +2078,7 @@ class Face(Mixin2D[TopoDS_Face]):
                     BRepAlgoAPI_Common(),
                 )
                 for topods_shell in get_top_level_topods_shapes(topods_shape):
-                    intersected_shapes.append(Shell(TopoDS.Shell_s(topods_shell)))
+                    intersected_shapes.append(Shell(TopoDS.Shell(topods_shell)))
 
         intersected_shapes = intersected_shapes.sort_by(Axis(self.center(), direction))
         projected_shapes: ShapeList[Face | Shell] = ShapeList()
@@ -2135,7 +2135,7 @@ class Face(Mixin2D[TopoDS_Face]):
         for hole_wire in inner_wires:
             reshaper.Remove(hole_wire.wrapped)
         modified_shape = downcast(reshaper.Apply(self.wrapped))
-        holeless.wrapped = TopoDS.Face_s(modified_shape)
+        holeless.wrapped = TopoDS.Face(modified_shape)
         return holeless
 
     def wire(self) -> Wire:
@@ -2539,7 +2539,7 @@ class Shell(Mixin2D[TopoDS_Shell]):
             obj = shell
         elif isinstance(obj, Iterable):
             try:
-                obj = TopoDS.Shell_s(_sew_topods_faces([f.wrapped for f in obj]))
+                obj = TopoDS.Shell(_sew_topods_faces([f.wrapped for f in obj]))
             except Standard_TypeMismatch:
                 raise TypeError("Unable to create Shell, invalid input type")
 
@@ -2582,7 +2582,7 @@ class Shell(Mixin2D[TopoDS_Shell]):
         Returns:
             Edge: extruded shape
         """
-        return Shell(TopoDS.Shell_s(_extrude_topods_shape(obj.wrapped, direction)))
+        return Shell(TopoDS.Shell(_extrude_topods_shape(obj.wrapped, direction)))
 
     @classmethod
     def make_loft(cls, objs: Iterable[Vertex | Wire], ruled: bool = False) -> Shell:
@@ -2602,7 +2602,7 @@ class Shell(Mixin2D[TopoDS_Shell]):
         Returns:
             Shell: Lofted object
         """
-        return cls(TopoDS.Shell_s(_make_loft(objs, False, ruled)))
+        return cls(TopoDS.Shell(_make_loft(objs, False, ruled)))
 
     @classmethod
     def revolve(
@@ -2628,7 +2628,7 @@ class Shell(Mixin2D[TopoDS_Shell]):
             profile.wrapped, axis.wrapped, angle * DEG2RAD, True
         )
 
-        return cls(TopoDS.Shell_s(revol_builder.Shape()))
+        return cls(TopoDS.Shell(revol_builder.Shape()))
 
     @classmethod
     def sweep(
@@ -2656,7 +2656,7 @@ class Shell(Mixin2D[TopoDS_Shell]):
         builder.Add(profile.wrapped, False, False)
         builder.SetTransitionMode(Shape._transModeDict[transition])
         builder.Build()
-        result = Shell(TopoDS.Shell_s(builder.Shape()))
+        result = Shell(TopoDS.Shell(builder.Shape()))
         if SkipClean.clean:
             result = result.clean()
 

--- a/src/build123d/topology/utils.py
+++ b/src/build123d/topology/utils.py
@@ -255,7 +255,7 @@ def _make_topods_face_from_wires(
     # fix outer wire
     sf_s = ShapeFix_Shape(outer_wire)
     sf_s.Perform()
-    topo_wire = TopoDS.Wire_s(sf_s.Shape())
+    topo_wire = TopoDS.Wire(sf_s.Shape())
 
     face_builder = BRepBuilderAPI_MakeFace(topo_wire, True)
 
@@ -264,7 +264,7 @@ def _make_topods_face_from_wires(
             raise ValueError("Cannot build face(s): inner wire is not closed")
         sf_s = ShapeFix_Shape(inner_wire)
         sf_s.Perform()
-        fixed_inner_wire = TopoDS.Wire_s(sf_s.Shape())
+        fixed_inner_wire = TopoDS.Wire(sf_s.Shape())
         face_builder.Add(fixed_inner_wire)
 
     face_builder.Build()
@@ -278,7 +278,7 @@ def _make_topods_face_from_wires(
     sf_f.FixOrientation()
     sf_f.Perform()
 
-    return TopoDS.Face_s(sf_f.Result())
+    return TopoDS.Face(sf_f.Result())
 
 
 def delta(shapes_one: Iterable[Shape], shapes_two: Iterable[Shape]) -> list[Shape]:

--- a/src/build123d/topology/zero_d.py
+++ b/src/build123d/topology/zero_d.py
@@ -161,7 +161,7 @@ class Vertex(Shape[TopoDS_Vertex]):
 
         shape_type = shapetype(obj)
         # NB downcast is needed to handle TopoDS_Shape types
-        return constructor_lut[shape_type](TopoDS.Vertex_s(obj))
+        return constructor_lut[shape_type](TopoDS.Vertex(obj))
 
     @classmethod
     def extrude(cls, obj: Shape, direction: VectorLike) -> Vertex:
@@ -373,7 +373,7 @@ def topo_explore_common_vertex(
 
             # Check if the vertices are the same
             if vertex1.IsSame(vertex2):
-                return Vertex(TopoDS.Vertex_s(vertex1))  # Common vertex found
+                return Vertex(TopoDS.Vertex(vertex1))  # Common vertex found
 
             explorer2.Next()
         vert_exp.Next()


### PR DESCRIPTION
Recently merged PR https://github.com/gumyr/build123d/pull/1168 upgraded build123d in dev to cadquery-ocp* 7.9 but on review failed to notice that `cadquery-ocp-stubs` was not similarly upgraded in the [stubs] category. This PR addresses that issue.

Similarly OCP 7.9.x renamed some static methods, such as `TopoDS.Vertex_s` to `TopoDS.Vertex`. These were monkeypatched in cadquery-ocp but not in cadquery-ocp-stubs, meaning that upgrading to the newest stubs was causing new type failures.

There was another change to the typing stubs that possibly a typing failure on my local machine, so I added a tcast for that case in `constrained_lines.py`:
```py
# stubs 7.9.3.0
class Geom2dAPI_ProjectPointOnCurve...
    @overload
    def Parameter(self,Index : int) -> tuple[float]: 
    @overload
    def Parameter(self,Index : int) -> float: ...
# stubs 7.8.1.1.post1
class Geom2dAPI_ProjectPointOnCurve...
    @overload
    def Parameter(self,Index : int) -> float: 
    @overload
    def Parameter(self,Index : int) -> tuple[float]: ...
```