### PR TITLE
Fix bare except clause in text.py

### DIFF
--- a/src/build123d/text.py
+++ b/src/build123d/text.py
@@ -194,7 +194,7 @@ class FontManager:
         for record in ft_font["name"].names:
             try:
                 value = record.toUnicode()
-            except:
+            except Exception:
                 continue
 
             if record.nameID == 1 and family == "":


### PR DESCRIPTION
## Summary
Fix bare `except:` clause in `text.py` to use `except Exception:` instead.

## Problem
Bare `except:` clauses catch all exceptions, including `KeyboardInterrupt` and `SystemExit`. This can make debugging more difficult and is discouraged by PEP 8.

## Solution
Replace `except:` with `except Exception:` which only catches regular exceptions while allowing system-level exceptions to propagate.

## Changes
- `src/build123d/text.py` line 197: Changed `except:` to `except Exception:`

## Testing
The change is minimal and safe - `record.toUnicode()` raises regular exceptions (not system-exiting ones) when font name records are malformed, so this maintains the same behavior while following best practices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)