### PR TITLE
Ensure add returns consistent results across Compounds

### DIFF
--- a/src/build123d/topology/composite.py
+++ b/src/build123d/topology/composite.py
@@ -59,6 +59,7 @@ import warnings
 from collections.abc import Iterable, Iterator, Sequence
 from itertools import combinations
 from os import PathLike, fspath
+from typing import cast as tcast
 from typing_extensions import Self
 
 import OCP.TopAbs as ta
@@ -491,7 +492,8 @@ class Compound(Mixin3D[TopoDS_Compound]):
         )
 
         # Only fuse the parts if necessary
-        cls = {1: Curve, 2: Sketch, 3: Part}.get(self._dim, Compound)
+        dim = self._dim if self._dim is not None else -1
+        cls = {1: Curve, 2: Sketch, 3: Part}.get(dim, Compound)
         if len(summands) <= 1:
             result: Shape = cls(summands[0:1])
         else:
@@ -935,7 +937,8 @@ class Curve(Compound):
     @property
     def length(self) -> float:
         """length - the total length of all edges and wires in this Curve"""
-        return sum(e.length for e in [*self.get_type(Edge), *self.get_type(Wire)])
+        items = tcast(list[Edge | Wire], [*self.get_type(Edge), *self.get_type(Wire)])
+        return sum(e.length for e in items)
 
     # ---- Instance Methods ----
 

--- a/src/build123d/topology/composite.py
+++ b/src/build123d/topology/composite.py
@@ -491,18 +491,27 @@ class Compound(Mixin3D[TopoDS_Compound]):
         )
 
         # Only fuse the parts if necessary
+        cls = {1: Curve, 2: Sketch, 3: Part}.get(self._dim, Compound)
         if len(summands) <= 1:
-            result: Shape = Compound(summands[0:1])
+            result: Shape = cls(summands[0:1])
         else:
             fuse_op = BRepAlgoAPI_Fuse()
             fuse_op.SetFuzzyValue(TOLERANCE)
             self.copy_attributes_to(summands[0], ["wrapped", "_NodeMixin__children"])
             bool_result = self._bool_op(summands[:1], summands[1:], fuse_op)
             if isinstance(bool_result, list):
-                result = Compound(bool_result)
+                result = cls(bool_result)
                 self.copy_attributes_to(result, ["wrapped", "_NodeMixin__children"])
             else:
                 result = bool_result
+                if not isinstance(result, cls):
+                    if isinstance(result, Compound):
+                        result = cls(result.wrapped)
+                    else:
+                        result = cls([result])
+                    self.copy_attributes_to(
+                        result, ["wrapped", "_NodeMixin__children"]
+                    )
 
         if SkipClean.clean:
             result = result.clean()
@@ -923,6 +932,11 @@ class Curve(Compound):
     def _dim(self) -> int:
         return 1
 
+    @property
+    def length(self) -> float:
+        """length - the total length of all edges and wires in this Curve"""
+        return sum(e.length for e in [*self.get_type(Edge), *self.get_type(Wire)])
+
     # ---- Instance Methods ----
 
     def __matmul__(self, position: float) -> Vector:
@@ -950,6 +964,11 @@ class Sketch(Compound):
     @property
     def _dim(self) -> int:
         return 2
+
+    @property
+    def area(self) -> float:
+        """area - the total area of all faces in this Sketch"""
+        return sum(f.area for f in [*self.get_type(Face), *self.get_type(Shell)])
 
 
 class Part(Compound):

--- a/src/build123d/topology/one_d.py
+++ b/src/build123d/topology/one_d.py
@@ -444,16 +444,18 @@ class Mixin1D(Shape[TOPODS]):
 
         if type(self).order == 4:
             # Preserve Compound type (e.g., Curve)
+            # At runtime type(self) is Curve, but mypy only sees Mixin1D
+            curve_cls = tcast("type[Curve]", type(self))
             if not isinstance(sum_shape, type(self)):
                 if isinstance(sum_shape, Shape) and sum_shape.wrapped is not None and isinstance(sum_shape.wrapped, TopoDS_Compound):
                     # Re-type an existing compound (e.g., Compound -> Curve)
-                    sum_shape = type(self)(sum_shape.wrapped)
+                    sum_shape = curve_cls(sum_shape.wrapped)
                 elif isinstance(sum_shape, Shape):
                     # Wrap a single shape (e.g., Edge) into a new Curve
-                    sum_shape = type(self)([sum_shape])
+                    sum_shape = curve_cls([sum_shape])
                 else:
                     # Already an Iterable[Shape] (e.g., ShapeList from fuse)
-                    sum_shape = type(self)(sum_shape)
+                    sum_shape = curve_cls(sum_shape)
         else:
             # If there is only one Edge, return that
             sum_shape = sum_shape.edge() if len(sum_shape.edges()) == 1 else sum_shape  # type: ignore

--- a/src/build123d/topology/one_d.py
+++ b/src/build123d/topology/one_d.py
@@ -442,8 +442,21 @@ class Mixin1D(Shape[TOPODS]):
         if SkipClean.clean and not isinstance(sum_shape, list):
             sum_shape = sum_shape.clean()
 
-        # If there is only one Edge, return that
-        sum_shape = sum_shape.edge() if len(sum_shape.edges()) == 1 else sum_shape  # type: ignore
+        if type(self).order == 4:
+            # Preserve Compound type (e.g., Curve)
+            if not isinstance(sum_shape, type(self)):
+                if isinstance(sum_shape, Shape) and sum_shape.wrapped is not None and isinstance(sum_shape.wrapped, TopoDS_Compound):
+                    # Re-type an existing compound (e.g., Compound -> Curve)
+                    sum_shape = type(self)(sum_shape.wrapped)
+                elif isinstance(sum_shape, Shape):
+                    # Wrap a single shape (e.g., Edge) into a new Curve
+                    sum_shape = type(self)([sum_shape])
+                else:
+                    # Already an Iterable[Shape] (e.g., ShapeList from fuse)
+                    sum_shape = type(self)(sum_shape)
+        else:
+            # If there is only one Edge, return that
+            sum_shape = sum_shape.edge() if len(sum_shape.edges()) == 1 else sum_shape  # type: ignore
 
         return sum_shape
 

--- a/tests/test_algebra.py
+++ b/tests/test_algebra.py
@@ -555,9 +555,9 @@ class AlgebraTests(unittest.TestCase):
         e2 = Edge.make_line((1, 1), (2, 1))
         e3 = Edge.make_line((2, 1), (3, 1))
         l = Curve() + [e1, e3]
-        self.assertTrue(isinstance(l, Compound))
+        self.assertTrue(isinstance(l, Curve))
         l += e2  # fills the hole and makes a single edge
-        self.assertTrue(isinstance(l, Edge))
+        self.assertTrue(isinstance(l, Curve))
         self.assertAlmostEqual(l.length, 3, 5)
 
         l2 = e1 + e3
@@ -572,7 +572,7 @@ class AlgebraTests(unittest.TestCase):
     def test_nothing_plus_curve(self):
         e1 = Edge.make_line((0, 1), (1, 1))
         l = Curve() + e1
-        self.assertTrue(isinstance(l, Edge))
+        self.assertTrue(isinstance(l, Curve))
         self.assertAlmostEqual(l.length, 1, 5)
 
     def test_bad_dims(self):


### PR DESCRIPTION
A fix attempt for https://github.com/gumyr/build123d/issues/1258 (add results inconsistent across Compound subtypes)

This has been analysed together with claude code:

**Solution approach:**

- one_d.py - `Mixin1D.__add__`

    Solves `Curve() + edges => Curve`

    `Mixin1D.__add__` (used by `Curve`) was designed for `Edge`/`Wire`. It would unwrap single-edge results and return bare `Edge` objects, losing the `Curve` type. The fix checks if `self` is a `Compound` type (`order == 4`) and ensures the result is always re-wrapped into the correct type (e.g., `Curve`).

- composite.py - `Compound.__add__`
    
    Solves `Part() + solids => Part` and `Sketch() + faces => Sketch`
    
    The general `__add__` path (for `Sketch`/`Part`) always created bare `Compound` objects regardless of the caller's type. The fix resolves the target class from `self._dim ({1: Curve, 2: Sketch, 3: Part}`, falling back to `Compound` for mixed dimensions) and uses that class for all wrapping. 

**Test impact:**

2 tests used 
- `isinstance(result, Edge)` which now is a `Curve` 
- `length` property on the Edge (now Curve). Curve is a `Mixin3D`, so it has `volume` but not `length`. `length` could have been added to `Compound` (leading to a `length` setter issue with `Box`). Hence `length` was added to `Curve` (and for completeness `area` to `Sketch`). btw. `volume` cannot easily be moved to `Part`.

An alternative solution would be to remove `length` and `area` again and fix the tests to use `sum(e.length for l.edges()`