### PR TITLE
make `Plane` moveable like `Shape`

### DIFF
--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -3050,12 +3050,11 @@ class Plane(metaclass=PlaneMeta):
             return self.moved(other)
         try:
             others = list(other)
-            if any(not isinstance(other, Location | Plane) for other in others):
-                raise ValueError("Planes can only be multiplied by locations or planes")
-            return [self.moved(loc) for loc in others]
+            if all(isinstance(other, Location | Plane) for other in others):
+                return [self.moved(loc) for loc in others]
         except TypeError:  # not iterable
             pass
-        raise TypeError()
+        raise TypeError("Planes can only be multiplied by locations or planes")
 
     def __and__(self: Plane, other: Axis | Location | Plane | VectorLike | Shape):
         """intersect plane with other &"""

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -3047,12 +3047,12 @@ class Plane(metaclass=PlaneMeta):
         self, other: Location | Plane | Iterable[Location | Plane]
     ) -> Plane | list[Plane]:
         if isinstance(other, Location | Plane):
-            return self.move(other)
+            return self.moved(other)
         try:
             others = list(other)
             if any(not isinstance(other, Location | Plane) for other in others):
                 raise ValueError("Planes can only be multiplied by locations or planes")
-            return [self.move(loc) for loc in others]
+            return [self.moved(loc) for loc in others]
         except TypeError:  # not iterable
             pass
         raise TypeError()
@@ -3177,8 +3177,7 @@ class Plane(metaclass=PlaneMeta):
 
         return Plane(self._origin, new_x_dir, new_z_dir)
 
-    # TODO should be called `moved` as it makes a new Plane?
-    def move(self, loc: Location | Plane) -> Plane:
+    def moved(self, loc: Location | Plane) -> Plane:
         """Change the position & orientation of a copy of self by applying a relative location
 
         Args:

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -3017,19 +3017,45 @@ class Plane(metaclass=PlaneMeta):
         return Plane(self.origin, self.x_dir, -self.z_dir)
 
     @overload
-    def __mul__(self, other: Location) -> Plane: ...
+    def __mul__(self, other: Location | Plane) -> Location: ...
     @overload
-    def __mul__(self, other: Iterable[Location]) -> list[Plane]: ...
-    def __mul__(self, other: Location | Iterable[Location]) -> Plane | list[Plane]:
+    def __mul__(self, other: Iterable[Location | Plane]) -> list[Location]: ...
+    def __mul__(
+        self, other: Location | Plane | Iterable[Location | Plane]
+    ) -> Location | list[Location]:
         if isinstance(other, Location):
-            return Plane(self.location * other)
+            return Location(self) * other
+        if isinstance(other, Plane):
+            return Location(self) * other.location
         try:
             others = list(other)
-            if all(isinstance(o, Location) for o in others):
-                return [self * loc for loc in others]
+            if all(isinstance(other, Location | Plane) for other in others):
+                return [
+                    Location(self)
+                    * (other.location if isinstance(other, Plane) else other)
+                    for other in others
+                ]
         except TypeError:  # not iterable
             pass
-        return NotImplemented  # will try Shape.__rmul__ for shapes
+        return NotImplemented  # will try __rmul__ on other
+
+    @overload
+    def __rmul__(self, other: Location) -> Plane: ...
+    @overload
+    def __rmul__(self, other: Iterable[Location | Plane]) -> list[Plane]: ...
+    def __rmul__(
+        self, other: Location | Plane | Iterable[Location | Plane]
+    ) -> Plane | list[Plane]:
+        if isinstance(other, Location | Plane):
+            return self.move(other)
+        try:
+            others = list(other)
+            if any(not isinstance(other, Location | Plane) for other in others):
+                raise ValueError("Planes can only be multiplied by locations or planes")
+            return [self.move(loc) for loc in others]
+        except TypeError:  # not iterable
+            pass
+        raise TypeError()
 
     def __and__(self: Plane, other: Axis | Location | Plane | VectorLike | Shape):
         """intersect plane with other &"""
@@ -3151,18 +3177,19 @@ class Plane(metaclass=PlaneMeta):
 
         return Plane(self._origin, new_x_dir, new_z_dir)
 
-    def move(self, loc: Location) -> Plane:
-        """Change the position & orientation of self by applying a relative location
+    # TODO should be called `moved` as it makes a new Plane?
+    def move(self, loc: Location | Plane) -> Plane:
+        """Change the position & orientation of a copy of self by applying a relative location
 
         Args:
-            loc (Location): relative change
+            loc (Location | Plane): relative change
 
         Returns:
             Plane: relocated plane
         """
-        self_copy = copy_module.deepcopy(self)
-        self_copy.wrapped.Transform(loc.wrapped.Transformation())
-        return Plane(self_copy.wrapped)
+        if isinstance(loc, Plane):
+            loc = loc.location
+        return Plane(self.location * loc)
 
     def _calc_transforms(self):
         """Computes transformation matrices to convert between local and global coordinates."""

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -3480,7 +3480,7 @@ def to_align_offset(
 
 class NotAllLocationLikeError(TypeError):
     def __init__(self, wrong_types: Iterable[Type[Any]]) -> None:
-        super().__init__(", ".join(t.__name__ for t in set(wrong_types)))
+        super().__init__(", ".join(sorted(t.__name__ for t in set(wrong_types))))
 
 
 def all_location_like(items: Iterable[Any]) -> list[Location | Plane]:

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -42,7 +42,7 @@ import logging
 import warnings
 from collections.abc import Callable, Iterable, Sequence
 from math import degrees, isclose, log10, pi, prod, radians
-from typing import TYPE_CHECKING, Any, TypeAlias, overload
+from typing import TYPE_CHECKING, Any, Type, TypeAlias, cast, overload
 
 import numpy as np
 import webcolors  # type: ignore
@@ -3049,12 +3049,14 @@ class Plane(metaclass=PlaneMeta):
         if isinstance(other, Location | Plane):
             return self.moved(other)
         try:
-            others = list(other)
-            if all(isinstance(other, Location | Plane) for other in others):
-                return [self.moved(loc) for loc in others]
+            return [self.moved(loc) for loc in all_location_like(other)]
+        except NotAllLocationLikeError as e:
+            raise TypeError(f"{type(self).__name__} cannot be multiplied by {e}")
         except TypeError:  # not iterable
             pass
-        raise TypeError("Planes can only be multiplied by locations or planes")
+        raise TypeError(
+            f"{type(self).__name__} cannot be multiplied by {type(other).__name__}"
+        )
 
     def __and__(self: Plane, other: Axis | Location | Plane | VectorLike | Shape):
         """intersect plane with other &"""
@@ -3474,3 +3476,23 @@ def to_align_offset(
         elif alignment == Align.NONE:
             align_offset.append(0)
     return Vector(*align_offset)
+
+
+class NotAllLocationLikeError(TypeError):
+    def __init__(self, wrong_types: Iterable[Type[Any]]) -> None:
+        super().__init__(", ".join(t.__name__ for t in set(wrong_types)))
+
+
+def all_location_like(items: Iterable[Any]) -> list[Location | Plane]:
+    """Returns the items as a list unless any of them is not an instance of `Location | Plane`.
+    Otherwise raises `NotAllLocationLikeError`."""
+    items = list(items)
+
+    if wrong_types := set(
+        cast(Type[Any], type(item))
+        for item in items
+        if not isinstance(item, Location | Plane)
+    ):
+        raise NotAllLocationLikeError(wrong_types)
+    else:
+        return items

--- a/src/build123d/topology/shape_core.py
+++ b/src/build123d/topology/shape_core.py
@@ -2881,7 +2881,7 @@ class ShapeList(list[T]):
                     plane_xyz = tcast(
                         gp_XYZ,
                         (
-                            tcast(Plane, plane * Location(shape.location).inverse())
+                            tcast(Plane, Location(shape.location).inverse() * plane)
                         ).z_dir.wrapped.XYZ(),
                     )
                     t_edge = tcast(BRep_TEdge, shape.wrapped.TShape())

--- a/src/build123d/topology/shape_core.py
+++ b/src/build123d/topology/shape_core.py
@@ -143,10 +143,12 @@ from build123d.geometry import (
     ColorLike,
     Location,
     Matrix,
+    NotAllLocationLikeError,
     OrientedBoundBox,
     Plane,
     Vector,
     VectorLike,
+    all_location_like,
     logger,
 )
 
@@ -1012,12 +1014,14 @@ class Shape(NodeMixin, Generic[TOPODS]):
         if isinstance(other, Location | Plane):
             return self.moved(other)
         try:
-            others = list(other)
-            if all(isinstance(o, Location | Plane) for o in others):
-                return [self.moved(other) for other in others]
+            return [self.moved(loc) for loc in all_location_like(other)]
+        except NotAllLocationLikeError as e:
+            raise TypeError(f"{type(self).__name__} cannot be multiplied by {e}")
         except TypeError:  # not iterable
             pass
-        raise ValueError("shapes can only be multiplied by locations or planes")
+        raise TypeError(
+            f"{type(self).__name__} cannot be multiplied by {type(other).__name__}"
+        )
 
     def __sub__(self, other: None | Shape | Iterable[Shape]) -> Self | Compound:
         """cut shape from self operator -"""

--- a/src/build123d/topology/three_d.py
+++ b/src/build123d/topology/three_d.py
@@ -1294,7 +1294,7 @@ class Solid(Mixin3D[TopoDS_Solid]):
         if isinstance(bbox, BoundBox):
             return Solid.make_box(*bbox.size).locate(Location(bbox.min))
         else:
-            moved_plane: Plane = Plane(Location(-bbox.size / 2)).move(bbox.location)
+            moved_plane: Plane = Plane(Location(-bbox.size / 2)).moved(bbox.location)
             return Solid.make_box(
                 bbox.size.X, bbox.size.Y, bbox.size.Z, plane=moved_plane
             )

--- a/tests/test_algebra.py
+++ b/tests/test_algebra.py
@@ -762,9 +762,9 @@ class AlgebraTests(unittest.TestCase):
         self.assertEqual(s3._dim, 3)
         self.assertAlmostEqual(s3.volume, (16 - 1) * 4, 5)
 
-        split_cut = Solid.make_box(
-            4, 1, 1, Plane((-2, -0.5, -0.5))
-        ) - Solid.make_box(1, 2, 2, Plane((-0.5, -1, -1)))
+        split_cut = Solid.make_box(4, 1, 1, Plane((-2, -0.5, -0.5))) - Solid.make_box(
+            1, 2, 2, Plane((-0.5, -1, -1))
+        )
         self.assertTrue(isinstance(split_cut, Part))
         self.assertEqual(len(split_cut.solids()), 2)
         self.assertAlmostEqual(split_cut.volume, 3, 5)
@@ -917,7 +917,9 @@ class RightMultipleTests(unittest.TestCase):
         self.assertTupleAlmostEquals(c[0].position, (1, 2, 3), 6)
 
     def test_rmul_error(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(
+            TypeError, r"Circle cannot be multiplied by Vector"
+        ):
             [Vector(1, 2, 3)] * Circle(1)
 
 

--- a/tests/test_direct_api/test_plane.py
+++ b/tests/test_direct_api/test_plane.py
@@ -314,7 +314,7 @@ class TestPlane(unittest.TestCase):
         with self.assertRaises(TypeError):
             1 * p
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             (2, 3, 4) * p
 
     def test_plane_mul_locations(self):

--- a/tests/test_direct_api/test_plane.py
+++ b/tests/test_direct_api/test_plane.py
@@ -308,14 +308,14 @@ class TestPlane(unittest.TestCase):
 
     def test_plane_rmul_error(self):
         p = Plane.XY
-        with self.assertRaises(TypeError):
-            Vector(1, 1, 1) * p
 
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, r"Plane cannot be multiplied by int"):
             1 * p
 
-        with self.assertRaises(TypeError):
-            (2, 3, 4) * p
+        with self.assertRaisesRegex(
+            TypeError, r"Plane cannot be multiplied by float, int"
+        ):
+            (2, 3.3, 4) * p
 
     def test_plane_mul_locations(self):
         p = Plane.XY

--- a/tests/test_direct_api/test_plane.py
+++ b/tests/test_direct_api/test_plane.py
@@ -311,6 +311,9 @@ class TestPlane(unittest.TestCase):
         with self.assertRaises(TypeError):
             Vector(1, 1, 1) * p
 
+        with self.assertRaises(TypeError):
+            1 * p
+
         with self.assertRaises(ValueError):
             (2, 3, 4) * p
 

--- a/tests/test_direct_api/test_plane.py
+++ b/tests/test_direct_api/test_plane.py
@@ -280,19 +280,19 @@ class TestPlane(unittest.TestCase):
 
     def test_plane_mul_location(self):
         p = Plane(origin=(1, 2, 3), x_dir=(1, 0, 0), z_dir=(0, 0, 1))
-        p2 = p * Location((1, 2, -1), (0, 0, 45))
+        p2 = Location((1, 2, -1), (0, 0, 45)) * p
         self.assertAlmostEqual(p2.origin, (2, 4, 2), 6)
         self.assertAlmostEqual(p2.x_dir, (math.sqrt(2) / 2, math.sqrt(2) / 2, 0), 6)
         self.assertAlmostEqual(p2.y_dir, (-math.sqrt(2) / 2, math.sqrt(2) / 2, 0), 6)
         self.assertAlmostEqual(p2.z_dir, (0, 0, 1), 6)
 
-        p2 = p * Location((1, 2, -1), (0, 45, 0))
+        p2 = Location((1, 2, -1), (0, 45, 0)) * p
         self.assertAlmostEqual(p2.origin, (2, 4, 2), 6)
         self.assertAlmostEqual(p2.x_dir, (math.sqrt(2) / 2, 0, -math.sqrt(2) / 2), 6)
         self.assertAlmostEqual(p2.y_dir, (0, 1, 0), 6)
         self.assertAlmostEqual(p2.z_dir, (math.sqrt(2) / 2, 0, math.sqrt(2) / 2), 6)
 
-        p2 = p * Location((1, 2, -1), (45, 0, 0))
+        p2 = Location((1, 2, -1), (45, 0, 0)) * p
         self.assertAlmostEqual(p2.origin, (2, 4, 2), 6)
         self.assertAlmostEqual(p2.x_dir, (1, 0, 0), 6)
         self.assertAlmostEqual(p2.y_dir, (0, math.sqrt(2) / 2, math.sqrt(2) / 2), 6)
@@ -306,10 +306,35 @@ class TestPlane(unittest.TestCase):
         with self.assertRaises(TypeError):
             p * 2
 
+    def test_plane_rmul_error(self):
+        p = Plane.XY
+        with self.assertRaises(TypeError):
+            Vector(1, 1, 1) * p
+
+        with self.assertRaises(ValueError):
+            (2, 3, 4) * p
+
     def test_plane_mul_locations(self):
         p = Plane.XY
         l1, l2 = Pos(1, 2, 3), Pos(4, 5, 6)
-        self.assertEqual(Plane.XY * (l1, l2), [p * l1, p * l2])
+        self.assertEqual(p * (l1, l2), [p * l1, p * l2])
+
+    def test_plane_mul_planes(self):
+        p = Plane.XY
+        p1, p2 = Plane.XZ.offset(1), Plane.ZY.offset(-2)
+        self.assertEqual(p * (p1, p2), [p * p1, p * p2])
+
+    def test_plane_rmul_locations(self):
+        p = Plane.XY
+        l1, l2 = Pos(1, 2, 3), Pos(4, 5, 6)
+        self.assertEqual((l1, l2) * p, [l1 * p, l2 * p])
+
+    def test_plane_rmul_planes(self):
+        """when multiplying multiple planes with a single plane,
+        the multiple planes are treated as locations"""
+        p = Plane.XY
+        p1, p2 = Plane.XZ.offset(1), Plane.ZY.offset(-2)
+        self.assertEqual((p1, p2) * p, [Location(p1) * p, Location(p2) * p])
 
     def test_plane_mul_shape(self):
         p = Plane.XY.offset(2)

--- a/tests/test_direct_api/test_plane.py
+++ b/tests/test_direct_api/test_plane.py
@@ -458,8 +458,8 @@ class TestPlane(unittest.TestCase):
         with self.assertRaises(TypeError):
             Plane.XY.shift_origin(Edge.make_line((0, 0), (1, 1)))
 
-    def test_move(self):
-        pln = Plane.XY.move(Location((1, 2, 3)))
+    def test_moved(self):
+        pln = Plane.XY.moved(Location((1, 2, 3)))
         self.assertAlmostEqual(pln.origin, (1, 2, 3), 5)
 
     def test_rotated(self):

--- a/tests/test_direct_api/test_shape.py
+++ b/tests/test_direct_api/test_shape.py
@@ -682,9 +682,16 @@ class TestShape(unittest.TestCase):
         translated_line = line.translate((0, 1, 0))
         self.assertIsNone(translated_line._wrapped)
 
-    def test_mul_non_iterable_non_location(self):
+    def test_rmul_iterable_non_location(self):
         line = Edge.make_line((0, 0), (1, 0))
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(
+            TypeError, r"Edge cannot be multiplied by float, str"
+        ):
+            x = (Pos(), "abc", 1.2) * line
+
+    def test_rmul_non_iterable_non_location(self):
+        line = Edge.make_line((0, 0), (1, 0))
+        with self.assertRaisesRegex(TypeError, r"Edge cannot be multiplied by int"):
             x = 3 * line
 
 


### PR DESCRIPTION
this PR reworks `Plane` multiplication so that it behaves similarly to `Shapes`'s, as per recent discussion on Discord.

The intentional breaking change here is that to apply a location to a plane and get a moved plane, one now has to do `location * plane` (same as `location * shape` to get a moved shape) instead of `plane * location` (which now results in a location)

with this PR:
<img width="519" height="199" alt="image" src="https://github.com/user-attachments/assets/36af52ac-9990-41b2-beb5-15af07ece8ad" />

without this PR:
<img width="519" height="199" alt="image" src="https://github.com/user-attachments/assets/2d390242-1686-484c-af2d-7c1b014ac3e8" />