### PR TITLE
Avoid duplicate boolean clean passes

### DIFF
--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -451,6 +451,7 @@ class Builder(ABC, Generic[ShapeT]):
                     mode,
                 )
                 combined: Shape | list[Shape] | None
+                needs_clean = clean
                 if mode == Mode.ADD:
                     if self._obj is None:
                         if len(typed[self._shape]) == 1:
@@ -459,16 +460,20 @@ class Builder(ABC, Generic[ShapeT]):
                             combined = (
                                 typed[self._shape].pop().fuse(*typed[self._shape])
                             )
+                            needs_clean = False
                     else:
                         combined = self._obj.fuse(*typed[self._shape])
+                        needs_clean = False
                 elif mode == Mode.SUBTRACT:
                     if self._obj is None:
                         raise RuntimeError("Nothing to subtract from")
                     combined = self._obj.cut(*typed[self._shape])
+                    needs_clean = False
                 elif mode == Mode.INTERSECT:
                     if self._obj is None:
                         raise RuntimeError("Nothing to intersect with")
                     combined = self._obj.intersect(Compound(typed[self._shape]))
+                    needs_clean = False
                 elif mode == Mode.REPLACE:
                     combined = self._sub_class(list(typed[self._shape]))
 
@@ -487,7 +492,7 @@ class Builder(ABC, Generic[ShapeT]):
                 #     else combined
                 # )
 
-                if self._obj is not None and clean:
+                if self._obj is not None and needs_clean:
                     self._obj = self._obj.clean()
 
                 logger.info(

--- a/src/build123d/topology/composite.py
+++ b/src/build123d/topology/composite.py
@@ -103,7 +103,6 @@ from .one_d import Edge, Wire, Mixin1D
 from .shape_core import (
     Shape,
     ShapeList,
-    SkipClean,
     Joint,
     downcast,
     shapetype,
@@ -491,7 +490,6 @@ class Compound(Mixin3D[TopoDS_Compound]):
             s for s in self.get_top_level_shapes() + summands if s is not None
         )
 
-        # Only fuse the parts if necessary
         if len(summands) <= 1:
             result: Shape = Compound(summands[0:1])
         else:
@@ -499,9 +497,6 @@ class Compound(Mixin3D[TopoDS_Compound]):
             fuse_op.SetFuzzyValue(TOLERANCE)
             self.copy_attributes_to(summands[0], ["wrapped", "_NodeMixin__children"])
             result = self._bool_op(summands[:1], summands[1:], fuse_op)
-
-        if SkipClean.clean:
-            result = result.clean()
 
         return result
 

--- a/src/build123d/topology/shape_core.py
+++ b/src/build123d/topology/shape_core.py
@@ -988,9 +988,6 @@ class Shape(NodeMixin, Generic[TOPODS]):
         else:
             sum_shape = self.fuse(*summands)
 
-        if SkipClean.clean and not isinstance(sum_shape, list):
-            sum_shape = sum_shape.clean()
-
         return sum_shape
 
     def __and__(self, other: Shape | Iterable[Shape]) -> None | Self | Compound:

--- a/tests/test_algebra.py
+++ b/tests/test_algebra.py
@@ -621,6 +621,58 @@ class AlgebraTests(unittest.TestCase):
         self.assertAlmostEqual(b.volume, r.volume, 5)
         self.assertEqual(r._dim, 3)
 
+    def test_empty_plus_overlapping_parts(self):
+        boxes = [
+            Pos(ix * 0.8, iy * 0.8, 0) * Box(1, 1, 1)
+            for ix in range(3)
+            for iy in range(3)
+        ]
+        sequential = boxes[0]
+        for box in boxes[1:]:
+            sequential += box
+        vectorized = Part() + boxes
+
+        self.assertTrue(vectorized.is_valid)
+        self.assertAlmostEqual(vectorized.volume, sequential.volume, 5)
+        self.assertEqual(len(vectorized.solids()), len(sequential.solids()))
+        self.assertEqual(len(vectorized.faces()), len(sequential.faces()))
+
+    def test_empty_plus_mixed_curved_parts(self):
+        shapes = [
+            Box(2, 2, 1),
+            Pos(0.5, 0.5, 0) * Cylinder(0.8, 1),
+            Pos(-0.4, 0.3, 0) * Cylinder(0.5, 1),
+            Pos(0.2, -0.6, 0) * Box(0.8, 0.8, 1),
+        ]
+        sequential = shapes[0]
+        for shape in shapes[1:]:
+            sequential += shape
+        vectorized = Part() + shapes
+
+        self.assertTrue(vectorized.is_valid)
+        self.assertAlmostEqual(vectorized.volume, sequential.volume, 5)
+        self.assertAlmostEqual(vectorized.area, sequential.area, 5)
+        self.assertEqual(len(vectorized.solids()), len(sequential.solids()))
+        self.assertEqual(len(vectorized.faces()), len(sequential.faces()))
+
+    def test_empty_plus_rotated_parts(self):
+        boxes = [
+            Rot(0, 0, index * 17)
+            * Pos(index * 0.35, index * 0.15, 0)
+            * Box(1.2, 0.8, 1)
+            for index in range(5)
+        ]
+        sequential = boxes[0]
+        for box in boxes[1:]:
+            sequential += box
+        vectorized = Part() + boxes
+
+        self.assertTrue(vectorized.is_valid)
+        self.assertAlmostEqual(vectorized.volume, sequential.volume, 5)
+        self.assertAlmostEqual(vectorized.area, sequential.area, 5)
+        self.assertEqual(len(vectorized.solids()), len(sequential.solids()))
+        self.assertEqual(len(vectorized.faces()), len(sequential.faces()))
+
     def test_part_plus_empty(self):
         b = Box(1, 2, 3)
         r = b + Part()


### PR DESCRIPTION
Avoid running a second clean pass after boolean operations that already clean their result.

The shared boolean helper already applies ShapeUpgrade_UnifySameDomain when SkipClean.clean is enabled. This removes the caller-level clean from direct Shape and Compound additions. Builder context integration now skips the caller-level clean for add, subtract, and intersect paths that call the shared boolean helper, while retaining cleanup for non-boolean integrations that do not go through that helper.

To keep the scope tight, this does not change logging behavior and does not enable OCCT glue.

* Remove redundant clean work in direct Shape and Compound additions.
* Skip duplicate clean work when builder context integration uses add, subtract, or intersect.
* Keep builder cleanup for non-boolean context integration paths.
* Add regression tests for empty-object batch additions with overlapping boxes, mixed curved solids, and rotated solids.

Validation:

* `uv run --extra development pytest` (`1988 passed, 2 skipped`)
* `uv run --extra development pytest tests/test_benchmarks.py::test_ppp_0106 tests/test_algebra.py tests/test_build_common.py tests/test_build_part.py tests/test_direct_api/test_compound.py tests/test_direct_api/test_shape.py` (`292 passed`)
* `uv run --extra development pytest tests/test_benchmarks.py::test_ppp_0106 tests/test_examples.py -k ppp0106` (`1 passed`)
* `uv run --extra development pylint --rcfile=.pylintrc --fail-under=9.5 src/build123d`
