### PR TITLE
use `@deprecated` for methods and classes

### DIFF
--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -45,6 +45,7 @@ from math import degrees, isclose, log10, pi, prod, radians
 from typing import TYPE_CHECKING, Any, Type, TypeAlias, cast, overload
 
 import numpy as np
+from typing_extensions import deprecated
 import webcolors  # type: ignore
 from OCP.Bnd import Bnd_Box, Bnd_OBB
 from OCP.BRep import BRep_Tool
@@ -274,14 +275,12 @@ class Vector:
         """OCCT object"""
         return self._wrapped
 
+    @deprecated(
+        "to_tuple is deprecated and will be removed in a future version. "
+        " Use 'tuple(Vector)' instead."
+    )
     def to_tuple(self) -> tuple[float, float, float]:
         """Return tuple equivalent"""
-        warnings.warn(
-            "to_tuple is deprecated and will be removed in a future version. "
-            "Use 'tuple(Vector)' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         return (self.X, self.Y, self.Z)
 
     @property
@@ -792,14 +791,12 @@ class Axis(metaclass=AxisMeta):
         new_gp_ax1: gp_Ax1 = self_gp_ax1.Transformed(top_location.Transformation())
         return Axis(new_gp_ax1)
 
+    @deprecated(
+        "to_tuple is deprecated and will be removed in a future version. "
+        " Use 'Plane(Axis)' instead."
+    )
     def to_plane(self) -> Plane:
         """Return self as Plane"""
-        warnings.warn(
-            "to_tuple is deprecated and will be removed in a future version. "
-            "Use 'Plane(Axis)' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         return Plane(origin=self.position, z_dir=self.direction)
 
     def is_coaxial(
@@ -2027,26 +2024,20 @@ class Location:
 
         return Location(Plane(origin=pos, x_dir=mx_dir, z_dir=mz_dir))
 
+    @deprecated(
+        "to_axis is deprecated and will be removed in a future version. "
+        " Use 'Axis(Location)' instead."
+    )
     def to_axis(self) -> Axis:
         """Convert the location into an Axis"""
-        warnings.warn(
-            "to_axis is deprecated and will be removed in a future version. "
-            "Use 'Axis(Location)' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         return Axis.Z.located(self)
 
+    @deprecated(
+        "to_tuple is deprecated and will be removed in a future version. "
+        " Use 'tuple(Location)' instead."
+    )
     def to_tuple(self) -> tuple[tuple[float, float, float], tuple[float, float, float]]:
         """Convert the location to a translation, rotation tuple."""
-
-        warnings.warn(
-            "to_tuple is deprecated and will be removed in a future version. "
-            "Use 'tuple(Location)' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
         transformation = self.wrapped.Transformation()
         trans = transformation.TranslationPart()
         rot = transformation.GetRotation()

--- a/src/build123d/objects_curve.py
+++ b/src/build123d/objects_curve.py
@@ -37,6 +37,7 @@ from itertools import product
 from math import atan2, copysign, cos, degrees, radians, sin, sqrt
 from scipy.optimize import minimize
 from typing import overload, Literal
+from typing_extensions import deprecated
 
 from build123d.build_common import WorkplaneList, flatten_sequence, validate_inputs
 from build123d.build_enums import (
@@ -2168,6 +2169,10 @@ class ThreePointArc(BaseEdgeObject):
         super().__init__(arc, mode=mode)
 
 
+@deprecated(
+    "The 'PointArcTangentLine' object is deprecated and will be removed in a future version."
+    " Use ConstrainedLines instead."
+)
 class PointArcTangentLine(BaseEdgeObject):
     """Line Object: Point Arc Tangent Line
 
@@ -2190,13 +2195,6 @@ class PointArcTangentLine(BaseEdgeObject):
         side: Side = Side.LEFT,
         mode: Mode = Mode.ADD,
     ):
-        warnings.warn(
-            "The 'PointArcTangentLine' object is deprecated and will be removed in a future version."
-            " Use ConstrainedLines instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
         side_sign = {
             Side.LEFT: -1,
             Side.RIGHT: 1,
@@ -2247,6 +2245,10 @@ class PointArcTangentLine(BaseEdgeObject):
         super().__init__(tangent, mode)
 
 
+@deprecated(
+    "The 'PointArcTangentArc' object is deprecated and will be removed in a future version."
+    " Use ConstrainedArcs instead."
+)
 class PointArcTangentArc(BaseEdgeObject):
     """Line Object: Point Arc Tangent Arc
 
@@ -2276,13 +2278,6 @@ class PointArcTangentArc(BaseEdgeObject):
         side: Side = Side.LEFT,
         mode: Mode = Mode.ADD,
     ):
-        warnings.warn(
-            "The 'PointArcTangentArc' object is deprecated and will be removed in a future version."
-            " Use ConstrainedArcs instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
         context: BuildLine | None = BuildLine._get_context(self)
         validate_inputs(context, self)
 
@@ -2402,6 +2397,10 @@ class PointArcTangentArc(BaseEdgeObject):
         super().__init__(arc, mode=mode)
 
 
+@deprecated(
+    "The 'ArcArcTangentLine' object is deprecated and will be removed in a future version."
+    " Use ConstrainedLines instead."
+)
 class ArcArcTangentLine(BaseEdgeObject):
     """Line Object: Arc Arc Tangent Line
 
@@ -2427,13 +2426,6 @@ class ArcArcTangentLine(BaseEdgeObject):
         keep: Keep = Keep.INSIDE,
         mode: Mode = Mode.ADD,
     ):
-        warnings.warn(
-            "The 'ArcArcTangentLine' object is deprecated and will be removed in a future version."
-            " Use ConstrainedLines instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
         context: BuildLine | None = BuildLine._get_context(self)
         validate_inputs(context, self)
 
@@ -2499,6 +2491,10 @@ class ArcArcTangentLine(BaseEdgeObject):
         super().__init__(tangent, mode)
 
 
+@deprecated(
+    "The 'ArcArcTangentArc' object is deprecated and will be removed in a future version."
+    " Use ConstrainedArcs instead."
+)
 class ArcArcTangentArc(BaseEdgeObject):
     """Line Object: Arc Arc Tangent Arc
 
@@ -2535,12 +2531,6 @@ class ArcArcTangentArc(BaseEdgeObject):
         short_sagitta: bool = True,
         mode: Mode = Mode.ADD,
     ):
-        warnings.warn(
-            "The 'ArcArcTangentArc' object is deprecated and will be removed in a future version."
-            " Use ConstrainedArcs instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         keep_placement, keep_type = (keep, keep) if isinstance(keep, Keep) else keep
 
         context: BuildLine | None = BuildLine._get_context(self)

--- a/src/build123d/topology/one_d.py
+++ b/src/build123d/topology/one_d.py
@@ -211,7 +211,7 @@ from OCP.TopTools import (
 )
 from scipy.optimize import minimize_scalar
 from scipy.spatial import ConvexHull
-from typing_extensions import Self
+from typing_extensions import Self, deprecated
 
 from build123d.build_enums import (
     AngularDirection,
@@ -3214,28 +3214,24 @@ class Edge(Mixin1D[TopoDS_Edge]):
             reversed_edge.wrapped = TopoDS.Edge(self.wrapped.Reversed())
         return reversed_edge
 
+    @deprecated(
+        "to_axis is deprecated and will be removed in a future version. "
+        " Use 'Axis(Edge)' instead."
+    )
     def to_axis(self) -> Axis:
         """Translate a linear Edge to an Axis"""
-        warnings.warn(
-            "to_axis is deprecated and will be removed in a future version. "
-            "Use 'Axis(Edge)' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         if self.geom_type != GeomType.LINE:
             raise ValueError(
                 f"to_axis is only valid for linear Edges not {self.geom_type}"
             )
         return Axis(self.position_at(0), self.position_at(1) - self.position_at(0))
 
+    @deprecated(
+        "to_wire is deprecated and will be removed in a future version. "
+        " Use 'Wire(Edge)' instead."
+    )
     def to_wire(self) -> Wire:
         """Edge as Wire"""
-        warnings.warn(
-            "to_wire is deprecated and will be removed in a future version. "
-            "Use 'Wire(Edge)' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         return Wire([self])
 
     def trim(self, start: float | VectorLike, end: float | VectorLike) -> Edge:
@@ -4526,14 +4522,12 @@ class Wire(Mixin1D[TopoDS_Wire]):
 
         return Edge(edge_builder.Edge())
 
+    @deprecated(
+        "to_wire is deprecated and will be removed in a future version. "
+        " Use 'Wire(Wire)' instead."
+    )
     def to_wire(self) -> Wire:
         """Return Wire - used as a pair with Edge.to_wire when self is Wire | Edge"""
-        warnings.warn(
-            "to_wire is deprecated and will be removed in a future version. "
-            "Use 'Wire(Wire)' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         return self
 
     def trim(self: Wire, start: float | VectorLike, end: float | VectorLike) -> Wire:

--- a/src/build123d/topology/shape_core.py
+++ b/src/build123d/topology/shape_core.py
@@ -131,7 +131,7 @@ from OCP.TopTools import (
     TopTools_ListOfShape,
     TopTools_SequenceOfShape,
 )
-from typing_extensions import Self
+from typing_extensions import Self, deprecated
 
 from build123d.build_enums import CenterOf, GeomType, Keep, SortBy, Transition
 from build123d.geometry import (
@@ -452,14 +452,12 @@ class Shape(NodeMixin, Generic[TOPODS]):
         return self._wrapped is None or self.wrapped.IsNull()
 
     @property
+    @deprecated(
+        "The 'is_planar_face' property is deprecated and will be removed in a future version."
+        " Use 'Face.is_planar' instead"
+    )
     def is_planar_face(self) -> bool:
         """Is the shape a planar face even though its geom_type may not be PLANE"""
-        warnings.warn(
-            "The ``is_planar_face`` property is deprecated and will be removed in a future version."
-            "Use ``Face.is_planar`` instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         if self._wrapped is None or not isinstance(self.wrapped, TopoDS_Face):
             return False
         surface = BRep_Tool.Surface_s(self.wrapped)

--- a/src/build123d/topology/two_d.py
+++ b/src/build123d/topology/two_d.py
@@ -129,7 +129,7 @@ from OCP.TopoDS import (
 )
 from OCP.TopTools import TopTools_IndexedDataMapOfShapeListOfShape, TopTools_ListOfShape
 from ocp_gordon import interpolate_curve_network
-from typing_extensions import Self
+from typing_extensions import Self, deprecated
 
 from build123d.build_enums import (
     CenterOf,
@@ -1291,17 +1291,14 @@ class Face(Mixin2D[TopoDS_Face]):
         )
 
     @classmethod
+    @deprecated(
+        "The 'make_plane' method is deprecated and will be removed in a future version."
+    )
     def make_plane(
         cls,
         plane: Plane = Plane.XY,
     ) -> Face:
         """Create a unlimited size Face aligned with plane"""
-        warnings.warn(
-            "The 'make_plane' method is deprecated and will be removed in a future version.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
         pln_shape = BRepBuilderAPI_MakeFace(plane.wrapped).Face()
         return cls(pln_shape)
 
@@ -2232,6 +2229,9 @@ class Face(Mixin2D[TopoDS_Face]):
                 projected_shapes.append(shape)
         return projected_shapes
 
+    @deprecated(
+        "The 'to_arcs' method is deprecated and will be removed in a future version."
+    )
     def to_arcs(self, tolerance: float = 1e-3) -> Face:
         """to_arcs
 
@@ -2247,11 +2247,6 @@ class Face(Mixin2D[TopoDS_Face]):
         Returns:
             Face: approximated face
         """
-        warnings.warn(
-            "The 'to_arcs' method is deprecated and will be removed in a future version.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         if self._wrapped is None:
             raise ValueError("Cannot approximate an empty shape")
 

--- a/src/build123d/topology/zero_d.py
+++ b/src/build123d/topology/zero_d.py
@@ -54,12 +54,11 @@ license:
 from __future__ import annotations
 
 import itertools
-import warnings
 
 from typing import overload, TYPE_CHECKING
 
 from collections.abc import Iterable
-from typing_extensions import Self
+from typing_extensions import Self, deprecated
 
 import OCP.TopAbs as ta
 from OCP.BRep import BRep_Tool
@@ -318,14 +317,9 @@ class Vertex(Shape[TopoDS_Vertex]):
         """split - not implemented"""
         raise NotImplementedError("Vertices cannot be split.")
 
+    @deprecated("Use 'tuple(Vertex)' instead.")
     def to_tuple(self) -> tuple[float, float, float]:
         """Return vertex as three tuple of floats"""
-        warnings.warn(
-            "to_tuple is deprecated and will be removed in a future version. "
-            "Use 'tuple(Vertex)' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         geom_point = BRep_Tool.Pnt_s(self.wrapped)
         return (geom_point.X(), geom_point.Y(), geom_point.Z())
 


### PR DESCRIPTION
Simplifies the code and allow typecheckers/IDE to see deprecated classes and methods before the script runs

<img width="1221" height="214" alt="image" src="https://github.com/user-attachments/assets/48df4830-79a5-44dc-8183-d002e25d632d" />
