### PR TITLE
fix: `JernArc` detect and modify global/local tangent directions as appropriate

### DIFF
--- a/src/build123d/objects_curve.py
+++ b/src/build123d/objects_curve.py
@@ -1102,9 +1102,14 @@ class JernArc(BaseEdgeObject):
                 WorkplaneList._get_context().workplanes[0]
             )
         jern_workplane.origin = start
-        start_tangent = Vector(tangent).transform(
-            jern_workplane.reverse_transform, is_direction=True
-        )
+
+        if isinstance(tangent, tuple) and len(tangent) == 2:
+            # de-localize to global tangent if supplied tangent is a 2-tuple
+            start_tangent = Vector(tangent).transform(
+                jern_workplane.reverse_transform, is_direction=True
+            ).normalized()
+        else:
+            start_tangent = Vector(tangent).normalized()
 
         arc_direction = copysign(1.0, arc_size)
         self.center_point = start + start_tangent.rotate(

--- a/tests/test_build_line.py
+++ b/tests/test_build_line.py
@@ -353,12 +353,17 @@ class BuildLineTests(unittest.TestCase):
         self.assertAlmostEqual(off1.radius, 1)
         self.assertAlmostEqual(off1.length, pi / 2)
 
-        plane_iso = Plane(origin=(0, 0, 0), x_dir=(1, 1, 0), z_dir=(1, -1, 1))
-        with BuildLine(plane_iso) as iso_l:
+        with BuildLine(Plane.isometric) as iso_l:
             iso1 = JernArc((0, 0), (0, 1), 1, 180)
         self.assertTupleAlmostEquals(iso_l.line @ 1, (-sqrt(2), -sqrt(2), 0), 5)
         self.assertAlmostEqual(iso1.radius, 1)
         self.assertAlmostEqual(iso1.length, pi)
+
+        with BuildLine(Plane.YZ) as jern_arc_vector:
+            jv1 = JernArc(start=Vector(0, 5, 4), tangent=Vector(0, 0, 1), radius=1, arc_size=90)
+        self.assertTupleAlmostEquals(jv1 @ 1, (0, 4, 5), 5)
+        self.assertAlmostEqual(jv1.radius, 1)
+        self.assertAlmostEqual(jv1.length, pi / 2)
 
         with BuildLine() as full_l:
             l1 = JernArc(start=(0, 0, 0), tangent=(1, 0, 0), radius=1, arc_size=360)


### PR DESCRIPTION
Resolves https://github.com/gumyr/build123d/issues/1225 and resolves https://github.com/gumyr/build123d/issues/997

I have added one additional test case derived from issue #1225 

Essentially what this PR does is introduce different logic to check if a tuple of length 2 (i.e. a 2-tuple) is supplied to JernArc as a tangent direction. If so it applies a transformation to this tangent direction to put it into the global coordinate system. If a 3-tuple or Vector is supplied this transformation is skipped as it is assumed these are already in the global coordinate system.

More context for this is also available in an older PR here https://github.com/gumyr/build123d/pull/644

cc @jwagenet 