### PR TITLE
Add error handling for font file loading in register_font

### DIFF
--- a/src/build123d/text.py
+++ b/src/build123d/text.py
@@ -28,6 +28,7 @@ from OCP.Font import (
 from OCP.TCollection import TCollection_AsciiString
 from OCP.TColStd import TColStd_SequenceOfHAsciiString
 
+from build123d.build_common import logger
 from build123d.build_enums import FontStyle
 
 
@@ -135,10 +136,14 @@ class FontManager:
     ) -> list[str]:
         """Register all font faces in a font file and return font face names."""
         _, ext = os.path.splitext(path)
-        if ext.strip(".") == "ttc": # pragma: no cover
-            fonts = ttCollection.TTCollection(path)
-        else:
-            fonts = [TTFont(path)]
+        try:
+            if ext.strip(".") == "ttc": # pragma: no cover
+                fonts = ttCollection.TTCollection(path)
+            else:
+                fonts = [TTFont(path)]
+        except Exception as e:
+            logger.warning("Failed to load font file '%s': %s", path, e)
+            return []
 
         font_faces = []
         for font in fonts:


### PR DESCRIPTION
When loading fonts, if corrupted fonts are present, even valid fonts will cause the operation to fail.

When corrupted fonts are detected, log a warning and skip them instead.