### PR TITLE
change `.wrapped` attrs to read-only props

### DIFF
--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -637,24 +637,23 @@ class Axis(metaclass=AxisMeta):
     _dim = 1
 
     @overload
-    def __init__(self, gp_ax1: gp_Ax1):
+    def __init__(self, gp_ax1: gp_Ax1) -> None:
         """Axis: point and direction"""
 
     @overload
-    def __init__(self, location: Location):
+    def __init__(self, location: Location) -> None:
         """Axis from location"""
 
     @overload
-    def __init__(self, origin: VectorLike, direction: VectorLike):
+    def __init__(self, origin: VectorLike, direction: VectorLike) -> None:
         """Axis: point and direction"""
 
     @overload
-    def __init__(self, edge: Edge):
+    def __init__(self, edge: Edge) -> None:
         """Axis: start of Edge"""
 
-    def __init__(
-        self, *args, **kwargs
-    ):  # pylint: disable=too-many-branches, too-many-locals
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        # pylint: disable=too-many-branches, too-many-locals
 
         gp_ax1 = kwargs.pop("gp_ax1", None)
         origin = kwargs.pop("origin", None)
@@ -714,7 +713,11 @@ class Axis(metaclass=AxisMeta):
         elif not isinstance(gp_ax1, gp_Ax1):
             raise ValueError(f"Invalid Axis parameter: {gp_ax1}")
 
-        self.wrapped: gp_Ax1 = gp_ax1  # type: ignore[annotation-unchecked]
+        self._wrapped: gp_Ax1 = gp_ax1
+
+    @property
+    def wrapped(self):
+        return self._wrapped
 
     @property
     def position(self) -> Vector:
@@ -785,9 +788,7 @@ class Axis(metaclass=AxisMeta):
 
     def located(self, new_location: Location):
         """relocates self to a new location possibly changing position and direction"""
-        if self.wrapped is None:
-            raise ValueError("Can't located empty Axis")
-        top_location: TopLoc_Location = new_location.wrapped  # type: ignore[has-type]
+        top_location = new_location.wrapped
         self_gp_ax1: gp_Ax1 = self.wrapped
         new_gp_ax1: gp_Ax1 = self_gp_ax1.Transformed(top_location.Transformation())
         return Axis(new_gp_ax1)
@@ -1653,19 +1654,21 @@ class Location:
     }
 
     @overload
-    def __init__(self):
+    def __init__(self) -> None:
         """Location with no position or orientation"""
 
     @overload
-    def __init__(self, location: Location):
+    def __init__(self, location: Location) -> None:
         """Location from Location"""
 
     @overload
-    def __init__(self, position: VectorLike, angle: float = 0):
+    def __init__(self, position: VectorLike, angle: float = 0) -> None:
         """Location from position and rotation around z-axis by optional angle"""
 
     @overload
-    def __init__(self, position: VectorLike, orientation: RotationLike | None = None):
+    def __init__(
+        self, position: VectorLike, orientation: RotationLike | None = None
+    ) -> None:
         """Location from position and optional orientation (see Rotation class)"""
 
     @overload
@@ -1674,34 +1677,35 @@ class Location:
         position: VectorLike,
         orientation: RotationLike,
         ordering: Extrinsic | Intrinsic,
-    ):
+    ) -> None:
         """Location from position and optional orientation (see Rotation class).
         Orientation determined by optional ordering, defaults to Intrinsic.XYZ
         """
 
     @overload
-    def __init__(self, plane: Plane):
+    def __init__(self, plane: Plane) -> None:
         """Location from location of Plane."""
 
     @overload
-    def __init__(self, plane: Plane, plane_offset: VectorLike):
+    def __init__(self, plane: Plane, plane_offset: VectorLike) -> None:
         """Location from location of Plane translated by plane_offset"""
 
     @overload
-    def __init__(self, top_loc: TopLoc_Location):
+    def __init__(self, top_loc: TopLoc_Location) -> None:
         """Location from low-level TopLoc_Location object"""
 
     @overload
-    def __init__(self, gp_trsf: gp_Trsf):
+    def __init__(self, gp_trsf: gp_Trsf) -> None:
         """Location from low-level gp_Trsf object"""
 
     @overload
-    def __init__(self, position: VectorLike, direction: VectorLike, angle: float):
+    def __init__(
+        self, position: VectorLike, direction: VectorLike, angle: float
+    ) -> None:
         """Location from position and rotation around direction by angle"""
 
-    def __init__(
-        self, *args, **kwargs
-    ):  # pylint: disable=too-many-branches, too-many-locals, too-many-statements
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        # pylint: disable=too-many-branches, too-many-locals, too-many-statements
 
         self.location_index = 0
 
@@ -1754,7 +1758,7 @@ class Location:
         # Construct transformation
         trsf = gp_Trsf()
 
-        if plane:
+        if isinstance(plane, Plane):
             cs = gp_Ax3(
                 plane.origin.to_pnt(),
                 plane.z_dir.to_dir(),
@@ -1763,7 +1767,7 @@ class Location:
             trsf.SetTransformation(cs)
             trsf.Invert()
 
-        elif gp_trsf:
+        elif isinstance(gp_trsf, gp_Trsf):
             trsf = gp_trsf
 
         elif angle is not None:
@@ -1786,12 +1790,16 @@ class Location:
             trsf.SetTranslationPart(Vector(position).wrapped)
 
         # Final assignment based on input
-        if location is not None:
-            self.wrapped = location.wrapped
-        elif top_loc is not None:
-            self.wrapped = top_loc
+        if isinstance(location, Location):
+            self._wrapped = location.wrapped
+        elif isinstance(top_loc, TopLoc_Location):
+            self._wrapped = top_loc
         else:
-            self.wrapped = TopLoc_Location(trsf)
+            self._wrapped = TopLoc_Location(trsf)
+
+    @property
+    def wrapped(self) -> TopLoc_Location:
+        return self._wrapped
 
     @property
     def position(self) -> Vector:
@@ -1810,13 +1818,11 @@ class Location:
         Args:
             value (VectorLike): New position
         """
-        if self.wrapped is None:
-            raise ValueError("Can't determine position of empty Location")
         trsf_position = gp_Trsf()
         trsf_position.SetTranslationPart(Vector(value).wrapped)
         trsf_orientation = gp_Trsf()
         trsf_orientation.SetRotation(self.wrapped.Transformation().GetRotation())
-        self.wrapped = TopLoc_Location(trsf_position * trsf_orientation)
+        self._wrapped = TopLoc_Location(trsf_position * trsf_orientation)
 
     @property
     def orientation(self) -> Vector:
@@ -1848,7 +1854,7 @@ class Location:
         quaternion.SetEulerAngles(self._rot_order_dict[ordering], *rotation)
         trsf_orientation = gp_Trsf()
         trsf_orientation.SetRotation(quaternion)
-        self.wrapped = TopLoc_Location(trsf_position * trsf_orientation)
+        self._wrapped = TopLoc_Location(trsf_position * trsf_orientation)
 
     @property
     def x_axis(self) -> Axis:
@@ -1890,19 +1896,13 @@ class Location:
         self, other: Location | Iterable[Location]
     ) -> Location | list[Location]:
         """Combine locations"""
-        if self.wrapped is None:
-            raise ValueError("Cannot multiply empty location")
 
         if isinstance(other, Location):
-            if other.wrapped is None:
-                raise ValueError("Can't multiply by empty location")
             return Location(self.wrapped * other.wrapped)
 
         try:
             others = list(other)
             if all(isinstance(o, Location) for o in others):
-                if any(o.wrapped is None for o in others):
-                    raise ValueError("Can't multiply by empty Locations")
                 return [Location(self.wrapped * loc.wrapped) for loc in others]
         except TypeError:  # not iterable
             pass
@@ -2196,7 +2196,11 @@ class OrientedBoundBox:
             BRepBndLib.AddOBB_s(shape.wrapped, obb, True)
         else:
             raise TypeError(f"Expected Bnd_OBB or Shape, got {type(shape).__name__}")
-        self.wrapped = obb
+        self._wrapped = obb
+
+    @property
+    def wrapped(self):
+        return self._wrapped
 
     @property
     def corners(self) -> list[Vector]:
@@ -2243,8 +2247,6 @@ class OrientedBoundBox:
         Returns:
             float: The diagonal length.
         """
-        if self.wrapped is None:
-            return 0.0
         return self.wrapped.SquareExtent() ** 0.5
 
     @property
@@ -2348,8 +2350,6 @@ class OrientedBoundBox:
         Returns:
             bool: True if 'other' is completely inside this bounding box; otherwise, False.
         """
-        if other.wrapped is None:
-            raise ValueError("Can't compare to a null obb")
         return self.wrapped.IsCompletelyInside(other.wrapped)
 
     def is_outside(self, point: Vector) -> bool:
@@ -2368,8 +2368,6 @@ class OrientedBoundBox:
         Returns:
             bool: True if the point is completely outside the bounding box; otherwise, False.
         """
-        if point.wrapped is None:
-            raise ValueError("Can't compare to a null point")
         return self.wrapped.IsOut(point.to_pnt())
 
     def __repr__(self) -> str:

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -1734,17 +1734,17 @@ class Location:
             elif gp_trsf is None and isinstance(args[0], gp_Trsf):
                 gp_trsf = args[0]
             elif isinstance(args[0], (Vector, Iterable)):
-                position = Vector(args[0])
+                position = Vector(args[0])  # type: ignore
                 if len(args) > 1:
                     if isinstance(args[1], (Vector, Iterable)):
-                        orientation = Vector(args[1])
+                        orientation = Vector(args[1])  # type: ignore
                     elif isinstance(args[1], (int, float)):
                         angle = args[1]
                 if len(args) > 2:
                     if isinstance(args[1], (Vector, Iterable)) and isinstance(
                         args[2], (int, float)
                     ):
-                        direction = Vector(args[1])
+                        direction = Vector(args[1])  # type: ignore
                         angle = args[2]
                     elif isinstance(args[2], (Intrinsic, Extrinsic)):
                         ordering = args[2]

--- a/src/build123d/topology/shape_core.py
+++ b/src/build123d/topology/shape_core.py
@@ -1505,8 +1505,6 @@ class Shape(NodeMixin, Generic[TOPODS]):
         """
         if self._wrapped is None:
             raise ValueError("Cannot locate an empty shape")
-        if loc.wrapped is None:
-            raise ValueError("Cannot locate a shape at an empty location")
         self.wrapped.Location(loc.wrapped)
 
         return self
@@ -1524,10 +1522,8 @@ class Shape(NodeMixin, Generic[TOPODS]):
         """
         if self._wrapped is None:
             raise ValueError("Cannot locate an empty shape")
-        if loc.wrapped is None:
-            raise ValueError("Cannot locate a shape at an empty location")
-        shape_copy: Shape = copy.deepcopy(self, None)
-        shape_copy.wrapped.Location(loc.wrapped)  # type: ignore
+        shape_copy = copy.deepcopy(self, None)
+        shape_copy.wrapped.Location(loc.wrapped)
         return shape_copy
 
     def mesh(self, tolerance: float, angular_tolerance: float = 0.1):
@@ -1581,8 +1577,6 @@ class Shape(NodeMixin, Generic[TOPODS]):
         """
         if self._wrapped is None:
             raise ValueError("Cannot move an empty shape")
-        if loc.wrapped is None:
-            raise ValueError("Cannot move a shape at an empty location")
 
         self.wrapped.Move(loc.wrapped)
 
@@ -1603,8 +1597,6 @@ class Shape(NodeMixin, Generic[TOPODS]):
             loc = loc.location
         if self._wrapped is None:
             raise ValueError("Cannot move an empty shape")
-        if loc.wrapped is None:
-            raise ValueError("Cannot move a shape at an empty location")
         shape_copy: Shape = copy.deepcopy(self, None)
         shape_copy.wrapped = tcast(TOPODS, downcast(self.wrapped.Moved(loc.wrapped)))
         return shape_copy
@@ -1738,12 +1730,10 @@ class Shape(NodeMixin, Generic[TOPODS]):
         )
         if self._wrapped is None:
             raise ValueError("Cannot relocate an empty shape")
-        if loc.wrapped is None:
-            raise ValueError("Cannot relocate a shape at an empty location")
 
         if self.location != loc:
             old_ax = gp_Ax3()
-            old_ax.Transform(self.location.wrapped.Transformation())  # type: ignore
+            old_ax.Transform(self.location.wrapped.Transformation())
 
             new_ax = gp_Ax3()
             new_ax.Transform(loc.wrapped.Transformation())

--- a/tests/test_direct_api/test_location.py
+++ b/tests/test_direct_api/test_location.py
@@ -322,27 +322,6 @@ class TestLocation(unittest.TestCase):
         self.assertAlmostEqual(locs[0].position, (-1, 2, 0), 5)
         self.assertAlmostEqual(locs[1].position, (3, 2, 0), 5)
 
-    def test_mult_empty_self(self):
-        """not sure if it can actually happen but the code checks for it"""
-        empty_loc = Location()
-        empty_loc.wrapped = None
-        with self.assertRaises(ValueError):
-            x = empty_loc * Pos(1, 2, 3)
-
-    def test_mult_empty_other(self):
-        """not sure if it can actually happen but the code checks for it"""
-        empty_loc = Location()
-        empty_loc.wrapped = None
-        with self.assertRaises(ValueError):
-            x = Pos(1, 2, 3) * empty_loc
-
-    def test_mult_empty_any_others(self):
-        """not sure if it can actually happen but the code checks for it"""
-        some_empty_locs = [Location(), Location(), Location()]
-        some_empty_locs[1].wrapped = None
-        with self.assertRaises(ValueError):
-            x = Pos(1, 2, 3) * some_empty_locs
-
     def test_as_json(self):
         data_dict = {
             "part1": {

--- a/tests/test_direct_api/test_oriented_bound_box.py
+++ b/tests/test_direct_api/test_oriented_bound_box.py
@@ -52,9 +52,6 @@ class TestOrientedBoundBox(unittest.TestCase):
         expected_diag = math.sqrt(3)
         self.assertAlmostEqual(obb.diagonal, expected_diag, places=6)
 
-        obb.wrapped = None
-        self.assertAlmostEqual(obb.diagonal, 0.0, places=6)
-
     def test_center(self):
         # For a cube made at the origin, the center should be at (0.5, 0.5, 0.5)
         cube = Solid.make_box(1, 1, 1)
@@ -86,10 +83,6 @@ class TestOrientedBoundBox(unittest.TestCase):
         outside_point = Vector(10, 10, 10)
         self.assertTrue(obb.is_outside(outside_point))
 
-        outside_point._wrapped = None
-        with self.assertRaises(ValueError):
-            obb.is_outside(outside_point)
-
     def test_is_completely_inside(self):
         # Create a larger cube and a smaller cube that is centered within it.
         large_cube = Solid.make_box(2, 2, 2)
@@ -105,10 +98,6 @@ class TestOrientedBoundBox(unittest.TestCase):
         self.assertTrue(large_obb.is_completely_inside(small_obb))
         # Conversely, the larger box cannot be completely inside the smaller one.
         self.assertFalse(small_obb.is_completely_inside(large_obb))
-
-        large_obb.wrapped = None
-        with self.assertRaises(ValueError):
-            small_obb.is_completely_inside(large_obb)
 
     def test_init_from_bnd_obb(self):
         # Test that constructing from an already computed Bnd_OBB works as expected.

--- a/tests/test_direct_api/test_shape.py
+++ b/tests/test_direct_api/test_shape.py
@@ -579,22 +579,13 @@ class TestShape(unittest.TestCase):
         self.assertIs(empty, empty.transform_geometry(Matrix(translate_matrix)))
         with self.assertRaises(ValueError):
             empty.locate(Location())
-        empty_loc = Location()
-        empty_loc.wrapped = None
-        with self.assertRaises(ValueError):
-            box.locate(empty_loc)
+        
         with self.assertRaises(ValueError):
             empty.located(Location())
         with self.assertRaises(ValueError):
-            box.located(empty_loc)
-        with self.assertRaises(ValueError):
             empty.move(Location())
         with self.assertRaises(ValueError):
-            box.move(empty_loc)
-        with self.assertRaises(ValueError):
             empty.moved(Location())
-        with self.assertRaises(ValueError):
-            box.moved(empty_loc)
         # with self.assertRaises(ValueError):
         #     empty.relocate(Location())
         # with self.assertRaises(ValueError):
@@ -605,8 +596,6 @@ class TestShape(unittest.TestCase):
             empty.distance_to_with_closest_points(Vector(1, 1, 1))
         with self.assertRaises(ValueError):
             empty.distance_to(Vector(1, 1, 1))
-        with self.assertRaises(AttributeError):
-            box.intersect(empty_loc)
         self.assertEqual(empty._ocp_section(Vertex(1, 1, 1)), ([], []))
         self.assertEqual(empty.faces_intersected_by_axis(Axis.Z), ShapeList())
         with self.assertRaises(ValueError):
@@ -623,15 +612,9 @@ class TestShape(unittest.TestCase):
             empty.tessellate(0.001)
         with self.assertRaises(ValueError):
             empty.to_splines()
-        empty_axis = Axis((0, 0, 0), (1, 0, 0))
-        empty_axis.wrapped = None
-        with self.assertRaises(ValueError):
-            box.vertices().group_by(empty_axis)
         empty_wire = Wire()
         with self.assertRaises(ValueError):
             box.vertices().group_by(empty_wire)
-        with self.assertRaises(ValueError):
-            box.vertices().sort_by(empty_axis)
         with self.assertRaises(ValueError):
             box.vertices().sort_by(empty_wire)
 


### PR DESCRIPTION
Change the public `.wrapped` attribute to a private `._wrapped` attribute and add a `.wrapped` read-only property to the following classes: `Axis`, `Location`, `OrientedBoundBox`.

This improves the type checking and removes the need for handling and testing of a bunch of unnecessary `.wrapped is None`.


I'm planning on also cleaning up the `Plane` class but I'll do that in a _separate_ PR _after_ #1282 is merged