### PR TITLE
`Solid.extrude_taper` switch to `Solid.draft` approach instead of `LocOpe_DPrism`

### DIFF
--- a/src/build123d/topology/three_d.py
+++ b/src/build123d/topology/three_d.py
@@ -940,14 +940,13 @@ class Solid(Mixin3D[TopoDS_Solid]):
 
         Extrude a cross section into a prismatic solid in the provided direction.
 
-        Note that two difference algorithms are used. If direction aligns with
-        the profile normal (which must be positive), the taper is positive and the profile
-        contains no holes the OCP LocOpe_DPrism algorithm is used as it generates the most
-        accurate results. Otherwise, a loft is created between the profile and the profile
-        with a 2D offset set at the appropriate direction.
+        Note that two different algorithms are used. If direction aligns with
+        the profile normal (which must be positive), the OCP BRepOffsetAPI_DraftAngle
+        algorithm is tried. Otherwise, a loft is created between the profile and the
+        profile with a 2D offset set at the appropriate direction.
 
         Args:
-            section (Face]): cross section
+            profile (Face): cross section
             normal (VectorLike): a vector along which to extrude the wires. The length
                 of the vector controls the length of the extrusion.
             taper (float): taper angle in degrees.
@@ -963,47 +962,51 @@ class Solid(Mixin3D[TopoDS_Solid]):
         if (
             direction.normalized() == profile.normal_at()
             and Plane(profile).z_dir.Z > 0
-            and taper > 0
-            and not profile.inner_wires()
+            and (flip_inner or not profile.inner_wires())
         ):
-            prism_builder = LocOpe_DPrism(
-                profile.wrapped,
-                direction.length / cos(radians(taper)),
-                radians(taper),
-            )
-            new_solid = Solid(TopoDS.Solid(prism_builder.Shape()))
-        else:
-            # Determine the offset to get the taper
-            offset_amt = -direction.length * tan(radians(taper))
+            straight_solid = Solid.extrude(profile, direction)
 
-            outer = profile.outer_wire()
-            local_outer: Wire = Plane(profile).to_local_coords(outer)
-            local_taper_outer = local_outer.offset_2d(
-                offset_amt, kind=Kind.INTERSECTION
-            )
-            taper_outer = Plane(profile).from_local_coords(local_taper_outer)
-            taper_outer.move(Location(direction))
-
-            profile_wires = [profile.outer_wire()] + profile.inner_wires()
-
-            taper_wires = []
-            for i, wire in enumerate(profile_wires):
-                flip = -1 if i > 0 and flip_inner else 1
-                local: Wire = Plane(profile).to_local_coords(wire)
-                local_taper = local.offset_2d(flip * offset_amt, kind=Kind.INTERSECTION)
-                taper_wire: Wire = Plane(profile).from_local_coords(local_taper)
-                taper_wire.move(Location(direction))
-                taper_wires.append(taper_wire)
-
-            solids = [
-                Solid.make_loft([p, t]) for p, t in zip(profile_wires, taper_wires)
+            # Select all side faces (outer walls AND inner hole walls)
+            profile_normal = direction.normalized()
+            side_faces = [
+                f
+                for f in straight_solid.faces()
+                if f.normal_at().cross(profile_normal).length > 1e-5
             ]
-            if len(solids) > 1:
-                complex_solid = solids[0].cut(*solids[1:])
-                assert isinstance(complex_solid, Solid)  # Can't be a list
-                new_solid = complex_solid
-            else:
-                new_solid = solids[0]
+            print(side_faces)
+            try:
+                # Will work for Circle/Rect holes, might fail for Spline holes
+                return straight_solid.draft(side_faces, Plane(profile), taper)
+            except (ValueError, DraftAngleError, RuntimeError):
+                pass  # Fall back to Loft logic below
+
+        # Determine the offset to get the taper
+        offset_amt = -direction.length * tan(radians(taper))
+
+        outer = profile.outer_wire()
+        local_outer: Wire = Plane(profile).to_local_coords(outer)
+        local_taper_outer = local_outer.offset_2d(offset_amt, kind=Kind.INTERSECTION)
+        taper_outer = Plane(profile).from_local_coords(local_taper_outer)
+        taper_outer.move(Location(direction))
+
+        profile_wires = [profile.outer_wire()] + profile.inner_wires()
+
+        taper_wires = []
+        for i, wire in enumerate(profile_wires):
+            flip = -1 if i > 0 and flip_inner else 1
+            local: Wire = Plane(profile).to_local_coords(wire)
+            local_taper = local.offset_2d(flip * offset_amt, kind=Kind.INTERSECTION)
+            taper_wire: Wire = Plane(profile).from_local_coords(local_taper)
+            taper_wire.move(Location(direction))
+            taper_wires.append(taper_wire)
+
+        solids = [Solid.make_loft([p, t]) for p, t in zip(profile_wires, taper_wires)]
+        if len(solids) > 1:
+            complex_solid = solids[0].cut(*solids[1:])
+            assert isinstance(complex_solid, Solid)
+            new_solid = complex_solid
+        else:
+            new_solid = solids[0]
 
         return new_solid
 

--- a/src/build123d/topology/three_d.py
+++ b/src/build123d/topology/three_d.py
@@ -973,7 +973,7 @@ class Solid(Mixin3D[TopoDS_Solid]):
                 for f in straight_solid.faces()
                 if f.normal_at().cross(profile_normal).length > 1e-5
             ]
-            print(side_faces)
+
             try:
                 # Will work for Circle/Rect holes, might fail for Spline holes
                 return straight_solid.draft(side_faces, Plane(profile), taper)

--- a/tests/test_build_generic.py
+++ b/tests/test_build_generic.py
@@ -622,14 +622,14 @@ class OffsetTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             offset(Vertex(), amount=1)
 
-    def test_offset_failure(self):
+    def test_offset_negative_taper_extrude(self):
         with BuildPart() as cup:
             with BuildSketch():
                 Circle(35)
             extrude(amount=50, taper=-3)
             topf = cup.faces().sort_by(Axis.Z)[-1]
-            with self.assertRaises(RuntimeError):
-                offset(amount=-2, openings=topf)
+            offset(amount=-2, openings=topf)
+            self.assertTrue(cup.part.volume > 0)
 
     def test_flipped_faces(self):
         box = Box(10, 10, 10)


### PR DESCRIPTION
The current approach for `Solid.extrude_taper` has a few issues:

1. Falls back to a loft approach in several common cases; negative taper angle and profile has holes
 2. The loft fallback often generates complex surfaces that affect the stability of downstream operations
 3. The LocOpe_DPrism approach seems to have its own issues such as https://github.com/gumyr/build123d/issues/987
 
This PR alters the approach from LocOpe_DPrism + loft fallback to `Solid.draft` + loft fallback. The internal method works by first creating a linear extrusion and then selecting the "side faces" and applying a draft angle to those. Here are the reasons why this may be a better approach than the current one:

1. Draft seems to have no issues with reasonable positive and negative taper angles
2. Draft seems to support some types of holes (composed of lines or circular arcs).
3. When it is used draft seems generates "clean" results, i.e. planar, cylindrical, conical faces instead of BSpline surfaces (loft)
4. I verified that this fixes issue #987 

Self Critique: I am wondering if rather than `Solid.draft` + loft fallback it should instead be: `Solid.draft` + LocOpe_DPrism/dprism fallback-1 + loft fallback-2. Also -- maybe I should also add some new tests to cover the issue 987 or 553 failures.

Related issues:
(linked above) #987 
#553  (similar to the above 987)
https://github.com/gumyr/build123d/issues/543 (need to check how corners are affected in this new approach)
https://github.com/gumyr/build123d/issues/568 (likely an issue in offset, not taper extrude)
https://github.com/gumyr/build123d/issues/746 (alternative approach proposed using dprism instead of draft)
