### PR TITLE
Add makerrepo in external tools doc page

### DIFF
--- a/docs/external.rst
+++ b/docs/external.rst
@@ -168,13 +168,15 @@ The ``makerrepo`` Python package (imported as ``mr``) is a lightweight library t
 provides decorators such as ``@artifact``, ``@customizable``, and ``@cached`` to
 annotate functions that build your models. The decorators have no effect on your
 existing build123d code until it is discovered and run by tools such as the
-`MakerRepo CLI <https://docs.makerrepo.com/makerrepo-cli/>`_ or
+`makerrepo-cli <https://docs.makerrepo.com/makerrepo-cli/>`_ or
 `MakerRepo.com <https://makerrepo.com/>`_ CI. The goal is to enable a code-driven
 workflow locally (e.g. command-line tools) or in CI. The library does not assume
-how it will be consumed, so the same build123d script works standalone or with
-MakerRepo.
+how it will be consumed, so annotated functions can be used with other tools and
+frameworks as well.
 
-See `MakerRepo Docs <https://docs.makerrepo.com>`_ for more information.
+See `MakerRepo Library Docs <https://docs.makerrepo.com/makerrepo-library/>`_ for
+more information and `LaunchPlatform/makerrepo <https://github.com/LaunchPlatform/makerrepo>`_
+for source code.
 
 makerrepo-cli
 =============

--- a/docs/external.rst
+++ b/docs/external.rst
@@ -161,6 +161,33 @@ from PartCAD repositories, and to
 `publish build123d designs <https://partcad.readthedocs.io/en/latest/use_cases.html#publish-packages>`_
 to be consumed by others.
 
+MakerRepo library (mr)
+======================
+
+The ``makerrepo`` Python package (imported as ``mr``) is a lightweight library that
+provides decorators such as ``@artifact``, ``@customizable``, and ``@cached`` to
+annotate functions that build your models. The decorators have no effect on your
+existing build123d code until it is discovered and run by tools such as the
+`MakerRepo CLI <https://docs.makerrepo.com/makerrepo-cli/>`_ or
+`MakerRepo.com <https://makerrepo.com/>`_ CI. The goal is to enable a code-driven
+workflow locally (e.g. command-line tools) or in CI. The library does not assume
+how it will be consumed, so the same build123d script works standalone or with
+MakerRepo.
+
+See `MakerRepo Docs <https://docs.makerrepo.com>`_ for more information.
+
+makerrepo-cli
+=============
+
+Command-line tool (available as ``makerrepo-cli`` or ``mr``) to build artifacts,
+run generators, snapshot artifacts, and manage cache locally. It scans the
+current directory for Python packages and modules that use the MakerRepo library
+decorators.
+
+See `MakerRepo CLI <https://docs.makerrepo.com/makerrepo-cli/>`_ for
+documentation and `LaunchPlatform/makerrepo-cli <https://github.com/LaunchPlatform/makerrepo-cli>`_
+for source code.
+
 dl4to4ocp
 =========
 


### PR DESCRIPTION
I’ve created two open-source projects:

- [**makerrepo lib**](https://github.com/LaunchPlatform/makerrepo)  
- [**makerrepo cli**](https://github.com/LaunchPlatform/makerrepo-cli)

While there are still many features I’d like to add, the libraries already provide some useful functionality such as viewing model, snapshot support, exporting to different format and caching.

I think it makes sense to share these tools with the build123d community at this point, so I’ve added them to the [External Tools documentation page](https://build123d.readthedocs.io/en/latest/external.html).

Could you please take a look and let me know if it reads well / looks okay, or if there’s anything I should change or improve? 🙏