### PR TITLE
Add NGSolve/Netgen interoperability API

### DIFF
--- a/docs/import_export.rst
+++ b/docs/import_export.rst
@@ -255,6 +255,104 @@ For example:
     If you need to align multiple components for 3D printing, you can use the  :ref:`pack() <pack>` function to arrange the objects side by side and align them on the same plane. This ensures that your components are well-organized and ready for the printing process.
 
 
+NGSolve/Netgen Interoperability
+================================
+
+.. py:module:: ngsolve_interop
+
+build123d shapes can be converted to `NGSolve <https://ngsolve.org/>`_ meshes for
+finite element analysis using the :func:`~ngsolve_interop.to_ngsolve_mesh` function.
+This enables CFD, structural, electromagnetic, and other PDE-based simulations directly
+from build123d geometry.
+
+The conversion works by:
+
+1. Exporting the build123d shape to a temporary BREP file
+2. Importing the BREP file into a Netgen ``OCCGeometry``
+3. Generating a tetrahedral mesh
+4. Propagating face labels as mesh boundary condition names using geometric center matching
+
+.. note::
+
+    ``netgen`` and ``ngsolve`` are **not** hard dependencies of build123d. Install them
+    separately with ``pip install ngsolve netgen-occt netgen-occt-devel``. Python 3.12+
+    is required so that ``cadquery-ocp`` and ``netgen-occt`` both use matching OCCT
+    versions (7.8.1+).
+
+Face Labels as Boundary Conditions
+-----------------------------------
+
+The key challenge in bridging CAD and FEA is preserving face identity across the
+transfer. Neither BREP nor STEP preserves face-level names, so ``to_ngsolve_mesh``
+matches faces by their geometric centers. You can label faces in two ways:
+
+* **Using a dictionary** — pass a ``face_labels`` dict mapping Face objects to label strings:
+
+.. code-block:: python
+
+    labels = {}
+    for f in part.faces():
+        if abs(f.center().Z) > 1:
+            labels[f] = "ends"
+        else:
+            labels[f] = "walls"
+
+    mesh = to_ngsolve_mesh(part, face_labels=labels, maxh=2)
+
+* **Using the** ``.label`` **attribute** — if no ``face_labels`` dict is provided, each
+  face's existing ``.label`` attribute is used (faces without a label get ``"default"``):
+
+.. code-block:: python
+
+    for f in part.faces():
+        f.label = "ends" if abs(f.center().Z) > 1 else "walls"
+
+    mesh = to_ngsolve_mesh(part, maxh=2)
+
+Full Example: Poisson Equation on a Hollow Cylinder
+-----------------------------------------------------
+
+This example builds a hollow cylinder in build123d, transfers it to NGSolve, labels
+the top and bottom faces as Dirichlet boundaries, and solves a Poisson equation.
+
+.. code-block:: python
+
+    import build123d as bd
+    from build123d import to_ngsolve_mesh
+    import ngsolve as ngs
+
+    # 1. Build geometry in build123d
+    part = bd.Cylinder(10, 20) - bd.Cylinder(5, 20)
+
+    # 2. Label faces for boundary conditions
+    labels = {}
+    for f in part.faces():
+        if abs(f.center().Z) > 1:
+            labels[f] = "ends"
+        else:
+            labels[f] = "walls"
+
+    # 3. Convert to NGSolve mesh (single call handles BREP transfer + face matching)
+    mesh = to_ngsolve_mesh(part, face_labels=labels, maxh=2)
+    print(f"Boundaries: {mesh.GetBoundaries()}")
+
+    # 4. Solve Poisson: -Laplacian(u) = 1, u=0 on ends
+    fes = ngs.H1(mesh, order=2, dirichlet="ends")
+    u, v = fes.TnT()
+    a = ngs.BilinearForm(ngs.grad(u) * ngs.grad(v) * ngs.dx).Assemble()
+    f = ngs.LinearForm(1 * v * ngs.dx).Assemble()
+    gfu = ngs.GridFunction(fes)
+    gfu.vec.data = a.mat.Inverse(fes.FreeDofs()) * f.vec
+    print(f"DOFs: {fes.ndof} ({sum(fes.FreeDofs())} free)")
+    print(f"Solution range: {min(gfu.vec):.4f} .. {max(gfu.vec):.4f}")
+
+API Reference
+-------------
+
+.. autofunction:: to_ngsolve_mesh
+   :noindex:
+
+
 2D Importers
 ============
 .. py:module:: importers

--- a/docs/import_export.rst
+++ b/docs/import_export.rst
@@ -277,10 +277,10 @@ The conversion works by:
     ``netgen`` and ``ngsolve`` are **not** hard dependencies of build123d. Install them
     separately with ``pip install ngsolve netgen-occt netgen-occt-devel``.
 
-    build123d (via ``cadquery-ocp-novtk >= 7.9``) and netgen use separate pybind11 type
-    namespaces for their OpenCASCADE wrappers, so they coexist in a single Python process
-    without conflicts. Direct shape passing between the two is not possible (different
-    wrapper types), so BREP file interchange is used.
+    On Python 3.10+, the pybind11 builds of ``cadquery-ocp`` / ``cadquery-ocp-novtk``
+    and ``netgen-occt`` coexist in a single process without type conflicts. Direct shape
+    passing between the two is not possible (different pybind11 wrapper types), so BREP
+    file interchange is used.
 
 Face Labels as Boundary Conditions
 -----------------------------------

--- a/docs/import_export.rst
+++ b/docs/import_export.rst
@@ -269,22 +269,26 @@ The conversion works by:
 
 1. Exporting the build123d shape to a temporary BREP file
 2. Importing the BREP file into a Netgen ``OCCGeometry``
-3. Generating a tetrahedral mesh
-4. Propagating face labels as mesh boundary condition names using geometric center matching
+3. Matching face labels from build123d to netgen faces using ``faces.Nearest(gp_Pnt)``
+4. Generating a tetrahedral mesh with labels propagated as boundary condition names
 
 .. note::
 
     ``netgen`` and ``ngsolve`` are **not** hard dependencies of build123d. Install them
-    separately with ``pip install ngsolve netgen-occt netgen-occt-devel``. Python 3.12+
-    is required so that ``cadquery-ocp`` and ``netgen-occt`` both use matching OCCT
-    versions (7.8.1+).
+    separately with ``pip install ngsolve netgen-occt netgen-occt-devel``.
+
+    build123d (via ``cadquery-ocp-novtk >= 7.9``) and netgen use separate pybind11 type
+    namespaces for their OpenCASCADE wrappers, so they coexist in a single Python process
+    without conflicts. Direct shape passing between the two is not possible (different
+    wrapper types), so BREP file interchange is used.
 
 Face Labels as Boundary Conditions
 -----------------------------------
 
-The key challenge in bridging CAD and FEA is preserving face identity across the
-transfer. Neither BREP nor STEP preserves face-level names, so ``to_ngsolve_mesh``
-matches faces by their geometric centers. You can label faces in two ways:
+Neither BREP nor STEP preserves face-level names, so ``to_ngsolve_mesh`` uses Netgen's
+``faces.Nearest(gp_Pnt)`` API to find the corresponding netgen face for each build123d
+face by geometric center, then sets its ``.name`` before meshing. You can label faces in
+two ways:
 
 * **Using a dictionary** — pass a ``face_labels`` dict mapping Face objects to label strings:
 
@@ -300,7 +304,7 @@ matches faces by their geometric centers. You can label faces in two ways:
     mesh = to_ngsolve_mesh(part, face_labels=labels, maxh=2)
 
 * **Using the** ``.label`` **attribute** — if no ``face_labels`` dict is provided, each
-  face's existing ``.label`` attribute is used (faces without a label get ``"default"``):
+  face's existing ``.label`` attribute is used (unlabeled faces get Netgen's default name):
 
 .. code-block:: python
 

--- a/examples/ngsolve_poisson.py
+++ b/examples/ngsolve_poisson.py
@@ -6,7 +6,6 @@ to NGSolve for finite element analysis, automatically propagating face labels
 as mesh boundary condition names.
 
 Requires: pip install ngsolve netgen-occt netgen-occt-devel
-Requires: Python 3.12+ (for matching OCCT versions between cadquery-ocp and netgen-occt)
 
 See: https://github.com/gumyr/build123d/issues/297
 """

--- a/examples/ngsolve_poisson.py
+++ b/examples/ngsolve_poisson.py
@@ -1,0 +1,41 @@
+"""
+build123d -> NGSolve: Poisson solve with named boundary conditions.
+
+Demonstrates the to_ngsolve_mesh() function which transfers build123d geometry
+to NGSolve for finite element analysis, automatically propagating face labels
+as mesh boundary condition names.
+
+Requires: pip install ngsolve netgen-occt netgen-occt-devel
+Requires: Python 3.12+ (for matching OCCT versions between cadquery-ocp and netgen-occt)
+
+See: https://github.com/gumyr/build123d/issues/297
+"""
+
+import build123d as bd
+from build123d import to_ngsolve_mesh
+import ngsolve as ngs
+
+# 1. Build geometry in build123d — a hollow cylinder
+part = bd.Cylinder(10, 20) - bd.Cylinder(5, 20)
+
+# 2. Label faces for boundary conditions by geometric position
+labels = {}
+for f in part.faces():
+    if abs(f.center().Z) > 1:
+        labels[f] = "ends"
+    else:
+        labels[f] = "walls"
+
+# 3. Convert to NGSolve mesh (handles BREP transfer + face matching in one call)
+mesh = to_ngsolve_mesh(part, face_labels=labels, maxh=2)
+print(f"Boundaries:  {mesh.GetBoundaries()}")
+
+# 4. Solve Poisson equation: -Laplacian(u) = 1 with u=0 on "ends"
+fes = ngs.H1(mesh, order=2, dirichlet="ends")
+u, v = fes.TnT()
+a = ngs.BilinearForm(ngs.grad(u) * ngs.grad(v) * ngs.dx).Assemble()
+f = ngs.LinearForm(1 * v * ngs.dx).Assemble()
+gfu = ngs.GridFunction(fes)
+gfu.vec.data = a.mat.Inverse(fes.FreeDofs()) * f.vec
+print(f"DOFs:        {fes.ndof} ({sum(fes.FreeDofs())} free)")
+print(f"Solution:    {min(gfu.vec):.4f} .. {max(gfu.vec):.4f}")

--- a/examples/ngsolve_poisson.py
+++ b/examples/ngsolve_poisson.py
@@ -11,9 +11,17 @@ Requires: Python 3.12+ (for matching OCCT versions between cadquery-ocp and netg
 See: https://github.com/gumyr/build123d/issues/297
 """
 
+import sys
+
 import build123d as bd
 from build123d import to_ngsolve_mesh
-import ngsolve as ngs
+
+try:
+    import ngsolve as ngs
+except ImportError:
+    print("ngsolve is not installed — skipping example.")
+    print("Install with: pip install ngsolve netgen-occt netgen-occt-devel")
+    sys.exit(0)
 
 # 1. Build geometry in build123d — a hollow cylinder
 part = bd.Cylinder(10, 20) - bd.Cylinder(5, 20)

--- a/src/build123d/__init__.py
+++ b/src/build123d/__init__.py
@@ -21,6 +21,7 @@ from build123d.topology import *
 from build123d.drafting import *
 from build123d.persistence import modify_copyreg
 from build123d.exporters3d import *
+from build123d.ngsolve_interop import *
 from build123d.text import available_fonts, FontManager
 
 from .version import version as __version__
@@ -240,4 +241,6 @@ __all__ = [
     "export_gltf",
     "export_stl",
     "export_brep",
+    # NGSolve interoperability
+    "to_ngsolve_mesh",
 ]

--- a/src/build123d/ngsolve_interop.py
+++ b/src/build123d/ngsolve_interop.py
@@ -1,0 +1,212 @@
+"""
+build123d NGSolve/Netgen Interoperability
+
+name: ngsolve_interop.py
+by:   build123d contributors
+date: March 30th, 2026
+
+desc:
+    Provides interoperability between build123d and NGSolve/Netgen for
+    finite element analysis. Transfers geometry via BREP interchange and
+    propagates face labels as mesh boundary condition names using geometric
+    center matching.
+
+    Requires Python 3.12+ where cadquery-ocp and netgen-occt both use
+    OCCT 7.8.1, allowing coexistence in the same process.
+
+    See: https://github.com/gumyr/build123d/issues/297
+
+license:
+
+    Copyright 2026 build123d contributors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+"""
+
+from __future__ import annotations
+
+import math
+import tempfile
+import warnings
+from typing import TYPE_CHECKING
+
+from build123d.exporters3d import export_brep
+from build123d.topology import Face, Shape
+
+if TYPE_CHECKING:
+    from netgen.occ import OCCGeometry
+    from ngsolve import Mesh as NGMesh
+
+__all__ = ["to_ngsolve_mesh"]
+
+
+def _lazy_import_netgen():
+    """Import netgen.occ, raising a helpful error if not installed."""
+    try:
+        from netgen.occ import OCCGeometry
+
+        return OCCGeometry
+    except ImportError:
+        raise ImportError(
+            "netgen is required for NGSolve interoperability but is not installed.\n"
+            "Install it with:  pip install netgen-occt netgen-occt-devel\n"
+            "Note: Python 3.12+ is required so that cadquery-ocp and netgen-occt\n"
+            "both use matching OCCT versions (7.8.1+).\n"
+            "See: https://ngsolve.org/  and  https://github.com/gumyr/build123d/issues/297"
+        ) from None
+
+
+def _lazy_import_ngsolve():
+    """Import ngsolve, raising a helpful error if not installed."""
+    try:
+        import ngsolve
+
+        return ngsolve
+    except ImportError:
+        raise ImportError(
+            "ngsolve is required for NGSolve interoperability but is not installed.\n"
+            "Install it with:  pip install ngsolve\n"
+            "Note: Python 3.12+ is required so that cadquery-ocp and netgen-occt\n"
+            "both use matching OCCT versions (7.8.1+).\n"
+            "See: https://ngsolve.org/  and  https://github.com/gumyr/build123d/issues/297"
+        ) from None
+
+
+def _match_face_labels(
+    b123d_faces: list[tuple[float, float, float, str]],
+    ng_geo: "OCCGeometry",
+) -> dict[int, str]:
+    """Match NGSolve geometry face indices to build123d face labels.
+
+    Uses nearest geometric center matching between build123d faces and
+    netgen geometry faces.
+
+    Args:
+        b123d_faces: list of (cx, cy, cz, label) tuples from build123d
+        ng_geo: netgen OCCGeometry object
+
+    Returns:
+        dict mapping netgen face index to label string
+    """
+    mapping = {}
+    for ng_idx, ng_face in enumerate(ng_geo.shape.faces):
+        nc = ng_face.center
+        best_label = min(
+            b123d_faces,
+            key=lambda fm: math.sqrt(
+                (nc.x - fm[0]) ** 2 + (nc.y - fm[1]) ** 2 + (nc.z - fm[2]) ** 2
+            ),
+        )[3]
+        mapping[ng_idx] = best_label
+    return mapping
+
+
+def to_ngsolve_mesh(
+    shape: Shape,
+    face_labels: dict[Face, str] | None = None,
+    maxh: float = 1.0,
+    **mesh_kwargs,
+) -> "NGMesh":
+    """Convert a build123d Shape to an NGSolve Mesh with named boundaries.
+
+    Transfers the geometry via BREP file interchange (direct shape passing is
+    not possible because build123d and netgen use different pybind11 wrappers
+    for OpenCASCADE types). Face labels are propagated by matching geometric
+    centers between the build123d and netgen representations.
+
+    Requires ``netgen`` and ``ngsolve`` packages to be installed. These are
+    **not** hard dependencies of build123d — an ``ImportError`` with
+    installation instructions is raised if they are missing.
+
+    Args:
+        shape: The build123d Shape to convert (Part, Solid, Compound, etc.).
+        face_labels: Optional dictionary mapping build123d Face objects to
+            label strings. These labels become NGSolve boundary condition
+            names accessible via ``mesh.Boundaries()``. If not provided,
+            each face's existing ``.label`` attribute is used; faces without
+            a label are assigned ``"default"``.
+        maxh: Maximum mesh element size passed to ``geo.GenerateMesh()``.
+            Defaults to 1.0.
+        **mesh_kwargs: Additional keyword arguments forwarded to
+            ``OCCGeometry.GenerateMesh()`` (e.g. ``grading``, ``segmentsperedge``).
+
+    Returns:
+        ngsolve.Mesh: A ready-to-use NGSolve mesh with boundary condition
+        names set from the face labels.
+
+    Raises:
+        ImportError: If ``netgen`` or ``ngsolve`` is not installed.
+
+    Example:
+
+    .. code-block:: python
+
+        import build123d as bd
+        from build123d import to_ngsolve_mesh
+        import ngsolve as ngs
+
+        # Build geometry
+        part = bd.Cylinder(10, 20) - bd.Cylinder(5, 20)
+
+        # Label faces for boundary conditions
+        labels = {}
+        for f in part.faces():
+            if abs(f.center().Z) > 1:
+                labels[f] = "ends"
+            else:
+                labels[f] = "walls"
+
+        # Convert to NGSolve mesh
+        mesh = to_ngsolve_mesh(part, face_labels=labels, maxh=2)
+        print(mesh.GetBoundaries())
+
+        # Use in a solve
+        fes = ngs.H1(mesh, order=2, dirichlet="ends")
+        u, v = fes.TnT()
+        a = ngs.BilinearForm(ngs.grad(u) * ngs.grad(v) * ngs.dx).Assemble()
+        f = ngs.LinearForm(1 * v * ngs.dx).Assemble()
+        gfu = ngs.GridFunction(fes)
+        gfu.vec.data = a.mat.Inverse(fes.FreeDofs()) * f.vec
+    """
+    OCCGeometry = _lazy_import_netgen()
+    ngsolve = _lazy_import_ngsolve()
+
+    # Build the (cx, cy, cz, label) list from build123d faces
+    b123d_faces = []
+    for f in shape.faces():
+        c = f.center()
+        if face_labels is not None:
+            label = face_labels.get(f, "default")
+        else:
+            label = f.label if f.label else "default"
+        b123d_faces.append((c.X, c.Y, c.Z, label))
+
+    if not b123d_faces:
+        warnings.warn("Shape has no faces — the resulting mesh will have no boundaries.")
+
+    # Transfer geometry via BREP file interchange
+    with tempfile.NamedTemporaryFile(suffix=".brep", delete=True) as tmp:
+        export_brep(shape, tmp.name)
+        geo = OCCGeometry(tmp.name)
+
+    # Generate the netgen mesh
+    ngmesh = geo.GenerateMesh(maxh=maxh, **mesh_kwargs)
+
+    # Propagate face labels by geometric center matching
+    if b123d_faces:
+        label_map = _match_face_labels(b123d_faces, geo)
+        for ng_idx, label in label_map.items():
+            ngmesh.SetBCName(ng_idx, label)
+
+    return ngsolve.Mesh(ngmesh)

--- a/src/build123d/ngsolve_interop.py
+++ b/src/build123d/ngsolve_interop.py
@@ -38,11 +38,19 @@ license:
 from __future__ import annotations
 
 import os
+import random
 import tempfile
 import warnings
 from typing import TYPE_CHECKING
 
+import OCP.TopAbs as ta
+from OCP.BRepClass import BRepClass_FaceClassifier
+from OCP.BRepGProp import BRepGProp_Face
+from OCP.gp import gp_Pnt as occ_gp_Pnt
+from OCP.gp import gp_Vec
+
 from build123d.exporters3d import export_brep
+from build123d.geometry import Vector
 from build123d.topology import Face, Shape
 
 if TYPE_CHECKING:
@@ -80,6 +88,45 @@ def _lazy_import_ngsolve():
         ) from None
 
 
+def _point_on_face(face: Face, max_attempts: int = 50) -> Vector:
+    """Get a point guaranteed to be on the trimmed face surface.
+
+    Uses ``face.center()`` when the center of geometry/mass lies within the
+    face boundary (the common case for convex faces). For non-convex faces
+    where the center falls outside the trimmed boundary (e.g. C-shapes,
+    annular sectors), falls back to rejection sampling in UV parameter space.
+
+    Args:
+        face: A build123d Face.
+        max_attempts: Maximum UV samples before giving up and returning center.
+
+    Returns:
+        A Vector that lies on the face surface within its trimmed boundary.
+    """
+    c = face.center()
+    pt = occ_gp_Pnt(c.X, c.Y, c.Z)
+    classifier = BRepClass_FaceClassifier(face.wrapped, pt, 1e-6)
+    if classifier.State() in (ta.TopAbs_ON, ta.TopAbs_IN):
+        return c
+
+    # Center is outside the trimmed face — sample random UV points
+    u0, u1, v0, v1 = face._uv_bounds()
+    brep_face = BRepGProp_Face(face.wrapped)
+    rng = random.Random(42)
+
+    for _ in range(max_attempts):
+        u = rng.uniform(u0, u1)
+        v = rng.uniform(v0, v1)
+        sample_pt = occ_gp_Pnt()
+        normal = gp_Vec()
+        brep_face.Normal(u, v, sample_pt, normal)
+        classifier = BRepClass_FaceClassifier(face.wrapped, sample_pt, 1e-6)
+        if classifier.State() in (ta.TopAbs_ON, ta.TopAbs_IN):
+            return Vector(sample_pt)
+
+    return c
+
+
 def _apply_face_labels(
     shape: Shape,
     ng_shape,
@@ -88,9 +135,10 @@ def _apply_face_labels(
 ) -> None:
     """Apply build123d face labels to netgen shape faces using Nearest().
 
-    Uses Netgen's ``faces.Nearest(gp_Pnt)`` API to find the corresponding
-    netgen face for each build123d face by geometric center, then sets
-    ``.name`` on it so the label propagates through meshing.
+    For each labeled build123d face, finds a point guaranteed to be on the
+    face surface (handling non-convex faces via rejection sampling), then
+    uses Netgen's ``faces.Nearest(gp_Pnt)`` to locate the corresponding
+    netgen face and set its ``.name``.
 
     Args:
         shape: The build123d Shape whose faces provide the labels.
@@ -108,8 +156,8 @@ def _apply_face_labels(
             label = f.label if f.label else None
             if label is None:
                 continue
-        c = f.center()
-        ng_shape.faces.Nearest(gp_Pnt(c.X, c.Y, c.Z)).name = label
+        pt = _point_on_face(f)
+        ng_shape.faces.Nearest(gp_Pnt(pt.X, pt.Y, pt.Z)).name = label
 
 
 def to_ngsolve_mesh(
@@ -125,6 +173,10 @@ def to_ngsolve_mesh(
     for OpenCASCADE types). Face labels are propagated to the netgen geometry
     using ``faces.Nearest(gp_Pnt).name`` before meshing, so they appear as
     boundary condition names in the resulting NGSolve mesh.
+
+    For non-convex faces where ``face.center()`` may fall outside the trimmed
+    boundary, a point on the face is found via rejection sampling in UV
+    parameter space to ensure correct ``Nearest()`` matching.
 
     Requires ``netgen`` and ``ngsolve`` packages to be installed. These are
     **not** hard dependencies of build123d — an ``ImportError`` with

--- a/src/build123d/ngsolve_interop.py
+++ b/src/build123d/ngsolve_interop.py
@@ -37,6 +37,8 @@ license:
 from __future__ import annotations
 
 import math
+import os
+import sys
 import tempfile
 import warnings
 from typing import TYPE_CHECKING
@@ -50,6 +52,8 @@ if TYPE_CHECKING:
 
 __all__ = ["to_ngsolve_mesh"]
 
+_MIN_PYTHON = (3, 12)
+
 
 def _lazy_import_netgen():
     """Import netgen.occ, raising a helpful error if not installed."""
@@ -57,7 +61,7 @@ def _lazy_import_netgen():
         from netgen.occ import OCCGeometry
 
         return OCCGeometry
-    except ImportError:
+    except ModuleNotFoundError:
         raise ImportError(
             "netgen is required for NGSolve interoperability but is not installed.\n"
             "Install it with:  pip install netgen-occt netgen-occt-devel\n"
@@ -73,7 +77,7 @@ def _lazy_import_ngsolve():
         import ngsolve
 
         return ngsolve
-    except ImportError:
+    except ModuleNotFoundError:
         raise ImportError(
             "ngsolve is required for NGSolve interoperability but is not installed.\n"
             "Install it with:  pip install ngsolve\n"
@@ -133,7 +137,7 @@ def to_ngsolve_mesh(
         shape: The build123d Shape to convert (Part, Solid, Compound, etc.).
         face_labels: Optional dictionary mapping build123d Face objects to
             label strings. These labels become NGSolve boundary condition
-            names accessible via ``mesh.Boundaries()``. If not provided,
+            names accessible via ``mesh.GetBoundaries()``. If not provided,
             each face's existing ``.label`` attribute is used; faces without
             a label are assigned ``"default"``.
         maxh: Maximum mesh element size passed to ``geo.GenerateMesh()``.
@@ -147,6 +151,7 @@ def to_ngsolve_mesh(
 
     Raises:
         ImportError: If ``netgen`` or ``ngsolve`` is not installed.
+        RuntimeError: If Python version is older than 3.12.
 
     Example:
 
@@ -179,6 +184,14 @@ def to_ngsolve_mesh(
         gfu = ngs.GridFunction(fes)
         gfu.vec.data = a.mat.Inverse(fes.FreeDofs()) * f.vec
     """
+    if sys.version_info < _MIN_PYTHON:
+        raise RuntimeError(
+            f"to_ngsolve_mesh() requires Python {_MIN_PYTHON[0]}.{_MIN_PYTHON[1]}+ "
+            f"(running {sys.version_info[0]}.{sys.version_info[1]}). "
+            "Older Python versions have mismatched OCCT versions between "
+            "cadquery-ocp and netgen-occt, which can cause crashes."
+        )
+
     OCCGeometry = _lazy_import_netgen()
     ngsolve = _lazy_import_ngsolve()
 
@@ -193,12 +206,20 @@ def to_ngsolve_mesh(
         b123d_faces.append((c.X, c.Y, c.Z, label))
 
     if not b123d_faces:
-        warnings.warn("Shape has no faces — the resulting mesh will have no boundaries.")
+        warnings.warn(
+            "Shape has no faces — the resulting mesh will have no boundaries.",
+            category=UserWarning,
+            stacklevel=2,
+        )
 
-    # Transfer geometry via BREP file interchange
-    with tempfile.NamedTemporaryFile(suffix=".brep", delete=True) as tmp:
-        export_brep(shape, tmp.name)
-        geo = OCCGeometry(tmp.name)
+    # Transfer geometry via BREP file interchange.
+    # Use a TemporaryDirectory instead of NamedTemporaryFile to avoid
+    # issues on Windows where the file can't be re-opened while the
+    # handle is still open.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        brep_path = os.path.join(tmpdir, "shape.brep")
+        export_brep(shape, brep_path)
+        geo = OCCGeometry(brep_path)
 
     # Generate the netgen mesh
     ngmesh = geo.GenerateMesh(maxh=maxh, **mesh_kwargs)

--- a/src/build123d/ngsolve_interop.py
+++ b/src/build123d/ngsolve_interop.py
@@ -8,11 +8,12 @@ date: March 30th, 2026
 desc:
     Provides interoperability between build123d and NGSolve/Netgen for
     finite element analysis. Transfers geometry via BREP interchange and
-    propagates face labels as mesh boundary condition names using geometric
-    center matching.
+    propagates face labels as mesh boundary condition names using Netgen's
+    faces.Nearest() API for geometric matching.
 
-    Requires Python 3.12+ where cadquery-ocp and netgen-occt both use
-    OCCT 7.8.1, allowing coexistence in the same process.
+    Requires build123d's cadquery-ocp-novtk >= 7.9 and netgen-occt, which
+    use separate pybind11 type namespaces and coexist in a single process
+    on Python 3.10+.
 
     See: https://github.com/gumyr/build123d/issues/297
 
@@ -36,9 +37,7 @@ license:
 
 from __future__ import annotations
 
-import math
 import os
-import sys
 import tempfile
 import warnings
 from typing import TYPE_CHECKING
@@ -52,21 +51,17 @@ if TYPE_CHECKING:
 
 __all__ = ["to_ngsolve_mesh"]
 
-_MIN_PYTHON = (3, 12)
-
 
 def _lazy_import_netgen():
     """Import netgen.occ, raising a helpful error if not installed."""
     try:
-        from netgen.occ import OCCGeometry
+        from netgen.occ import OCCGeometry, gp_Pnt
 
-        return OCCGeometry
+        return OCCGeometry, gp_Pnt
     except ModuleNotFoundError:
         raise ImportError(
             "netgen is required for NGSolve interoperability but is not installed.\n"
             "Install it with:  pip install netgen-occt netgen-occt-devel\n"
-            "Note: Python 3.12+ is required so that cadquery-ocp and netgen-occt\n"
-            "both use matching OCCT versions (7.8.1+).\n"
             "See: https://ngsolve.org/  and  https://github.com/gumyr/build123d/issues/297"
         ) from None
 
@@ -81,39 +76,40 @@ def _lazy_import_ngsolve():
         raise ImportError(
             "ngsolve is required for NGSolve interoperability but is not installed.\n"
             "Install it with:  pip install ngsolve\n"
-            "Note: Python 3.12+ is required so that cadquery-ocp and netgen-occt\n"
-            "both use matching OCCT versions (7.8.1+).\n"
             "See: https://ngsolve.org/  and  https://github.com/gumyr/build123d/issues/297"
         ) from None
 
 
-def _match_face_labels(
-    b123d_faces: list[tuple[float, float, float, str]],
-    ng_geo: "OCCGeometry",
-) -> dict[int, str]:
-    """Match NGSolve geometry face indices to build123d face labels.
+def _apply_face_labels(
+    shape: Shape,
+    ng_shape,
+    gp_Pnt,
+    face_labels: dict[Face, str] | None,
+) -> None:
+    """Apply build123d face labels to netgen shape faces using Nearest().
 
-    Uses nearest geometric center matching between build123d faces and
-    netgen geometry faces.
+    Uses Netgen's ``faces.Nearest(gp_Pnt)`` API to find the corresponding
+    netgen face for each build123d face by geometric center, then sets
+    ``.name`` on it so the label propagates through meshing.
 
     Args:
-        b123d_faces: list of (cx, cy, cz, label) tuples from build123d
-        ng_geo: netgen OCCGeometry object
-
-    Returns:
-        dict mapping netgen face index to label string
+        shape: The build123d Shape whose faces provide the labels.
+        ng_shape: The netgen shape (from ``OCCGeometry(...).shape``).
+        gp_Pnt: The netgen ``gp_Pnt`` constructor.
+        face_labels: Optional dict mapping Face -> label string. If None,
+            each face's ``.label`` attribute is used.
     """
-    mapping = {}
-    for ng_idx, ng_face in enumerate(ng_geo.shape.faces):
-        nc = ng_face.center
-        best_label = min(
-            b123d_faces,
-            key=lambda fm: math.sqrt(
-                (nc.x - fm[0]) ** 2 + (nc.y - fm[1]) ** 2 + (nc.z - fm[2]) ** 2
-            ),
-        )[3]
-        mapping[ng_idx] = best_label
-    return mapping
+    for f in shape.faces():
+        if face_labels is not None:
+            label = face_labels.get(f)
+            if label is None:
+                continue
+        else:
+            label = f.label if f.label else None
+            if label is None:
+                continue
+        c = f.center()
+        ng_shape.faces.Nearest(gp_Pnt(c.X, c.Y, c.Z)).name = label
 
 
 def to_ngsolve_mesh(
@@ -126,8 +122,9 @@ def to_ngsolve_mesh(
 
     Transfers the geometry via BREP file interchange (direct shape passing is
     not possible because build123d and netgen use different pybind11 wrappers
-    for OpenCASCADE types). Face labels are propagated by matching geometric
-    centers between the build123d and netgen representations.
+    for OpenCASCADE types). Face labels are propagated to the netgen geometry
+    using ``faces.Nearest(gp_Pnt).name`` before meshing, so they appear as
+    boundary condition names in the resulting NGSolve mesh.
 
     Requires ``netgen`` and ``ngsolve`` packages to be installed. These are
     **not** hard dependencies of build123d — an ``ImportError`` with
@@ -138,8 +135,8 @@ def to_ngsolve_mesh(
         face_labels: Optional dictionary mapping build123d Face objects to
             label strings. These labels become NGSolve boundary condition
             names accessible via ``mesh.GetBoundaries()``. If not provided,
-            each face's existing ``.label`` attribute is used; faces without
-            a label are assigned ``"default"``.
+            each face's existing ``.label`` attribute is used; unlabeled
+            faces get Netgen's default name.
         maxh: Maximum mesh element size passed to ``geo.GenerateMesh()``.
             Defaults to 1.0.
         **mesh_kwargs: Additional keyword arguments forwarded to
@@ -151,7 +148,6 @@ def to_ngsolve_mesh(
 
     Raises:
         ImportError: If ``netgen`` or ``ngsolve`` is not installed.
-        RuntimeError: If Python version is older than 3.12.
 
     Example:
 
@@ -184,28 +180,10 @@ def to_ngsolve_mesh(
         gfu = ngs.GridFunction(fes)
         gfu.vec.data = a.mat.Inverse(fes.FreeDofs()) * f.vec
     """
-    if sys.version_info < _MIN_PYTHON:
-        raise RuntimeError(
-            f"to_ngsolve_mesh() requires Python {_MIN_PYTHON[0]}.{_MIN_PYTHON[1]}+ "
-            f"(running {sys.version_info[0]}.{sys.version_info[1]}). "
-            "Older Python versions have mismatched OCCT versions between "
-            "cadquery-ocp and netgen-occt, which can cause crashes."
-        )
-
-    OCCGeometry = _lazy_import_netgen()
+    OCCGeometry, gp_Pnt = _lazy_import_netgen()
     ngsolve = _lazy_import_ngsolve()
 
-    # Build the (cx, cy, cz, label) list from build123d faces
-    b123d_faces = []
-    for f in shape.faces():
-        c = f.center()
-        if face_labels is not None:
-            label = face_labels.get(f, "default")
-        else:
-            label = f.label if f.label else "default"
-        b123d_faces.append((c.X, c.Y, c.Z, label))
-
-    if not b123d_faces:
+    if not shape.faces():
         warnings.warn(
             "Shape has no faces — the resulting mesh will have no boundaries.",
             category=UserWarning,
@@ -221,13 +199,13 @@ def to_ngsolve_mesh(
         export_brep(shape, brep_path)
         geo = OCCGeometry(brep_path)
 
+    # Apply face labels on the netgen shape using Nearest() matching,
+    # then re-wrap in OCCGeometry so labels propagate through meshing.
+    ng_shape = geo.shape
+    _apply_face_labels(shape, ng_shape, gp_Pnt, face_labels)
+    geo = OCCGeometry(ng_shape)
+
     # Generate the netgen mesh
     ngmesh = geo.GenerateMesh(maxh=maxh, **mesh_kwargs)
-
-    # Propagate face labels by geometric center matching
-    if b123d_faces:
-        label_map = _match_face_labels(b123d_faces, geo)
-        for ng_idx, label in label_map.items():
-            ngmesh.SetBCName(ng_idx, label)
 
     return ngsolve.Mesh(ngmesh)

--- a/src/build123d/ngsolve_interop.py
+++ b/src/build123d/ngsolve_interop.py
@@ -11,9 +11,10 @@ desc:
     propagates face labels as mesh boundary condition names using Netgen's
     faces.Nearest() API for geometric matching.
 
-    Requires build123d's cadquery-ocp-novtk >= 7.9 and netgen-occt, which
-    use separate pybind11 type namespaces and coexist in a single process
-    on Python 3.10+.
+    On Python 3.10+, the pybind11 builds of cadquery-ocp (any version) and
+    netgen-occt coexist in a single process without type conflicts. Direct
+    shape passing is not possible (different pybind11 wrapper types), so
+    BREP file interchange is used.
 
     See: https://github.com/gumyr/build123d/issues/297
 

--- a/tests/test_ngsolve_interop.py
+++ b/tests/test_ngsolve_interop.py
@@ -53,16 +53,8 @@ class TestNgsolveInteropImport(unittest.TestCase):
         """Calling to_ngsolve_mesh without ngsolve should raise ImportError."""
         part = Cylinder(5, 10)
         with patch.dict(sys.modules, {"ngsolve": None}):
-            with self.assertRaises((ImportError, RuntimeError)):
+            with self.assertRaises(ImportError):
                 to_ngsolve_mesh(part)
-
-    def test_python_version_check(self):
-        """to_ngsolve_mesh should reject Python < 3.12."""
-        part = Cylinder(5, 10)
-        with patch.object(sys, "version_info", (3, 9, 0)):
-            with self.assertRaises(RuntimeError) as ctx:
-                to_ngsolve_mesh(part)
-            self.assertIn("3.12", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/tests/test_ngsolve_interop.py
+++ b/tests/test_ngsolve_interop.py
@@ -1,0 +1,69 @@
+"""
+NGSolve Interop Tests
+
+name: test_ngsolve_interop.py
+by:   build123d contributors
+date: March 30th, 2026
+
+desc: Test the build123d NGSolve/Netgen interoperability module.
+      These tests verify behavior *without* ngsolve/netgen installed.
+
+license:
+
+    Copyright 2026 build123d contributors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+"""
+
+import sys
+import unittest
+from unittest.mock import patch
+
+from build123d import Cylinder, to_ngsolve_mesh
+
+
+class TestNgsolveInteropImport(unittest.TestCase):
+    """Tests that work without ngsolve/netgen installed."""
+
+    def test_import_succeeds(self):
+        """to_ngsolve_mesh should be importable without ngsolve installed."""
+        self.assertTrue(callable(to_ngsolve_mesh))
+
+    def test_missing_netgen_raises_helpful_error(self):
+        """Calling to_ngsolve_mesh without netgen should raise ImportError."""
+        part = Cylinder(5, 10)
+        with patch.dict(sys.modules, {"netgen": None, "netgen.occ": None}):
+            with self.assertRaises(ImportError) as ctx:
+                to_ngsolve_mesh(part)
+            self.assertIn("netgen", str(ctx.exception))
+            self.assertIn("pip install", str(ctx.exception))
+
+    def test_missing_ngsolve_raises_helpful_error(self):
+        """Calling to_ngsolve_mesh without ngsolve should raise ImportError."""
+        part = Cylinder(5, 10)
+        with patch.dict(sys.modules, {"ngsolve": None}):
+            with self.assertRaises((ImportError, RuntimeError)):
+                to_ngsolve_mesh(part)
+
+    def test_python_version_check(self):
+        """to_ngsolve_mesh should reject Python < 3.12."""
+        part = Cylinder(5, 10)
+        with patch.object(sys, "version_info", (3, 9, 0)):
+            with self.assertRaises(RuntimeError) as ctx:
+                to_ngsolve_mesh(part)
+            self.assertIn("3.12", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a `to_ngsolve_mesh()` function that converts build123d shapes to NGSolve meshes for finite element analysis, closing the gap described in #297.

- **New module**: `src/build123d/ngsolve_interop.py` with `to_ngsolve_mesh()` function
- **BREP interchange**: Transfers geometry via temporary BREP file (direct shape passing not possible due to different pybind11 wrapper types)
- **Face label propagation**: Uses Netgen's `faces.Nearest(gp_Pnt).name` API (credit: @rmsc's [suggestion](https://github.com/gumyr/build123d/issues/297#issuecomment-4159945906)) to match build123d face labels to netgen faces before meshing. Handles non-convex faces (C-shapes, annular sectors) via rejection sampling in UV parameter space when `face.center()` falls outside the trimmed boundary.
- **Lazy imports**: `netgen` and `ngsolve` are imported lazily with helpful error messages — they are **not** added as hard dependencies
- **Python 3.10+**: No additional version requirements beyond build123d's own `requires-python >= 3.10`
- **Two labeling modes**: Pass a `face_labels` dict, or set `.label` on faces using build123d's selection API
- **Documentation**: Section added to `docs/import_export.rst`
- **Example**: `examples/ngsolve_poisson.py` (gracefully skips if ngsolve not installed)
- **Tests**: `tests/test_ngsolve_interop.py`

### Why Python 3.10+ with no OCP version restriction?

We tested every combination systematically:

| Python | cadquery-ocp package | OCP version | netgen-occt | Co-import | Full pipeline |
|--------|---------------------|-------------|-------------|-----------|---------------|
| 3.9 | cadquery-ocp 7.7.2 | OCCT 7.7.2 | 7.8.1 | **FAILS** (`gp_Pnt already registered`) | N/A |
| 3.10 | cadquery-ocp 7.7.2 | OCCT 7.7.2 | 7.8.1 | OK | OK |
| 3.10 | cadquery-ocp-novtk 7.7.2.2b2 | OCCT 7.7.2 | 7.8.1 | OK | OK |
| 3.10 | cadquery-ocp 7.8.1 | OCCT 7.8.1 | 7.8.1 | OK | OK |
| 3.10 | cadquery-ocp-novtk 7.9.3 | OCCT 7.9.3 | 7.8.1 | OK | OK |
| 3.11 | cadquery-ocp-novtk 7.9.3 | OCCT 7.9.3 | 7.8.1 | OK | OK |
| 3.12 | cadquery-ocp-novtk 7.9.3 | OCCT 7.9.3 | 7.8.1 | OK | OK |

The pybind11 type conflict is a **Python 3.9 runtime issue**, not a package version issue. The same `cadquery-ocp==7.7.2` that fails on 3.9 works fine on 3.10. Since build123d already requires Python >= 3.10, no additional version guard is needed.

### aarch64 Linux

`netgen-occt` only ships wheels for x86_64 Linux, macOS (x86_64 + arm64), and Windows. No aarch64 Linux wheels exist — this is a netgen upstream limitation. The lazy import handles this gracefully: build123d imports fine, and `to_ngsolve_mesh()` raises a clear `ImportError`.

### Usage

```python
import build123d as bd
from build123d import to_ngsolve_mesh
import ngsolve as ngs

part = bd.Cylinder(10, 20) - bd.Cylinder(5, 20)

# Option 1: face_labels dict
labels = {}
for f in part.faces():
    labels[f] = "ends" if abs(f.center().Z) > 1 else "walls"
mesh = to_ngsolve_mesh(part, face_labels=labels, maxh=2)

# Option 2: .label attribute (uses build123d's face selection API)
for f in part.faces():
    f.label = "ends" if abs(f.center().Z) > 1 else "walls"
mesh = to_ngsolve_mesh(part, maxh=2)
```

## Test plan

- [x] `from build123d import to_ngsolve_mesh` works without ngsolve installed
- [x] Calling without ngsolve raises helpful `ImportError` with install instructions
- [x] End-to-end example runs on Python 3.10, 3.11, and 3.12 (identical results)
- [x] Face labels propagate correctly on convex and non-convex geometries
- [x] Non-convex faces (C-shapes, U-channels) matched correctly via UV rejection sampling

### Test output (identical on 3.10, 3.11, 3.12)
```
Boundaries:  ('walls', 'ends', 'ends', 'walls')
DOFs:        3783 (3185 free)
Solution:    -16.2320 .. 50.0242
```

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)