### PR TITLE
Modify fillet radius handling in one_d.py

### DIFF
--- a/src/build123d/topology/one_d.py
+++ b/src/build123d/topology/one_d.py
@@ -332,6 +332,9 @@ def _solve_wire_fillet_corner_chfi2d(
         corner.connected_edges[1].wrapped,
         Plane.XY.wrapped,
     )
+  
+    if not fillet_builder.Perform(radius):
+        radius -= 1e-11
 
     vertex_point = BRep_Tool.Pnt_s(corner.vertex.wrapped)
     if (


### PR DESCRIPTION
Adjust fillet radius before performing operation.
Addresses [#1296](https://github.com/gumyr/build123d/issues/1296) by reducing radius by 1e-11 to avoid ChFi2dFilletAlgo failure.