### PR TITLE
Add environment markers for linux-aarch64 to use py-lib3mf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,9 @@
 [build-system]
-
 requires = [
     "setuptools>=45",
     "wheel",
     "setuptools_scm[toml]>=6.2",
 ]
-
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -42,13 +40,18 @@ dependencies = [
     "anytree >= 2.8.0, < 3",
     "ezdxf >= 1.1.0, < 2",
     "ipython >= 8.0.0, < 10",
-    "lib3mf >= 2.4.1",
     "ocpsvg >= 0.6, < 0.7",
     "ocp_gordon >= 0.2, < 0.3",
     "trianglesolver",
     "sympy",
     "scipy",
     "webcolors ~= 24.8.0",
+
+    # Install standard official lib3mf on everything EXCEPT linux aarch64
+    "lib3mf >= 2.4.1; sys_platform != 'linux' or platform_machine != 'aarch64'",
+    
+    # Install py-lib3mf ONLY on linux aarch64
+    "py-lib3mf >= 2.4.1; sys_platform == 'linux' and platform_machine == 'aarch64'",
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR adds environment markers for linux-aarch64 to use py-lib3mf, and the other current platforms to use the official lib3mf from PyPI. This PR enables simple installation of build123d (e.g. `pip install build123d`) on Linux aarch64 platforms such as the Raspberry Pi 5 in combination with the prior release of cadquery-ocp(-novtk) for this platform as well.

I also plan to enable some amount of testing workflows for this platform at a later date.