### PR TITLE
future-proof rounding in `group_by`

### DIFF
--- a/src/build123d/topology/shape_core.py
+++ b/src/build123d/topology/shape_core.py
@@ -3043,17 +3043,22 @@ class ShapeList(list[T]):
                     return round(obj.volume, tol_digits)
 
         elif callable(group_by):
-            raw_key_f = group_by
 
             def key_f(obj):
-                val = raw_key_f(obj)
-                return round(val, tol_digits) if isinstance(val, (int, float)) else val
+                val = group_by(obj)
+                try:
+                    return round(val, tol_digits)
+                except TypeError:
+                    return val
 
         elif isinstance(group_by, property):
 
             def key_f(obj):
                 val = group_by.__get__(obj)
-                return round(val, tol_digits) if isinstance(val, (int, float)) else val
+                try:
+                    return round(val, tol_digits)
+                except TypeError:
+                    return val
 
         else:
             raise ValueError(f"Unsupported group_by function: {group_by}")

--- a/tests/test_direct_api/test_group_by.py
+++ b/tests/test_direct_api/test_group_by.py
@@ -29,8 +29,9 @@ license:
 import pprint
 import unittest
 
+from build123d import Cylinder
 from build123d.geometry import Axis
-from build123d.topology import Edge, Solid
+from build123d.topology import Edge, Shape, Solid
 from build123d.objects_curve import CenterArc
 
 
@@ -82,6 +83,11 @@ class TestGroupBy(unittest.TestCase):
         lines = Edge.make_constrained_lines(c1, c2)
         longest_lines = lines.group_by(edge_length)[-1]
         self.assertEqual(len(longest_lines), 2)
+
+    def test_non_roundable_property(self):
+        cyl = Cylinder(1, 2)
+        grouped = cyl.faces().group_by(Shape.matrix_of_inertia)
+        self.assertEqual(len(grouped.groups), 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
because anything could be roundable not just `float` and `int`