### PR TITLE
.gitignore -> add stp, STP, brep, gltf, bin, glb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,18 +16,25 @@ docs/_build/
 # User generated debris
 *.swp
 *.log
+
+# User generated debris (3D)
 *.stp
 *.STP
 *.step
 *.STEP
 *.stl
-*.svg
-*.dxf
 *.3mf
 *.brep
 *.gltf
 *.bin
 *.glb
+
+# User generated debris (2D)
+*.dxf
+*.jpeg
+*.jpg
+*.png
+*.svg
 
 #mypy cache
 .mypy_cache

--- a/.gitignore
+++ b/.gitignore
@@ -16,12 +16,18 @@ docs/_build/
 # User generated debris
 *.swp
 *.log
+*.stp
+*.STP
 *.step
 *.STEP
 *.stl
 *.svg
 *.dxf
 *.3mf
+*.brep
+*.gltf
+*.bin
+*.glb
 
 #mypy cache
 .mypy_cache


### PR DESCRIPTION
This is to avoid the issue where a large stp file was accidentally committed. I have also added other file formats as I think it makes sense to avoid committing large binary files. This can always be overridden by e.g. `git add --force somefile.glb` if necessary for e.g. use in the docs.