### PR TITLE
Improve LSP support for Builder

### DIFF
--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -266,8 +266,8 @@ class Builder(ABC, Generic[ShapeT]):
         builder_context = Builder._get_context()
         current_frame = inspect.currentframe()
         same_scope = (
-            builder_context._python_frame == inspect.currentframe().f_back
-            if builder_context is not None and current_frame is not None
+            builder_context._python_frame == current_Frame.f_back
+            if builder_context and current_frame
             else False
         )
 

--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -263,9 +263,11 @@ class Builder(ABC, Generic[ShapeT]):
         # by CPython in Linux, Window & MacOS but may not be supported in other python
         # implementations.  Support outside of these OS's is outside the scope of this
         # project.
+        builder_context = Builder._get_context()
+        current_frame = inspect.currentframe()
         same_scope = (
-            Builder._get_context()._python_frame == inspect.currentframe().f_back
-            if Builder._get_context()
+            builder_context._python_frame == inspect.currentframe().f_back
+            if builder_context and current_frame
             else False
         )
 

--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -219,13 +219,13 @@ class Builder(ABC, Generic[ShapeT]):
         self.mode = mode
         planes = WorkplaneList._convert_to_planes(workplanes)
         self.workplanes = planes if planes else [Plane.XY]
-        self._reset_tok = None
+        self._reset_tok : contextvars.Token[Builder] | None = None
         current_frame = inspect.currentframe()
         assert current_frame is not None
         assert current_frame.f_back is not None
         self._python_frame = current_frame.f_back.f_back
         self.parent_frame = None
-        self.builder_parent = None
+        self.builder_parent : Builder | None = None
         self.lasts: dict = {Vertex: [], Edge: [], Face: [], Solid: []}
         self.workplanes_context = None
         self.exit_workplanes: list[Plane] = []
@@ -276,7 +276,7 @@ class Builder(ABC, Generic[ShapeT]):
         else:
             self.builder_parent = None
 
-        self._reset_tok : Token[Builder] | None = self._current.set(self)
+        self._reset_tok = self._current.set(self)
 
         logger.info(
             "Entering %s with mode=%s which is in %s scope as parent",

--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -263,7 +263,7 @@ class Builder(ABC, Generic[ShapeT]):
         # by CPython in Linux, Window & MacOS but may not be supported in other python
         # implementations.  Support outside of these OS's is outside the scope of this
         # project.
-        builder_context : Builder[ShapeT] | None = Builder._get_context()
+        builder_context : Builder | None = Builder._get_context()
         current_frame = inspect.currentframe()
         same_scope = (
             builder_context._python_frame == current_frame.f_back
@@ -276,7 +276,7 @@ class Builder(ABC, Generic[ShapeT]):
         else:
             self.builder_parent = None
 
-        self._reset_tok = self._current.set(self)
+        self._reset_tok Token[Builder] | None = self._current.set(self)
 
         logger.info(
             "Entering %s with mode=%s which is in %s scope as parent",

--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -256,7 +256,7 @@ class Builder(ABC, Generic[ShapeT]):
         before_list = [] if self.obj_before is None else [self.obj_before]
         return new_edges(*(before_list + self.to_combine), combined=self._obj)
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         """Upon entering record the parent and a token to restore contextvars"""
 
         # Only set parents from the same scope. Note inspect.currentframe() is supported

--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -266,7 +266,7 @@ class Builder(ABC, Generic[ShapeT]):
         builder_context : Builder[ShapeT] | None = Builder._get_context()
         current_frame = inspect.currentframe()
         same_scope = (
-            builder_context._python_frame == current_Frame.f_back
+            builder_context._python_frame == current_frame.f_back
             if builder_context and current_frame
             else False
         )

--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -272,7 +272,7 @@ class Builder(ABC, Generic[ShapeT]):
         )
 
         if same_scope:
-            self.builder_parent = Builder._get_context()
+            self.builder_parent = builder_context
         else:
             self.builder_parent = None
 

--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -276,7 +276,7 @@ class Builder(ABC, Generic[ShapeT]):
         else:
             self.builder_parent = None
 
-        self._reset_tok Token[Builder] | None = self._current.set(self)
+        self._reset_tok : Token[Builder] | None = self._current.set(self)
 
         logger.info(
             "Entering %s with mode=%s which is in %s scope as parent",

--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -267,7 +267,7 @@ class Builder(ABC, Generic[ShapeT]):
         current_frame = inspect.currentframe()
         same_scope = (
             builder_context._python_frame == inspect.currentframe().f_back
-            if builder_context and current_frame
+            if builder_context is not None and current_frame is not None
             else False
         )
 

--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -263,7 +263,7 @@ class Builder(ABC, Generic[ShapeT]):
         # by CPython in Linux, Window & MacOS but may not be supported in other python
         # implementations.  Support outside of these OS's is outside the scope of this
         # project.
-        builder_context = Builder._get_context()
+        builder_context : Builder[ShapeT] | None = Builder._get_context()
         current_frame = inspect.currentframe()
         same_scope = (
             builder_context._python_frame == current_Frame.f_back


### PR DESCRIPTION
The explicit type annotation helps additional tooling like language servers to correctly determine the type in context manager.

For me, this solves a problem with the `ty` language server, which was unable to determine the types `BuildPart`, `BuildSketch` and `BuildLine` context managers.