### PR TITLE
drop stateful `__iter__` implementations

### DIFF
--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -878,9 +878,6 @@ class LocationList:
     def __init__(self, locations: list[Location]):
         self._reset_tok = None
         self.local_locations = locations
-        self.location_index = 0
-        self.plane_index = 0
-        self.iter_loc = None
 
     def __enter__(self):
         """Upon entering create a token to restore contextvars"""
@@ -902,18 +899,7 @@ class LocationList:
         )
 
     def __iter__(self):
-        """Initialize to beginning"""
-        self.location_index = 0
-        self.iter_loc = self.locations
-        return self
-
-    def __next__(self):
-        """While not through all the locations, return the next one"""
-        if self.location_index >= len(self.iter_loc):
-            raise StopIteration
-        result = self.iter_loc[self.location_index]
-        self.location_index += 1
-        return result
+        return iter(self.locations)
 
     @classmethod
     def _get_context(cls):
@@ -1249,7 +1235,6 @@ class WorkplaneList:
         self._reset_tok = None
         self.workplanes = WorkplaneList._convert_to_planes(workplanes)
         self.locations_context = None
-        self.plane_index = 0
 
     @staticmethod
     def _convert_to_planes(objs: Iterable[Face | Plane | Location]) -> list[Plane]:
@@ -1286,17 +1271,7 @@ class WorkplaneList:
         )
 
     def __iter__(self):
-        """Initialize to beginning"""
-        self.plane_index = 0
-        return self
-
-    def __next__(self):
-        """While not through all the workplanes, return the next one"""
-        if self.plane_index >= len(self.workplanes):
-            raise StopIteration
-        result = self.workplanes[self.plane_index]
-        self.plane_index += 1
-        return result
+        return iter(self.workplanes)
 
     @classmethod
     def _get_context(cls):

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -220,24 +220,7 @@ class Vector:
         self._wrapped = ocp_vec
 
     def __iter__(self):
-        """Initialize to beginning"""
-        self.vector_index = 0
-        return self
-
-    def __next__(self):
-        """return the next value"""
-        if self.vector_index == 0:
-            self.vector_index += 1
-            value = self.X
-        elif self.vector_index == 1:
-            self.vector_index += 1
-            value = self.Y
-        elif self.vector_index == 2:
-            self.vector_index += 1
-            value = self.Z
-        else:
-            raise StopIteration
-        return value
+        return iter((self.X, self.Y, self.Z))
 
     @property
     def X(self) -> float:
@@ -1305,7 +1288,6 @@ class Color:
 
     def __init__(self, *args, **kwargs):
         self.wrapped = None
-        self.iter_index = 0
         red, green, blue, alpha, name, color_code = (1.0, 1.0, 1.0, 1.0, None, None)
         default_rgb = (red, green, blue, alpha)
 
@@ -1403,20 +1385,9 @@ class Color:
             self.wrapped = Quantity_ColorRGBA(the_color, alpha)
 
     def __iter__(self):
-        """Initialize to beginning"""
-        self.iter_index = 0
-        return self
-
-    def __next__(self):
-        """return the next value"""
         r, g, b = self.wrapped.GetRGB().Values(Quantity_TypeOfColor.Quantity_TOC_sRGB)
         rgb_tuple = (r, g, b, self.wrapped.Alpha())
-
-        if self.iter_index > 3:
-            raise StopIteration
-        value = rgb_tuple[self.iter_index]
-        self.iter_index += 1
-        return round(value, 7)
+        return (round(value, 7) for value in rgb_tuple)
 
     def __copy__(self) -> Color:
         """Return copy of self"""
@@ -1702,9 +1673,6 @@ class Location:
     def __init__(
         self, *args, **kwargs
     ):  # pylint: disable=too-many-branches, too-many-locals, too-many-statements
-
-        self.location_index = 0
-
         position = kwargs.pop("position", None)
         orientation = kwargs.pop("orientation", None)
         direction = kwargs.pop("direction", None)
@@ -1950,28 +1918,14 @@ class Location:
         )
 
     def __iter__(self):
-        """Initialize to beginning"""
-        self.location_index = 0
-        return self
-
-    def __next__(self) -> Vector:
-        """return the next value"""
         transformation = self.wrapped.Transformation()
         trans = transformation.TranslationPart()
         rot = transformation.GetRotation()
-        rv_trans: Vector = Vector(trans.X(), trans.Y(), trans.Z())
-        rv_rot: Vector = Vector(
-            *[degrees(a) for a in rot.GetEulerAngles(gp_EulerSequence.gp_Intrinsic_XYZ)]
+        rv_trans: Vector = Vector(trans)
+        rv_rot = Vector(
+            map(degrees, rot.GetEulerAngles(gp_EulerSequence.gp_Intrinsic_XYZ))
         )  # type: ignore[assignment]
-        if self.location_index == 0:
-            self.location_index += 1
-            value = rv_trans
-        elif self.location_index == 1:
-            self.location_index += 1
-            value = rv_rot
-        else:
-            raise StopIteration
-        return value
+        return iter((rv_trans, rv_rot))
 
     def __neg__(self) -> Location:
         """Flip the orientation without changing the position operator -"""

--- a/src/build123d/topology/zero_d.py
+++ b/src/build123d/topology/zero_d.py
@@ -104,8 +104,6 @@ class Vertex(Shape[TopoDS_Vertex]):
         """Vertex from Vector or other iterators"""
 
     def __init__(self, *args, **kwargs):
-        self.vertex_index = 0
-
         ocp_vx = kwargs.pop("ocp_vx", None)
         v = kwargs.pop("v", None)
         x = kwargs.pop("X", 0)
@@ -252,23 +250,7 @@ class Vertex(Shape[TopoDS_Vertex]):
 
     def __iter__(self):
         """Initialize to beginning"""
-        self.vertex_index = 0
-        return self
-
-    def __next__(self):
-        """return the next value"""
-        if self.vertex_index == 0:
-            self.vertex_index += 1
-            value = self.X
-        elif self.vertex_index == 1:
-            self.vertex_index += 1
-            value = self.Y
-        elif self.vertex_index == 2:
-            self.vertex_index += 1
-            value = self.Z
-        else:
-            raise StopIteration
-        return value
+        return iter((self.X, self.Y, self.Z))
 
     def __repr__(self) -> str:
         """To String


### PR DESCRIPTION
Refactor `__iter__` implementations by returning an iterator to the underlying structures instead of managing the state internally in order to simplify the code.

(Unless there's an unstated and untested reason to do it the stateful way, in which case let me know)