### PR TITLE
Add Axis and angle constructor overload in Rotation

### DIFF
--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -2402,44 +2402,69 @@ class Rotation(Location):
         """Rotation from axis of rotation and angle."""
 
     def __init__(self, *args, **kwargs):
-        if not all(
-            key in ("X", "Y", "Z", "rotation", "ordering", "axis", "angle")
-            for key in kwargs
-        ):
-            raise TypeError("Invalid key for Rotation")
-        angles, rotations, orderings = [0, 0, 0], [], []
-        trsf = None
+        rotation = kwargs.pop("rotation", None)
+        x_angle = kwargs.pop("X", 0.0)
+        y_angle = kwargs.pop("Y", 0.0)
+        z_angle = kwargs.pop("Z", 0.0)
+        ordering = kwargs.pop("ordering", Intrinsic.XYZ)
+        axis = kwargs.pop("axis", None)
+        axis_angle = kwargs.pop("angle", None)
+
+        # If any unexpected kwargs remain
+        if kwargs:
+            raise TypeError(f"Unexpected keyword arguments: {', '.join(kwargs)}")
+
+        # Fill from positional args if not given via kwargs
         if args:
-            angles = list(filter(lambda item: isinstance(item, (int, float)), args))
-            vectors = list(filter(lambda item: isinstance(item, Vector), args))
-            tuples = list(filter(lambda item: isinstance(item, tuple), args))
-            axis_items = list(filter(lambda item: isinstance(item, Axis), args))
-            if tuples and not axis_items:
-                angles = list(*tuples)
-            if vectors:
-                angles = tuple(vectors[0])
-            if axis_items and angles:
-                angle = angles[0]
-                trsf = gp_Trsf()
-                trsf.SetRotation(axis_items[0].wrapped, angle)
-            if len(angles) < 3:
-                angles.extend([0.0] * (3 - len(angles)))
-            rotations = list(filter(lambda item: isinstance(item, Rotation), args))
-            orderings = list(
-                filter(lambda item: isinstance(item, (Extrinsic, Intrinsic)), args)
-            )
-        kwargs.setdefault("X", angles[0])
-        kwargs.setdefault("Y", angles[1])
-        kwargs.setdefault("Z", angles[2])
-        kwargs.setdefault("ordering", orderings[0] if orderings else Intrinsic.XYZ)
-        if rotations:
-            super().__init__(rotations[0])
-        elif trsf:
+            if rotation is None and isinstance(args[0], Rotation):
+                rotation = args[0]
+
+            elif axis is None and isinstance(args[0], Axis):
+                # Check for correct args
+                if len(args) < 2:
+                    raise TypeError(f"Too few arguments: Requires Axis and Angle")
+                elif not isinstance(args[1], (int, float)):
+                    raise TypeError(f"Angle must be a float not {args[1]}")
+
+                axis, axis_angle = args[0], args[1]
+
+                if axis_angle == 0.0:
+                    # No valid rotation: Fallback mode
+                    axis, axis_angle = None, None
+
+            else: # Euler angles
+                euler = list(filter(lambda item: isinstance(item, (int, float)), args))
+                vectors = list(filter(lambda item: isinstance(item, Vector), args))
+                tuples = list(filter(lambda item: isinstance(item, tuple), args))
+
+                if tuples:
+                    euler = list(*tuples)
+                if vectors:
+                    euler = tuple(vectors[0])
+
+                # Extract individual angles
+                x_angle = euler[0] if len(euler) > 0 else x_angle
+                y_angle = euler[1] if len(euler) > 1 else y_angle
+                z_angle = euler[2] if len(euler) > 2 else z_angle
+
+                ord_arg = next(
+                    filter(lambda item: isinstance(item, (Extrinsic, Intrinsic)), args),
+                    None,
+                )
+                if ord_arg:
+                    ordering = ord_arg
+
+        # Construct Rotation
+        if rotation:
+            super().__init__(rotation)
+
+        elif axis:
+            trsf = gp_Trsf()
+            trsf.SetRotation(axis.wrapped, axis_angle)
             super().__init__(trsf)
+
         else:
-            super().__init__(
-                (0, 0, 0), (kwargs["X"], kwargs["Y"], kwargs["Z"]), kwargs["ordering"]
-            )
+            super().__init__((0, 0, 0), (x_angle, y_angle, z_angle), ordering)
 
 
 Rot = Rotation  # Short form for Algebra users who like compact notation
@@ -2625,7 +2650,7 @@ class Matrix:
         """
         if not isinstance(row_col, tuple) or (len(row_col) != 2):
             raise IndexError("Matrix subscript must provide (row, column)")
-        (row, col) = row_col
+        row, col = row_col
         if not ((0 <= row <= 3) and (0 <= col <= 3)):
             raise IndexError(f"Out of bounds access into 4x4 matrix: {repr(row_col)}")
         if row < 3:

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -2341,7 +2341,7 @@ class Rotation(Location):
     def __init__(
         self,
         rotation: RotationLike,
-        ordering: Extrinsic | Intrinsic == Intrinsic.XYZ,  # type: ignore[valid-type]
+        ordering: Extrinsic | Intrinsic = Intrinsic.XYZ,
     ):
         """Rotation from other RotationLike object."""
 
@@ -2365,89 +2365,101 @@ class Rotation(Location):
 
     def __init__(self, *args, **kwargs):
         rotation_like = kwargs.pop("rotation", None)
-        x_angle = kwargs.pop("X", 0.0)
-        y_angle = kwargs.pop("Y", 0.0)
-        z_angle = kwargs.pop("Z", 0.0)
-        ordering = kwargs.pop("ordering", Intrinsic.XYZ)
+        x_angle = kwargs.pop("X", None)
+        y_angle = kwargs.pop("Y", None)
+        z_angle = kwargs.pop("Z", None)
+        ordering = kwargs.pop("ordering", None)
         axis = kwargs.pop("axis", None)
-        axis_angle = kwargs.pop("angle", 0.0)
+        axis_angle = kwargs.pop("angle", None)
 
-        # If any unexpected kwargs remain
+        # Handle unexpected kwargs
         if kwargs:
             raise TypeError(f"Unexpected keyword arguments: {', '.join(kwargs)}")
 
         # Fill from positional args if not given via kwargs
-        rotation = None
         if args:
-            if isinstance(args[0], Rotation):
-                rotation = args[0]
-                # Ordering is ignored
-
-            elif axis is None and isinstance(args[0], Axis):
-                # Check for correct args
-                if len(args) < 2:
-                    raise TypeError("Too few arguments: Requires Axis and Angle")
-                if not isinstance(args[1], (int, float)):
-                    raise TypeError(f"Angle must be an int or float not {args[1]}")
-
-                axis, axis_angle = args[0], args[1]
-
-            else:  # Euler angles
-                euler = list(filter(lambda item: isinstance(item, (int, float)), args))
-                vectors = list(filter(lambda item: isinstance(item, Vector), args))
-                tuples = list(filter(lambda item: isinstance(item, tuple), args))
-
-                if [bool(euler), bool(vectors), bool(tuples)].count(True) > 1:
-                    raise TypeError(
-                        "Provide angles in one way only: individually, tuple, or Vector"
-                    )
-
-                if tuples:
-                    if len(tuples) > 1:
-                        raise TypeError("Too many tuples provided")
-                    euler = tuples[0]
-                elif vectors:
-                    if len(vectors) > 1:
-                        raise TypeError("Too many Vectors provided")
-                    euler = tuple(vectors[0])
-
-                # Extract individual angles
-                x_angle = euler[0] if len(euler) > 0 else x_angle
-                y_angle = euler[1] if len(euler) > 1 else y_angle
-                z_angle = euler[2] if len(euler) > 2 else z_angle
-
-                ord_arg = next(
-                    filter(lambda item: isinstance(item, (Extrinsic, Intrinsic)), args),
-                    None,
+            if isinstance(args[0], Axis):
+                axis = args[0] if axis is None else axis
+                axis_angle = (
+                    args[1] if len(args) > 1 and axis_angle is None else axis_angle
                 )
-                if ord_arg:
-                    ordering = ord_arg
-
-        # Validate (kw)args
-        if rotation_like:
-            if isinstance(rotation_like, Rotation):
-                rotation = rotation_like
+                if len(args) > 2:
+                    raise TypeError("Too many arguments for axis-angle Rotation")
+            elif isinstance(args[0], (Rotation, Vector, tuple)):
+                rotation_like = args[0] if rotation_like is None else rotation_like
+                ordering = args[1] if len(args) > 1 and ordering is None else ordering
+                if len(args) > 2:
+                    raise TypeError("Too many arguments for RotationLike Rotation")
+            elif isinstance(args[0], (int, float)):
+                x_angle = args[0] if x_angle is None else x_angle
+                y_angle = args[1] if len(args) > 1 and y_angle is None else y_angle
+                z_angle = args[2] if len(args) > 2 and z_angle is None else z_angle
+                ordering = args[3] if len(args) > 3 and ordering is None else ordering
+                if len(args) > 4:
+                    raise TypeError("Too many arguments for Euler-angle Rotation")
             else:
-                x_angle = rotation_like[0] if len(rotation_like) > 0 else x_angle
-                y_angle = rotation_like[1] if len(rotation_like) > 1 else y_angle
-                z_angle = rotation_like[2] if len(rotation_like) > 2 else z_angle
-                # ordering has to be kwarg
+                raise TypeError(f"Invalid positional arguments: {args}")
 
-        if axis and axis_angle == 0.0:
-            # No valid rotation: Fallback mode
-            axis, axis_angle = None, None
+        has_axis_angle = axis is not None or axis_angle is not None
+        has_euler_angles = any(
+            angle is not None for angle in (x_angle, y_angle, z_angle)
+        )
 
-        # Construct Rotation
-        if rotation:
-            super().__init__(rotation)
+        # Construct Rotation from one unambiguous overload
+        if has_axis_angle:
+            if axis is None or axis_angle is None:
+                raise TypeError("Both an Axis and angle must be provided")
+            if rotation_like is not None or has_euler_angles or ordering is not None:
+                raise TypeError("Unsupported or ambiguous Rotation arguments")
+            if not isinstance(axis, Axis):
+                raise TypeError(f"Axis must be an Axis, not {type(axis).__name__}")
+            if not isinstance(axis_angle, (int, float)):
+                raise TypeError(
+                    f"Angle must be an int or float, not {type(axis_angle).__name__}"
+                )
 
-        elif axis:
             trsf = gp_Trsf()
-            trsf.SetRotation(axis.wrapped, radians(axis_angle))
+            if axis_angle != 0.0:
+                trsf.SetRotation(axis.wrapped, radians(axis_angle))
             super().__init__(trsf)
 
+        elif rotation_like is not None:
+            if has_euler_angles:
+                raise TypeError("Unsupported or ambiguous Rotation arguments")
+            if ordering is not None and not isinstance(ordering, (Extrinsic, Intrinsic)):
+                raise TypeError("ordering must be an Extrinsic or Intrinsic value")
+            if isinstance(rotation_like, Rotation):
+                super().__init__(rotation_like)
+            elif isinstance(rotation_like, (Vector, tuple)):
+                rotation_angles = list(rotation_like)[:3]
+                rotation_angles.extend([0.0] * (3 - len(rotation_angles)))
+                if not all(
+                    isinstance(angle, (int, float)) for angle in rotation_angles
+                ):
+                    raise TypeError("Euler angles must be int or float values")
+                super().__init__(
+                    (0, 0, 0),
+                    tuple(rotation_angles),
+                    ordering or Intrinsic.XYZ,
+                )
+            else:
+                raise TypeError(
+                    "rotation must be a Rotation, Vector, or tuple of Euler angles"
+                )
+
         else:
-            super().__init__((0, 0, 0), (x_angle, y_angle, z_angle), ordering)
+            euler_angles = (
+                x_angle if x_angle is not None else 0.0,
+                y_angle if y_angle is not None else 0.0,
+                z_angle if z_angle is not None else 0.0,
+            )
+            if not all(isinstance(angle, (int, float)) for angle in euler_angles):
+                raise TypeError("Euler angles must be int or float values")
+            if ordering is not None and not isinstance(ordering, (Extrinsic, Intrinsic)):
+                raise TypeError("ordering must be an Extrinsic or Intrinsic value")
+            super().__init__(
+                (0, 0, 0), euler_angles, ordering or Intrinsic.XYZ
+            )
 
 
 Rot = Rotation  # Short form for Algebra users who like compact notation

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -2364,7 +2364,7 @@ class Rotation(Location):
         """Rotation about an Axis by an angle in degrees."""
 
     def __init__(self, *args, **kwargs):
-        rotation = kwargs.pop("rotation", None)
+        rotation_like = kwargs.pop("rotation", None)
         x_angle = kwargs.pop("X", 0.0)
         y_angle = kwargs.pop("Y", 0.0)
         z_angle = kwargs.pop("Z", 0.0)
@@ -2377,9 +2377,11 @@ class Rotation(Location):
             raise TypeError(f"Unexpected keyword arguments: {', '.join(kwargs)}")
 
         # Fill from positional args if not given via kwargs
+        rotation = None
         if args:
-            if rotation is None and isinstance(args[0], Rotation):
+            if isinstance(args[0], Rotation):
                 rotation = args[0]
+                # Ordering is ignored
 
             elif axis is None and isinstance(args[0], Axis):
                 # Check for correct args
@@ -2422,13 +2424,14 @@ class Rotation(Location):
                     ordering = ord_arg
 
         # Validate (kw)args
-        if rotation and not isinstance(rotation, Rotation):
-            x_angle = rotation[0] if len(rotation) > 0 else x_angle
-            y_angle = rotation[1] if len(rotation) > 1 else y_angle
-            z_angle = rotation[2] if len(rotation) > 2 else z_angle
-            # rotation is kwarg, else it would have been handled by else-case
-            # ordering has to be kwarg
-            rotation = None
+        if rotation_like:
+            if isinstance(rotation_like, Rotation):
+                rotation = rotation_like
+            else:
+                x_angle = rotation_like[0] if len(rotation_like) > 0 else x_angle
+                y_angle = rotation_like[1] if len(rotation_like) > 1 else y_angle
+                z_angle = rotation_like[2] if len(rotation_like) > 2 else z_angle
+                # ordering has to be kwarg
 
         if axis and axis_angle == 0.0:
             # No valid rotation: Fallback mode

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -2341,6 +2341,7 @@ class Rotation(Location):
     def __init__(
         self,
         rotation: RotationLike,
+        ordering: Extrinsic | Intrinsic == Intrinsic.XYZ,  # type: ignore[valid-type]
     ):
         """Rotation from other RotationLike object."""
 

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -2360,7 +2360,7 @@ class Rotation(Location):
         axis: Axis,
         angle: float,
     ):
-        """Rotation from axis of rotation and angle."""
+        """Rotation about an Axis by an angle in degrees."""
 
     def __init__(self, *args, **kwargs):
         rotation = kwargs.pop("rotation", None)

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -2396,18 +2396,36 @@ class Rotation(Location):
         """Subclass of Location used only for object rotation
         ordering is for order of rotations in Intrinsic or Extrinsic enums"""
 
+    @overload
+    def __init__(
+        self,
+        axis: Axis,
+        angle: float,
+    ):
+        """Subclass of Location used only for object rotation
+        ordering is for order of rotations in Intrinsic or Extrinsic enums"""
+
     def __init__(self, *args, **kwargs):
-        if not all(key in ("X", "Y", "Z", "rotation", "ordering") for key in kwargs):
+        if not all(
+            key in ("X", "Y", "Z", "rotation", "ordering", "axis", "angle")
+            for key in kwargs
+        ):
             raise TypeError("Invalid key for Rotation")
         angles, rotations, orderings = [0, 0, 0], [], []
+        trsf = None
         if args:
             angles = list(filter(lambda item: isinstance(item, (int, float)), args))
             vectors = list(filter(lambda item: isinstance(item, Vector), args))
             tuples = list(filter(lambda item: isinstance(item, tuple), args))
-            if tuples:
+            axis = list(filter(lambda item: isinstance(item, Axis), args))
+            if tuples and not axis:
                 angles = list(*tuples)
             if vectors:
                 angles = tuple(vectors[0])
+            if axis and angles:
+                angle = angles[0]
+                trsf = gp_Trsf()
+                trsf.SetRotation(axis[0].wrapped, angle)
             if len(angles) < 3:
                 angles.extend([0.0] * (3 - len(angles)))
             rotations = list(filter(lambda item: isinstance(item, Rotation), args))
@@ -2420,6 +2438,8 @@ class Rotation(Location):
         kwargs.setdefault("ordering", orderings[0] if orderings else Intrinsic.XYZ)
         if rotations:
             super().__init__(rotations[0])
+        elif trsf:
+            super().__init__(trsf)
         else:
             super().__init__(
                 (0, 0, 0), (kwargs["X"], kwargs["Y"], kwargs["Z"]), kwargs["ordering"]

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -2369,7 +2369,7 @@ class Rotation(Location):
         z_angle = kwargs.pop("Z", 0.0)
         ordering = kwargs.pop("ordering", Intrinsic.XYZ)
         axis = kwargs.pop("axis", None)
-        axis_angle = kwargs.pop("angle", None)
+        axis_angle = kwargs.pop("angle", 0.0)
 
         # If any unexpected kwargs remain
         if kwargs:
@@ -2388,10 +2388,6 @@ class Rotation(Location):
                     raise TypeError(f"Angle must be an int or float not {args[1]}")
 
                 axis, axis_angle = args[0], args[1]
-
-                if axis_angle == 0.0:
-                    # No valid rotation: Fallback mode
-                    axis, axis_angle = None, None
 
             else:  # Euler angles
                 euler = list(filter(lambda item: isinstance(item, (int, float)), args))
@@ -2423,6 +2419,11 @@ class Rotation(Location):
                 )
                 if ord_arg:
                     ordering = ord_arg
+
+        # Validate args
+        if axis and axis_angle == 0.0:
+            # No valid rotation: Fallback mode
+            axis, axis_angle = None, None
 
         # Construct Rotation
         if rotation:

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -2380,7 +2380,6 @@ class Rotation(Location):
     def __init__(
         self,
         rotation: RotationLike,
-        ordering: Extrinsic | Intrinsic == Intrinsic.XYZ,  # type: ignore[valid-type]
     ):
         """Rotation from other RotationLike object."""
 

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -2417,15 +2417,15 @@ class Rotation(Location):
             angles = list(filter(lambda item: isinstance(item, (int, float)), args))
             vectors = list(filter(lambda item: isinstance(item, Vector), args))
             tuples = list(filter(lambda item: isinstance(item, tuple), args))
-            axis = list(filter(lambda item: isinstance(item, Axis), args))
-            if tuples and not axis:
+            axis_items = list(filter(lambda item: isinstance(item, Axis), args))
+            if tuples and not axis_items:
                 angles = list(*tuples)
             if vectors:
                 angles = tuple(vectors[0])
-            if axis and angles:
+            if axis_items and angles:
                 angle = angles[0]
                 trsf = gp_Trsf()
-                trsf.SetRotation(axis[0].wrapped, angle)
+                trsf.SetRotation(axis_items[0].wrapped, angle)
             if len(angles) < 3:
                 angles.extend([0.0] * (3 - len(angles)))
             rotations = list(filter(lambda item: isinstance(item, Rotation), args))

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -2421,7 +2421,15 @@ class Rotation(Location):
                 if ord_arg:
                     ordering = ord_arg
 
-        # Validate args
+        # Validate (kw)args
+        if rotation and not isinstance(rotation, Rotation):
+            x_angle = rotation[0] if len(rotation) > 0 else x_angle
+            y_angle = rotation[1] if len(rotation) > 1 else y_angle
+            z_angle = rotation[2] if len(rotation) > 2 else z_angle
+            # rotation is kwarg, else it would have been handled by else-case
+            # ordering has to be kwarg
+            rotation = None
+
         if axis and axis_angle == 0.0:
             # No valid rotation: Fallback mode
             axis, axis_angle = None, None

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -2429,7 +2429,7 @@ class Rotation(Location):
 
         elif axis:
             trsf = gp_Trsf()
-            trsf.SetRotation(axis.wrapped, axis_angle)
+            trsf.SetRotation(axis.wrapped, radians(axis_angle))
             super().__init__(trsf)
 
         else:

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -2382,8 +2382,7 @@ class Rotation(Location):
         rotation: RotationLike,
         ordering: Extrinsic | Intrinsic == Intrinsic.XYZ,  # type: ignore[valid-type]
     ):
-        """Subclass of Location used only for object rotation
-        ordering is for order of rotations in Intrinsic or Extrinsic enums"""
+        """Rotation from other RotationLike object."""
 
     @overload
     def __init__(
@@ -2393,8 +2392,7 @@ class Rotation(Location):
         Z: float = 0,
         ordering: Extrinsic | Intrinsic = Intrinsic.XYZ,
     ):
-        """Subclass of Location used only for object rotation
-        ordering is for order of rotations in Intrinsic or Extrinsic enums"""
+        """Rotation from Euler angles and ordering (default: Intrinsic.XYZ)."""
 
     @overload
     def __init__(
@@ -2402,8 +2400,7 @@ class Rotation(Location):
         axis: Axis,
         angle: float,
     ):
-        """Subclass of Location used only for object rotation
-        ordering is for order of rotations in Intrinsic or Extrinsic enums"""
+        """Rotation from axis of rotation and angle."""
 
     def __init__(self, *args, **kwargs):
         if not all(

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -2383,8 +2383,8 @@ class Rotation(Location):
             elif axis is None and isinstance(args[0], Axis):
                 # Check for correct args
                 if len(args) < 2:
-                    raise TypeError(f"Too few arguments: Requires Axis and Angle")
-                elif not isinstance(args[1], (int, float)):
+                    raise TypeError("Too few arguments: Requires Axis and Angle")
+                if not isinstance(args[1], (int, float)):
                     raise TypeError(f"Angle must be an int or float not {args[1]}")
 
                 axis, axis_angle = args[0], args[1]
@@ -2393,22 +2393,23 @@ class Rotation(Location):
                     # No valid rotation: Fallback mode
                     axis, axis_angle = None, None
 
-            else: # Euler angles
+            else:  # Euler angles
                 euler = list(filter(lambda item: isinstance(item, (int, float)), args))
                 vectors = list(filter(lambda item: isinstance(item, Vector), args))
                 tuples = list(filter(lambda item: isinstance(item, tuple), args))
 
                 if [bool(euler), bool(vectors), bool(tuples)].count(True) > 1:
                     raise TypeError(
-                        f"Provide angles in one way only: individually, tuple, or Vector"
+                        "Provide angles in one way only: individually, tuple, or Vector"
                     )
-                elif tuples:
+
+                if tuples:
                     if len(tuples) > 1:
-                        raise TypeError(f"Too many tuples provided")
+                        raise TypeError("Too many tuples provided")
                     euler = tuples[0]
                 elif vectors:
                     if len(vectors) > 1:
-                        raise TypeError(f"Too many Vectors provided")
+                        raise TypeError("Too many Vectors provided")
                     euler = tuple(vectors[0])
 
                 # Extract individual angles

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -2424,7 +2424,7 @@ class Rotation(Location):
                 if len(args) < 2:
                     raise TypeError(f"Too few arguments: Requires Axis and Angle")
                 elif not isinstance(args[1], (int, float)):
-                    raise TypeError(f"Angle must be a float not {args[1]}")
+                    raise TypeError(f"Angle must be an int or float not {args[1]}")
 
                 axis, axis_angle = args[0], args[1]
 
@@ -2437,9 +2437,17 @@ class Rotation(Location):
                 vectors = list(filter(lambda item: isinstance(item, Vector), args))
                 tuples = list(filter(lambda item: isinstance(item, tuple), args))
 
-                if tuples:
-                    euler = list(*tuples)
-                if vectors:
+                if [bool(euler), bool(vectors), bool(tuples)].count(True) > 1:
+                    raise TypeError(
+                        f"Provide angles in one way only: individually, tuple, or Vector"
+                    )
+                elif tuples:
+                    if len(tuples) > 1:
+                        raise TypeError(f"Too many tuples provided")
+                    euler = tuples[0]
+                elif vectors:
+                    if len(vectors) > 1:
+                        raise TypeError(f"Too many Vectors provided")
                     euler = tuple(vectors[0])
 
                 # Extract individual angles

--- a/tests/test_build_common.py
+++ b/tests/test_build_common.py
@@ -28,6 +28,8 @@ license:
 
 import unittest
 from math import pi
+from scipy.linalg import norm as scipy_norm
+from scipy.spatial.transform import Rotation as scipy_Rotation
 from build123d import *
 from build123d import WorkplaneList, flatten_sequence
 
@@ -435,6 +437,38 @@ class TestRotation(unittest.TestCase):
     def test_init(self):
         thirty_by_three = Rotation(30, 30, 30)
         box_vertices = Solid.make_box(1, 1, 1).moved(thirty_by_three).vertices()
+        self.assertTupleAlmostEquals(tuple(box_vertices[0]), (0.5, -0.4330127, 0.75), 5)
+        self.assertTupleAlmostEquals(tuple(box_vertices[1]), (0.0, 0.0, 0.0), 7)
+        self.assertTupleAlmostEquals(
+            tuple(box_vertices[2]), (0.0669872, 0.191987, 1.399519), 5
+        )
+        self.assertTupleAlmostEquals(
+            tuple(box_vertices[3]), (-0.4330127, 0.625, 0.6495190), 5
+        )
+        self.assertTupleAlmostEquals(
+            tuple(box_vertices[4]), (1.25, 0.2165063, 0.625), 5
+        )
+        self.assertTupleAlmostEquals(
+            tuple(box_vertices[5]), (0.75, 0.649519, -0.125), 5
+        )
+        self.assertTupleAlmostEquals(
+            tuple(box_vertices[6]), (0.816987, 0.841506, 1.274519), 5
+        )
+        self.assertTupleAlmostEquals(
+            tuple(box_vertices[7]), (0.3169872, 1.2745190, 0.52451905), 5
+        )
+
+    def test_init_by_axis_angle(self):
+        # Rotation with about Intrinsic XYZ with each angle 30 degrees
+        rot = scipy_Rotation.from_euler("XYZ", [30, 30, 30], degrees=True)
+        rot_vec = rot.as_rotvec()
+        angle = scipy_norm(rot_vec)
+        vec_normalized = tuple(rot_vec / angle)
+        axis = Axis((0, 0, 0), vec_normalized)
+
+        thirty_by_three = Rotation(axis, angle)
+        box_vertices = Solid.make_box(1, 1, 1).moved(thirty_by_three).vertices()
+
         self.assertTupleAlmostEquals(tuple(box_vertices[0]), (0.5, -0.4330127, 0.75), 5)
         self.assertTupleAlmostEquals(tuple(box_vertices[1]), (0.0, 0.0, 0.0), 7)
         self.assertTupleAlmostEquals(

--- a/tests/test_build_common.py
+++ b/tests/test_build_common.py
@@ -461,7 +461,7 @@ class TestRotation(unittest.TestCase):
     def test_init_by_axis_angle(self):
         # Rotation with about Intrinsic XYZ with each angle 30 degrees
         rot = scipy_Rotation.from_euler("XYZ", [30, 30, 30], degrees=True)
-        rot_vec = rot.as_rotvec(degrees = True)
+        rot_vec = rot.as_rotvec(degrees=True)
         angle = scipy_norm(rot_vec)
         vec_normalized = tuple(rot_vec / angle)
         axis = Axis((0, 0, 0), vec_normalized)
@@ -489,6 +489,35 @@ class TestRotation(unittest.TestCase):
         self.assertTupleAlmostEquals(
             tuple(box_vertices[7]), (0.3169872, 1.2745190, 0.52451905), 5
         )
+
+    def test_init_by_axis_angle_arguments(self):
+        for rotation in (
+            Rotation(Axis.Z, 30),
+            Rotation(Axis.Z, angle=30),
+            Rotation(axis=Axis.Z, angle=30),
+        ):
+            self.assertTupleAlmostEquals(rotation.orientation, (0, 0, 30), 5)
+
+        # As with other overloaded constructors, a keyword overrides the
+        # corresponding positional value.
+        self.assertTupleAlmostEquals(
+            Rotation(Axis.Z, 30, angle=40).orientation, (0, 0, 40), 5
+        )
+        self.assertTupleAlmostEquals(Rotation(Axis.Z, 0).orientation, (0, 0, 0), 7)
+
+        invalid_rotations = (
+            lambda: Rotation(Axis.Z),
+            lambda: Rotation(axis=Axis.Z),
+            lambda: Rotation(angle=30),
+            lambda: Rotation(30, axis=Axis.Z),
+            lambda: Rotation(axis="Z", angle=30),
+            lambda: Rotation(axis=Axis.Z, angle="30"),
+            lambda: Rotation(Axis.Z, 30, 40),
+            lambda: Rotation(axis=Axis.Z, angle=30, X=10),
+        )
+        for invalid_rotation in invalid_rotations:
+            with self.assertRaises(TypeError):
+                invalid_rotation()
 
 
 class TestShapeList(unittest.TestCase):

--- a/tests/test_build_common.py
+++ b/tests/test_build_common.py
@@ -461,7 +461,7 @@ class TestRotation(unittest.TestCase):
     def test_init_by_axis_angle(self):
         # Rotation with about Intrinsic XYZ with each angle 30 degrees
         rot = scipy_Rotation.from_euler("XYZ", [30, 30, 30], degrees=True)
-        rot_vec = rot.as_rotvec()
+        rot_vec = rot.as_rotvec(degrees = True)
         angle = scipy_norm(rot_vec)
         vec_normalized = tuple(rot_vec / angle)
         axis = Axis((0, 0, 0), vec_normalized)


### PR DESCRIPTION
My extension to the parsing of the arguments in `Rotation.__init__()` does not feel very robust / elegant... If you have any suggestions on how to improve it, e.g. align it with `Location.__init__()`, I can rework it. If it is fine as is, I am happy as well :smile: 

From CONTRIBUTING.md
- [x] Run tests with: python -m pytest -n auto
- [x] Check added files' style with: pylint <path/to/file.py>
- [x] Check added files' type annotations with: mypy <path/to/file.py>
- [x] Run black formatter against files' changed: black <path/to/file.py>

Fixes #1253