### PR TITLE
feat: accept pymat.Material on Compound/Solid.material (draft, refs MorePET/mat#3)

### DIFF
--- a/examples/pbr_material_pymat.py
+++ b/examples/pbr_material_pymat.py
@@ -1,0 +1,141 @@
+"""
+End-to-end example: build123d + py-materials + ocp_vscode.
+
+Demonstrates the proposed `Shape.material` integration with
+`pymat.Material` (from `py-materials`) carrying both physics
+properties (density, molar mass, thermal) AND rich PBR rendering
+via `threejs-materials`. When `material` is set to a `pymat.Material`
+instance, `ocp_vscode` reads it for PBR rendering; the same object
+also answers physics queries.
+
+This example is part of the ongoing collaboration tracked in
+[MorePET/mat#3](https://github.com/MorePET/mat/issues/3) — see the
+issue for the full design discussion.
+
+Requirements:
+    pip install build123d[materials,ocp_vscode]
+
+Run (headless):
+    python examples/pbr_material_pymat.py
+
+Run (with live render in VS Code's OCP CAD Viewer):
+    python examples/pbr_material_pymat.py --visual
+
+The headless mode prints the Three.js `MeshPhysicalMaterial` dict and
+physics properties to stdout. The visual mode additionally calls
+`ocp_vscode.show()` to render the part in the viewer.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from build123d import Box, Cylinder, Part, Pos
+
+try:
+    from pymat import Material
+except ImportError as e:
+    sys.stderr.write(
+        "This example requires py-materials with the [pbr] extra.\n"
+        "Install via:\n"
+        "    pip install build123d[materials]\n"
+        f"\n(underlying error: {e})\n"
+    )
+    sys.exit(2)
+
+try:
+    from pymat.pbr import PbrProperties  # noqa: F401  # re-exported when [pbr]
+    RICH_PBR_AVAILABLE = True
+except ImportError:
+    RICH_PBR_AVAILABLE = False
+
+
+def build_part() -> Part:
+    """A simple machined flange — box with a cylindrical hole."""
+    body = Box(60, 40, 10)
+    hole = Pos(0, 0, 0) * Cylinder(8, 12)
+    return Part() + body - hole
+
+
+def build_material() -> Material:
+    """
+    Build a stainless steel `pymat.Material` carrying physics values
+    AND a rich PBR rendering source.
+
+    When the `[pbr]` extra is installed (via `build123d[materials]`),
+    the material downloads a MaterialX "Stainless Steel Brushed"
+    texture set from matlib.gpuopen.com on first run and caches it.
+    Without the extra, falls back to the lite in-tree PBR dataclass
+    (scalar values only, no texture maps).
+    """
+    base = Material(
+        name="Stainless Steel 304",
+        density=8.0,
+        formula="Fe",
+        mechanical={"youngs_modulus": 193, "yield_strength": 170},
+        thermal={"melting_point": 1450, "thermal_conductivity": 15.1},
+        # Lite PBR — used when rich backend unavailable.
+        pbr={
+            "base_color": (0.75, 0.75, 0.77, 1.0),
+            "metallic": 1.0,
+            "roughness": 0.35,
+        },
+    )
+    if RICH_PBR_AVAILABLE:
+        # Upgrade to the rich backend for proper MaterialX textures.
+        # This is the canonical pattern from ADR-0002 in py-materials:
+        # Material carries both physics AND a PbrSource, rendering
+        # code calls `to_three_js_material_dict()` and gets the
+        # right output regardless of which backend is behind it.
+        base.pbr_source = PbrProperties.from_gpuopen("Stainless Steel Brushed")
+    return base
+
+
+def main() -> int:
+    part = build_part()
+    steel = build_material()
+
+    # The point of the integration: a single assignment lets the
+    # part carry both the physics + rendering story.
+    part.material = steel
+
+    print("=== Physics properties (via py-materials) ===")
+    print(f"  name:         {steel.name}")
+    print(f"  density:      {steel.density} g/cm³")
+    print(f"  formula:      {steel.formula}")
+    print(f"  molar mass:   {steel.molar_mass} g/mol")
+
+    # Computed from build123d geometry + pymat density.
+    volume_cm3 = part.volume / 1000  # mm³ → cm³
+    mass_g = volume_cm3 * (steel.density or 0.0)
+    print(f"  part volume:  {volume_cm3:.2f} cm³")
+    print(f"  part mass:    {mass_g:.2f} g")
+
+    print("\n=== PBR rendering (Three.js MeshPhysicalMaterial dict) ===")
+    three_js = steel.to_three_js_material_dict()
+    print(json.dumps(three_js, indent=2, sort_keys=True))
+
+    print("\n=== Backend summary ===")
+    print(f"  rich PBR available:    {RICH_PBR_AVAILABLE}")
+    print(f"  rich backend in use:   {steel.pbr_source is not None}")
+    print("  (rich backend requires `pip install build123d[materials]`)")
+
+    if "--visual" in sys.argv:
+        try:
+            from ocp_vscode import show
+        except ImportError as e:
+            print(
+                "\n--visual requires build123d[ocp_vscode]: "
+                f"pip install build123d[ocp_vscode,materials]\n({e})"
+            )
+            return 1
+        print("\nRendering in ocp_vscode... "
+              "(requires VS Code with OCP CAD Viewer extension)")
+        show(part)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/pbr_material_pymat.py
+++ b/examples/pbr_material_pymat.py
@@ -1,29 +1,92 @@
 """
-End-to-end example: build123d + py-materials + ocp_vscode.
+Hot-wired proof of concept: build123d + py-materials + ocp_vscode.
 
-Demonstrates the proposed `Shape.material` integration with
-`pymat.Material` (from `py-materials`) carrying both physics
-properties (density, molar mass, thermal) AND rich PBR rendering
-via `threejs-materials`. When `material` is set to a `pymat.Material`
-instance, `ocp_vscode` reads it for PBR rendering; the same object
-also answers physics queries.
+A single `pymat.Material` instance can be assigned to
+`shape.material` and carries BOTH the materials-science story
+(density, molar mass, formula, thermal properties) AND a rich
+MaterialX-backed PBR rendering source (from `threejs-materials`,
+which loads from matlib.gpuopen.com / ambientcg / polyhaven /
+physicallybased.info). `ocp_vscode.show()` then renders the part
+with full textured PBR while the same object still answers
+physics queries.
 
-This example is part of the ongoing collaboration tracked in
-[MorePET/mat#3](https://github.com/MorePET/mat/issues/3) — see the
-issue for the full design discussion.
+Tracked in [MorePET/mat#3](https://github.com/MorePET/mat/issues/3).
+This example is the exploratory "here's what it could look like"
+demo — not yet merged upstream in any of the three repos.
 
-Requirements:
-    pip install build123d[materials,ocp_vscode]
+-----------------------------------------------------------------
+Three draft PRs make up the integration stack
+-----------------------------------------------------------------
 
-Run (headless):
-    python examples/pbr_material_pymat.py
+- [MorePET/mat#30](https://github.com/MorePET/mat/pull/30) —
+  py-materials: `Material.pbr_source` field + `pymat.pbr` Protocol
+  + `[pbr]` optional extra + ADR-0002
+- [gumyr/build123d#1276](https://github.com/gumyr/build123d/pull/1276) —
+  build123d: `Compound.material` / `Solid.material` type widened
+  from `str` to `str | pymat.Material | None`
+- [bernhard-42/vscode-ocp-cad-viewer#228](https://github.com/bernhard-42/vscode-ocp-cad-viewer/pull/228) —
+  ocp_vscode: `_extract_materials_from_node` prefers the rich
+  `pbr_source` instead of the lossy field-by-field copy
 
-Run (with live render in VS Code's OCP CAD Viewer):
-    python examples/pbr_material_pymat.py --visual
+This example runs against all three PRs at once via exact-SHA git
+pins in `pyproject.toml`'s `[materials]` extra and
+`[tool.uv.sources]` override.
 
-The headless mode prints the Three.js `MeshPhysicalMaterial` dict and
-physics properties to stdout. The visual mode additionally calls
-`ocp_vscode.show()` to render the part in the viewer.
+-----------------------------------------------------------------
+Try it yourself
+-----------------------------------------------------------------
+
+Requires **`uv`** (the `[tool.uv.sources]` override is
+uv-specific; `pip` / `poetry` users need to install the
+`ocp_vscode` fork manually — see the note in `pyproject.toml`).
+
+```bash
+git clone -b feature/pymat-material-integration \\
+    https://github.com/gerchowl/build123d.git
+cd build123d
+uv sync --extra materials --extra ocp_vscode
+uv run python examples/pbr_material_pymat.py --material wood --visual
+```
+
+That single `uv sync` resolves the whole dependency chain:
+
+```
+gerchowl/build123d @ feature/pymat-material-integration    (local clone)
+  ↓ [materials] extra
+MorePET/mat          @ 8c7729c (feature/3-pbr-protocol-integration)
+  ↓ [pbr] sub-extra
+threejs-materials[materialx] 1.0.4                         (PyPI)
+  ↓ via tool.uv.sources override
+gerchowl/vscode-ocp-cad-viewer @ 94cecc7 (fix/pymat-pbr-source-bypass)
+```
+
+-----------------------------------------------------------------
+Running the example
+-----------------------------------------------------------------
+
+```bash
+# headless — prints physics + Three.js dict
+uv run python examples/pbr_material_pymat.py
+
+# pick a MaterialX preset (wood, steel, bricks, tiles, gold, bronze)
+uv run python examples/pbr_material_pymat.py --material wood
+
+# open VS Code with the OCP CAD Viewer extension, then:
+uv run python examples/pbr_material_pymat.py --material wood --visual
+```
+
+Before hitting `--visual`, make sure you have the **OCP CAD Viewer**
+extension installed in VS Code (`Cmd+Shift+P` → "Extensions: Install
+Extensions" → "OCP CAD Viewer"). When the viewer panel opens,
+click the **Material** tab in its toolbar and ensure **Studio**
+mode is selected (the `--visual` mode passes the right studio kwargs
+to `show()`, but the viewer's panel can override them).
+
+Each preset downloads its MaterialX set from matlib.gpuopen.com on
+first run (cached under `~/.cache/threejs-materials/` afterwards).
+Wood grain is the most unambiguous "is this working?" signal —
+if you see wood grain on a 200×200 mm plate, every layer of the
+three-repo integration is working end-to-end.
 """
 
 from __future__ import annotations
@@ -52,78 +115,151 @@ except ImportError:
 
 
 def build_part() -> Part:
-    """A simple machined flange — box with a cylindrical hole."""
-    body = Box(60, 40, 10)
-    hole = Pos(0, 0, 0) * Cylinder(8, 12)
+    """A 200 mm square plate with a central hole.
+
+    Sized deliberately large (200 × 200 × 20 mm) so PBR textures
+    are visible at a reasonable tile rate. Brushed/grained textures
+    can look washed out on small faces if the UV scale doesn't match
+    the geometry — a bigger plate gives the texture room to breathe.
+    """
+    body = Box(200, 200, 20)
+    hole = Pos(0, 0, 0) * Cylinder(30, 25)
     return Part() + body - hole
 
 
-def build_material() -> Material:
+# Preset materials from matlib.gpuopen.com. Each is visually
+# distinctive so it's obvious when the PBR pipeline is working.
+# These are lifted from Bernhard's own `material-object.py` demo in
+# `bernhard-42/vscode-ocp-cad-viewer`, which confirms they render
+# correctly in ocp_vscode's studio mode.
+PRESETS = {
+    "wood": {
+        "name": "Ivory Walnut Solid Wood",
+        "density": 0.65,  # g/cm³, typical for walnut
+        "formula": None,
+        "gpuopen_name": "Ivory Walnut Solid Wood",
+    },
+    "steel": {
+        "name": "Stainless Steel Brushed",
+        "density": 8.0,
+        "formula": "Fe",
+        "gpuopen_name": "Stainless Steel Brushed",
+    },
+    "bricks": {
+        "name": "TH Large Red Bricks",
+        "density": 1.92,  # g/cm³, typical clay brick
+        "formula": None,
+        "gpuopen_name": "TH Large Red Bricks",
+    },
+    "tiles": {
+        "name": "Iberian Blue Ceramic Tiles",
+        "density": 2.4,  # g/cm³, typical ceramic
+        "formula": None,
+        "gpuopen_name": "Iberian Blue Ceramic Tiles",
+    },
+    "gold": {
+        "name": "Gold",
+        "density": 19.3,
+        "formula": "Au",
+        "gpuopen_name": "Gold",
+    },
+    "bronze": {
+        "name": "Bronze Oxydized",
+        "density": 8.8,
+        "formula": None,
+        "gpuopen_name": "Bronze Oxydized",
+    },
+}
+
+
+def build_material(preset: str = "wood") -> Material:
     """
-    Build a stainless steel `pymat.Material` carrying physics values
-    AND a rich PBR rendering source.
+    Build a `pymat.Material` carrying physics values AND a rich PBR
+    source, from one of the visually distinctive presets defined in
+    `PRESETS`. Default is ``wood`` — its grain pattern is the most
+    unambiguous texture to spot, which makes it the best "is the PBR
+    pipeline working?" test case.
 
     When the `[pbr]` extra is installed (via `build123d[materials]`),
-    the material downloads a MaterialX "Stainless Steel Brushed"
-    texture set from matlib.gpuopen.com on first run and caches it.
-    Without the extra, falls back to the lite in-tree PBR dataclass
-    (scalar values only, no texture maps).
+    the material downloads the requested MaterialX texture set from
+    matlib.gpuopen.com on first run and caches it under the user's
+    threejs-materials cache directory for reuse.
     """
+    if preset not in PRESETS:
+        raise ValueError(
+            f"Unknown preset {preset!r}. Available: {sorted(PRESETS)}"
+        )
+    spec = PRESETS[preset]
     base = Material(
-        name="Stainless Steel 304",
-        density=8.0,
-        formula="Fe",
-        mechanical={"youngs_modulus": 193, "yield_strength": 170},
-        thermal={"melting_point": 1450, "thermal_conductivity": 15.1},
-        # Lite PBR — used when rich backend unavailable.
+        name=spec["name"],
+        density=spec["density"],
+        formula=spec["formula"],
+        # Lite PBR fallback (used when rich backend unavailable —
+        # intentionally neutral so the fallback is obviously worse
+        # than the rich path).
         pbr={
-            "base_color": (0.75, 0.75, 0.77, 1.0),
-            "metallic": 1.0,
-            "roughness": 0.35,
+            "base_color": (0.7, 0.7, 0.7, 1.0),
+            "metallic": 0.0,
+            "roughness": 0.5,
         },
     )
     if RICH_PBR_AVAILABLE:
-        # Upgrade to the rich backend for proper MaterialX textures.
-        # This is the canonical pattern from ADR-0002 in py-materials:
-        # Material carries both physics AND a PbrSource, rendering
-        # code calls `to_three_js_material_dict()` and gets the
-        # right output regardless of which backend is behind it.
-        base.pbr_source = PbrProperties.from_gpuopen("Stainless Steel Brushed")
+        base.pbr_source = PbrProperties.from_gpuopen(spec["gpuopen_name"])
     return base
 
 
+def _parse_material_arg() -> str:
+    """Parse `--material NAME` from argv, default to `wood`."""
+    if "--material" in sys.argv:
+        i = sys.argv.index("--material")
+        if i + 1 < len(sys.argv):
+            return sys.argv[i + 1]
+    return "wood"
+
+
 def main() -> int:
+    preset = _parse_material_arg()
     part = build_part()
-    steel = build_material()
+    mat = build_material(preset)
 
     # The point of the integration: a single assignment lets the
     # part carry both the physics + rendering story.
-    part.material = steel
+    part.material = mat
 
-    print("=== Physics properties (via py-materials) ===")
-    print(f"  name:         {steel.name}")
-    print(f"  density:      {steel.density} g/cm³")
-    print(f"  formula:      {steel.formula}")
-    print(f"  molar mass:   {steel.molar_mass} g/mol")
+    print(f"=== Physics properties (via py-materials, preset={preset!r}) ===")
+    print(f"  name:         {mat.name}")
+    print(f"  density:      {mat.density} g/cm³")
+    print(f"  formula:      {mat.formula}")
+    print(f"  molar mass:   {mat.molar_mass} g/mol")
 
     # Computed from build123d geometry + pymat density.
     volume_cm3 = part.volume / 1000  # mm³ → cm³
-    mass_g = volume_cm3 * (steel.density or 0.0)
+    mass_g = volume_cm3 * (mat.density or 0.0)
     print(f"  part volume:  {volume_cm3:.2f} cm³")
     print(f"  part mass:    {mass_g:.2f} g")
 
     print("\n=== PBR rendering (Three.js MeshPhysicalMaterial dict) ===")
-    three_js = steel.to_three_js_material_dict()
-    print(json.dumps(three_js, indent=2, sort_keys=True))
+    three_js = mat.to_three_js_material_dict()
+    # Abbreviate data URIs so the dump is readable.
+    def _abbrev(obj):
+        if isinstance(obj, str) and obj.startswith("data:"):
+            return f"data:...;base64,...({len(obj)} chars)"
+        if isinstance(obj, dict):
+            return {k: _abbrev(v) for k, v in obj.items()}
+        if isinstance(obj, list):
+            return [_abbrev(v) for v in obj]
+        return obj
+    print(json.dumps(_abbrev(three_js), indent=2, sort_keys=True))
 
     print("\n=== Backend summary ===")
     print(f"  rich PBR available:    {RICH_PBR_AVAILABLE}")
-    print(f"  rich backend in use:   {steel.pbr_source is not None}")
-    print("  (rich backend requires `pip install build123d[materials]`)")
+    print(f"  rich backend in use:   {mat.pbr_source is not None}")
+    print(f"  available presets:     {sorted(PRESETS.keys())}")
+    print(f"  current preset:        {preset!r}  (change via `--material NAME`)")
 
     if "--visual" in sys.argv:
         try:
-            from ocp_vscode import show
+            from ocp_vscode import show, StudioEnvironment, StudioTextureMapping
         except ImportError as e:
             print(
                 "\n--visual requires build123d[ocp_vscode]: "
@@ -132,7 +268,18 @@ def main() -> int:
             return 1
         print("\nRendering in ocp_vscode... "
               "(requires VS Code with OCP CAD Viewer extension)")
-        show(part)
+        # Studio mode + an HDR environment map activate PBR texture
+        # sampling in three-cad-viewer. Without these, the viewer
+        # falls back to CAD mode (flat interpolated color — renders
+        # yellow/mustard as the ocp_vscode default). PROCEDURAL_STUDIO
+        # is the default procedural env map (no HDR download needed);
+        # PARAMETRIC mapping uses the UVs baked into threejs-materials'
+        # texture output.
+        show(
+            part,
+            studio_environment=StudioEnvironment.PROCEDURAL_STUDIO,
+            studio_texture_mapping=StudioTextureMapping.PARAMETRIC,
+        )
 
     return 0
 

--- a/examples/pbr_smoke_test.py
+++ b/examples/pbr_smoke_test.py
@@ -1,0 +1,52 @@
+"""
+Smoke test: bypass pymat entirely, assign threejs_materials.PbrProperties
+directly to part.material. If this renders with textures in
+ocp_vscode.show(), the ocp_vscode <-> threejs-materials pipeline is
+working and our pymat integration is the only thing to fix.
+
+If this ALSO renders white, there's a deeper pipeline problem
+independent of our integration.
+
+Run:
+    python examples/pbr_smoke_test.py           # headless, prints dict
+    python examples/pbr_smoke_test.py --visual  # sends to ocp_vscode
+"""
+
+from __future__ import annotations
+
+import sys
+
+from build123d import Box, Cylinder, Part, Pos
+from threejs_materials import PbrProperties
+
+
+def main() -> int:
+    body = Box(200, 200, 20)
+    hole = Pos(0, 0, 0) * Cylinder(30, 25)
+    part = Part() + body - hole
+
+    # Directly assign the rich backend — NO pymat wrapper, NO
+    # backfill. This is the path Bernhard's example uses
+    # (material-object.py in vscode-ocp-cad-viewer) and the path
+    # his adapter handles via `isinstance(node.material, PbrProperties)`.
+    wood = PbrProperties.from_gpuopen("Ivory Walnut Solid Wood")
+    part.material = wood
+
+    print(f"material type: {type(part.material).__name__}")
+    print(f"material name: {wood.name}")
+    print(f"texture maps:  {list(wood.maps.to_dict().keys())}")
+
+    if "--visual" in sys.argv:
+        from ocp_vscode import StudioEnvironment, StudioTextureMapping, show
+
+        print("\nRendering in ocp_vscode (bypass: direct PbrProperties)...")
+        show(
+            part,
+            studio_environment=StudioEnvironment.PROCEDURAL_STUDIO,
+            studio_texture_mapping=StudioTextureMapping.PARAMETRIC,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,12 +47,11 @@ dependencies = [
     "scipy",
     "scikit-learn >= 1.5, < 2",
     "webcolors ~= 24.8.0",
-
     # Install standard official lib3mf on everything EXCEPT linux aarch64
     "lib3mf >= 2.4.1; sys_platform != 'linux' or platform_machine != 'aarch64'",
-    
     # Install py-lib3mf ONLY on linux aarch64
     "py-lib3mf >= 2.4.1; sys_platform == 'linux' and platform_machine == 'aarch64'",
+    "ocp-vscode>=3.3.4",
 ]
 
 [project.urls]
@@ -72,12 +71,13 @@ ocp_vscode = [
 # extra installed, those attributes can carry a `pymat.Material` instance
 # in addition to the legacy str tag.
 #
-# EXPLORATION: this pin points at the pymat feature branch (MorePET/mat#30)
-# where the pbr Protocol lives. Before proposing this change upstream to
-# gumyr/build123d, switch to a PyPI version pin — `py-materials[pbr]>=2.2.0`
-# once the pbr extra ships in a PyPI release.
+# EXPLORATION: pinned to the exact commit on the pymat feature branch
+# (MorePET/mat#30) where the pbr Protocol lives. SHA pin is deliberate —
+# before proposing this change upstream to gumyr/build123d, switch to a
+# PyPI version pin (`py-materials[pbr]>=2.2.0`) once the pbr extra ships
+# in a PyPI release.
 materials = [
-    "py-materials[pbr] @ git+https://github.com/MorePET/mat.git@feature/3-pbr-protocol-integration",
+    "py-materials[pbr] @ git+https://github.com/MorePET/mat.git@8c7729c",
 ]
 
 # development dependencies
@@ -115,6 +115,17 @@ all = [
     "build123d[stubs]",
     "build123d[materials]",
 ]
+
+[tool.uv.sources]
+# EXPLORATION: pin ocp_vscode to the fork commit carrying the
+# pymat.pbr_source adapter fix, pending the upstream PR at
+# bernhard-42/vscode-ocp-cad-viewer#228.
+# Revert to the PyPI `ocp_vscode` dep once the fix is released.
+#
+# NOTE: this section is uv-specific. If you use `pip` or `poetry`,
+# you'll need to install ocp_vscode from the fork manually:
+#   pip install "ocp-vscode @ git+https://github.com/gerchowl/vscode-ocp-cad-viewer.git@94cecc7"
+ocp-vscode = { git = "https://github.com/gerchowl/vscode-ocp-cad-viewer.git", rev = "94cecc7" }
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,19 @@ ocp_vscode = [
     "ocp_vscode",
 ]
 
+# enable the optional py-materials (physics + PBR rendering) integration
+# See docstrings on `Compound.material` and `Solid.material` — with this
+# extra installed, those attributes can carry a `pymat.Material` instance
+# in addition to the legacy str tag.
+#
+# EXPLORATION: this pin points at the pymat feature branch (MorePET/mat#30)
+# where the pbr Protocol lives. Before proposing this change upstream to
+# gumyr/build123d, switch to a PyPI version pin — `py-materials[pbr]>=2.2.0`
+# once the pbr extra ships in a PyPI release.
+materials = [
+    "py-materials[pbr] @ git+https://github.com/MorePET/mat.git@feature/3-pbr-protocol-integration",
+]
+
 # development dependencies
 development = [
     "black",
@@ -100,6 +113,7 @@ all = [
     "build123d[development]",
     "build123d[docs]",
     "build123d[stubs]",
+    "build123d[materials]",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ dependencies = [
     "lib3mf >= 2.4.1; sys_platform != 'linux' or platform_machine != 'aarch64'",
     # Install py-lib3mf ONLY on linux aarch64
     "py-lib3mf >= 2.4.1; sys_platform == 'linux' and platform_machine == 'aarch64'",
-    "ocp-vscode>=3.3.4",
 ]
 
 [project.urls]

--- a/src/build123d/topology/composite.py
+++ b/src/build123d/topology/composite.py
@@ -59,8 +59,17 @@ import warnings
 from collections.abc import Iterable, Iterator, Sequence
 from itertools import combinations
 from os import PathLike, fspath
-from typing import overload
+from typing import TYPE_CHECKING, overload
 from typing_extensions import Self
+
+if TYPE_CHECKING:  # pragma: no cover
+    # Optional py-materials integration. Type-only import keeps
+    # build123d runtime-independent of py-materials — users who want
+    # the materials integration install `build123d[materials]`, which
+    # pulls py-materials as a runtime dependency. When py-materials
+    # is not installed, `Compound.material` is still usable with the
+    # legacy `str` tag or any duck-typed object.
+    from pymat import Material as PymatMaterial
 
 import OCP.TopAbs as ta
 from OCP.BRepAlgoAPI import BRepAlgoAPI_Common, BRepAlgoAPI_Fuse, BRepAlgoAPI_Section
@@ -139,7 +148,7 @@ class Compound(Mixin3D[TopoDS_Compound]):
         obj: TopoDS_Compound | Iterable[Shape] | None = None,
         label: str = "",
         color: Color | None = None,
-        material: str = "",
+        material: str | PymatMaterial | None = None,
         joints: dict[str, Joint] | None = None,
         parent: Compound | None = None,
         children: Sequence[Shape] | None = None,
@@ -150,7 +159,17 @@ class Compound(Mixin3D[TopoDS_Compound]):
             obj (TopoDS_Compound | Iterable[Shape], optional): OCCT Compound or shapes
             label (str, optional): Defaults to ''.
             color (Color, optional): Defaults to None.
-            material (str, optional): tag for external tools. Defaults to ''.
+            material (str | pymat.Material, optional): materials-science
+                + PBR carrier, or legacy str tag for external tools.
+                When a `pymat.Material` is assigned, consumers like
+                ocp_vscode can read
+                `compound.material.to_three_js_material_dict()` for
+                PBR rendering and `compound.material.density`,
+                `compound.material.molar_mass`, etc. for physics
+                queries. The str form remains accepted for backward
+                compatibility — downstream code should
+                `isinstance`-check to distinguish.
+                Defaults to None (stored as empty str).
             joints (dict[str, Joint], optional): names joints. Defaults to None.
             parent (Compound, optional): assembly parent. Defaults to None.
             children (Sequence[Shape], optional): assembly children. Defaults to None.

--- a/src/build123d/topology/three_d.py
+++ b/src/build123d/topology/three_d.py
@@ -139,6 +139,10 @@ from .zero_d import Vertex
 if TYPE_CHECKING:  # pragma: no cover
     from .composite import Compound  # pylint: disable=R0801
 
+    # Optional py-materials integration. See Compound.__init__ docstring
+    # for rationale; Solid.material accepts the same type union.
+    from pymat import Material as PymatMaterial
+
 
 class Mixin3D(Shape[TOPODS]):
     """Additional methods to add to 3D Shape classes"""
@@ -721,7 +725,7 @@ class Solid(Mixin3D[TopoDS_Solid]):
         obj: TopoDS_Solid | Shell | None = None,
         label: str = "",
         color: Color | None = None,
-        material: str = "",
+        material: str | PymatMaterial | None = None,
         joints: dict[str, Joint] | None = None,
         parent: Compound | None = None,
     ):
@@ -731,7 +735,16 @@ class Solid(Mixin3D[TopoDS_Solid]):
             obj (TopoDS_Shape | Shell, optional): OCCT Solid or Shell.
             label (str, optional): Defaults to ''.
             color (Color, optional): Defaults to None.
-            material (str, optional): tag for external tools. Defaults to ''.
+            material (str | pymat.Material, optional): materials-science
+                + PBR carrier, or legacy str tag for external tools.
+                When a `pymat.Material` is assigned, consumers like
+                ocp_vscode can read
+                `solid.material.to_three_js_material_dict()` for PBR
+                rendering and `solid.material.density`,
+                `solid.material.molar_mass`, etc. for physics queries.
+                The str form remains accepted for backward compatibility
+                — downstream code should `isinstance`-check to
+                distinguish. Defaults to None (stored as empty str).
             joints (dict[str, Joint], optional): names joints. Defaults to None.
             parent (Compound, optional): assembly parent. Defaults to None.
         """


### PR DESCRIPTION
## Draft — exploratory

Opened as a **draft** in response to the feature request in [MorePET/mat#3](https://github.com/MorePET/mat/issues/3), where a user proposed that build123d shapes carry \`pymat.Material\` instances on \`.material\` for unified physics + PBR rendering.

**Not ready to merge** until:
1. The py-materials side ([MorePET/mat#30](https://github.com/MorePET/mat/pull/30)) lands and ships as py-materials 2.2.0 on PyPI
2. The \`materials\` extra's git+https pin is switched to a PyPI version pin
3. The API-collision resolution (type widen — see below) is reviewed
4. @bernhard-42's \`threejs-materials\` side is confirmed as the canonical PBR loader

## What this does

Evolves the existing \`Compound.material\` / \`Solid.material\` attribute (currently a free-form \`str\` tag for external-tool export) to **also** accept \`pymat.Material\` instances. Type-widened, not renamed — existing str usage stays backward compatible.

\`\`\`python
from build123d import Box
from pymat import Material
from pymat.pbr import PbrProperties  # requires build123d[materials]

box = Box(50, 50, 10)
box.material = Material(
    name="Stainless Steel 304",
    density=8.0,
    formula="Fe",
    pbr_source=PbrProperties.from_gpuopen("Stainless Steel Brushed"),
)

# One object, two consumers:
box.material.density         # → 8.0    (physics: mass calc)
box.material.molar_mass      # → 55.85  (physics: radiation transport)
box.material.to_three_js_material_dict()  # → Three.js render dict (PBR)
\`\`\`

## Why type widen instead of replace

\`Compound.material\` and \`Solid.material\` currently exist as \`str = ""\` — documented as "tag for external tools". Replacing the type outright would break STEP/STL export code that writes those tags. Widening to \`str | pymat.Material | None\` preserves every existing consumer and lets downstream code \`isinstance\`-check to distinguish.

If you prefer a different resolution (rename the legacy attribute, keep them separate, deprecation path), happy to rework — the goal here is to surface the collision concretely so the design decision is grounded in real code.

## Changes

- \`src/build123d/topology/composite.py\`: \`Compound.__init__\` material type widened + docstring. TYPE_CHECKING-only import of \`pymat.Material\`.
- \`src/build123d/topology/three_d.py\`: \`Solid.__init__\` matches. Same TYPE_CHECKING-only import.
- \`pyproject.toml\`: new \`[materials]\` optional extra pulling \`py-materials[pbr]\` (git+https to the exploration branch for now — will switch to PyPI pin before merge).
- \`examples/pbr_material_pymat.py\`: end-to-end demo — creates a machined flange part, attaches a stainless steel Material, prints physics values, geometry-derived mass, and the Three.js PBR dict. \`--visual\` flag calls \`ocp_vscode.show()\` for live rendering.

## Runtime dep posture

**Zero runtime dependency on py-materials** in the default install. The \`PymatMaterial\` import is \`TYPE_CHECKING\`-only. Users without \`[materials]\` installed keep using \`shape.material = "some-tag"\` as they do today. Only users who want the unified physics + PBR story pay the install cost:

\`\`\`bash
pip install build123d[materials]           # + py-materials[pbr]
pip install build123d[materials,ocp_vscode]  # + live rendering
\`\`\`

## Verified end-to-end

\`\`\`text
$ python examples/pbr_material_pymat.py
=== Physics properties (via py-materials) ===
  name:         Stainless Steel 304
  density:      8.0 g/cm³
  formula:      Fe
  molar mass:   55.85 g/mol
  part volume:  21.99 cm³
  part mass:    175.92 g

=== PBR rendering (Three.js MeshPhysicalMaterial dict) ===
{ "color": [0.75, 0.75, 0.77], "metalness": 1.0, "roughness": 0.35 }

=== Backend summary ===
  rich PBR available:    False
  rich backend in use:   False
\`\`\`

(Rich backend path is verified manually with \`pip install py-materials[pbr]\` installed — downloads Stainless Steel Brushed MaterialX textures from matlib.gpuopen.com on first run and caches them.)

## Refs

- [MorePET/mat#3](https://github.com/MorePET/mat/issues/3) — the feature request, design discussion, ADR-style analysis
- [MorePET/mat#30](https://github.com/MorePET/mat/pull/30) — py-materials side (matching draft PR)
- [bernhard-42/threejs-materials](https://github.com/bernhard-42/threejs-materials) — the PBR loader this integration ultimately feeds

cc @bernhard-42 (threejs-materials + ocp_vscode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)