### PR TITLE
Improve github action security, Change testing workflow matrix, Add linux-aarch64 to benchmark and test workflows

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Python
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b #v8.1.0
       with:
         enable-cache: false
         python-version: ${{ env.PYTHON_INPUT_VER }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,8 +1,12 @@
 name: benchmarks
 
 on: [push, pull_request, workflow_dispatch]
-jobs:
 
+permissions:
+  contents: read
+  actions: write
+
+jobs:
   benchmarks:
     strategy:
       fail-fast: false
@@ -10,11 +14,13 @@ jobs:
         python-version: [
           "3.12",
           ]
-        os: [macos-15-intel, macos-14, ubuntu-latest, windows-latest]
+        os: [macos-15-intel, macos-14, ubuntu-latest, windows-latest, ubuntu-24.04-arm]
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup/
         with:
           python-version: ${{ matrix.python-version }}
@@ -24,7 +30,7 @@ jobs:
           python -m pytest --benchmark-only --benchmark-autosave
           pytest-benchmark compare --csv="results.csv"
           cat results.csv
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
           name: benchmark-results-${{ matrix.os }}
           path: results.csv

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,11 +1,19 @@
 name: Upload coverage reports to Codecov
+
 on: [push, pull_request]
+
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   run:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup
         uses: ./.github/actions/setup/
         with:
@@ -14,4 +22,4 @@ jobs:
       - name: Run tests and collect coverage
         run: pytest --cov=build123d
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: pylint
 
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   lint:
     strategy:
@@ -8,7 +12,9 @@ jobs:
         python-version: [ "3.10" ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,17 +2,22 @@ name: Wheel building and publishing
 
 on: [push, pull_request, workflow_dispatch] # TODO: update this later
 
+permissions: {}
+
 jobs:
   build_wheel:
     # This does the actual wheel building or if triggered manually via the workflow dispatch, or for a tag.
     # this job does NOT publish the wheel
     name: Build wheel on ubuntu-latest
     runs-on: ubuntu-latest
-    #if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      actions: write
     if: (github.repository == 'gumyr/build123d' && ( startsWith(github.ref, 'refs/tags/v'))) || github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0 # get all history for setuptools_scm
         
       - name: Build sdist and wheel
@@ -28,7 +33,7 @@ jobs:
           python3 -m pip freeze
           ls -lR
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
           path: ./wheelhouse/build123d*.* # store the build123d wheel and sdist
       
@@ -40,18 +45,17 @@ jobs:
       url: https://pypi.org/p/build123d
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
-    # if: github.event_name == 'release' && github.event.action == 'published'
     # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
     if: needs.build_wheel.result == 'success'
     #if: (github.repository == 'gumyr/build123d' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 #v7.0.0
         with:
           # unpacks default artifact into dist/
           # if `name: artifact` is omitted, the action will create extra parent dir
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b #v1.14.0
         # with: # for testing with test.pypi.org
           # To test: repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,21 +1,32 @@
 name: tests
 
 on: [push, pull_request, workflow_dispatch]
-jobs:
 
+permissions:
+  contents: read
+
+jobs:
   tests:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [
-          "3.10",
-          "3.14",
-          ]
-        os: [macos-15-intel, macos-14, ubuntu-latest, windows-latest]
+        python-version: ["3.14"]
+        os: [
+          macos-15-intel, 
+          macos-14, 
+          ubuntu-latest, 
+          windows-latest, 
+          ubuntu-24.04-arm
+        ]
+        include:
+          - python-version: "3.10"
+            os: ubuntu-latest
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup/
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/type.yml
+++ b/.github/workflows/type.yml
@@ -1,6 +1,10 @@
 name: Run type checking
 
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     strategy:
@@ -13,7 +17,9 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup
         uses: ./.github/actions/setup
         with:


### PR DESCRIPTION
1. Incorporate zizmor github action security recommendations. Main changes are to pin to actions commit hash, which helps prevent supply chain attacks on build123d. Also, made several updates to the PyPI publish workflow to restrict permissions -- as this would be the biggest target for attackers that would want to publish a malicious build123d package.
2. Test all platforms on python 3.14, one test on 3.10 + linux-x86_64. Reason behind this change is that adding linux-aarch64 meant we would now run 10 test runs. With this change it is down to 6 and should not compromise breadth of testing. (Apart from stochastic failures, we have not seen significant platform-dependent behavior differences when comparing python 3.10 to 3.14.)
3. Add linux-aarch64 to benchmark and test workflows. This is part of promoting this platform to an officially supported build123d platform for the next release.