### PR TITLE
export `Shape`

### DIFF
--- a/src/build123d/__init__.py
+++ b/src/build123d/__init__.py
@@ -149,6 +149,7 @@ __all__ = [
     "Rot",
     "Pos",
     "RotationLike",
+    "Shape",
     "ShapeList",
     "Axis",
     "Color",


### PR DESCRIPTION
Fixes an import warning for my fellow type-checking enthusiasts
<img width="963" height="84" alt="Screenshot From 2026-05-03 07-42-52" src="https://github.com/user-attachments/assets/af16896d-7ed1-4b75-812c-88fc4c6cecaf" />
