### PR TITLE
feat: allow Axis construction with end_point

### DIFF
--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -626,11 +626,12 @@ class AxisMeta(type):
 class Axis(metaclass=AxisMeta):
     """Axis
 
-    Axis defined by point and direction
+    Axis defined by point and direction or by two points
 
     Args:
         origin (VectorLike): start point
         direction (VectorLike): direction
+        end_point (VectorLike): point used with origin to define direction
         edge (Edge): origin & direction defined by start of edge
         location (Location): location to convert to axis
 
@@ -655,6 +656,10 @@ class Axis(metaclass=AxisMeta):
         """Axis: point and direction"""
 
     @overload
+    def __init__(self, origin: VectorLike, *, end_point: VectorLike) -> None:
+        """Axis: point and end point"""
+
+    @overload
     def __init__(self, edge: Edge) -> None:
         """Axis: start of Edge"""
 
@@ -664,6 +669,7 @@ class Axis(metaclass=AxisMeta):
         gp_ax1 = kwargs.pop("gp_ax1", None)
         origin = kwargs.pop("origin", None)
         direction = kwargs.pop("direction", None)
+        end_point = kwargs.pop("end_point", None)
         edge = kwargs.pop("edge", None)
         location = kwargs.pop("location", None)
 
@@ -686,6 +692,12 @@ class Axis(metaclass=AxisMeta):
                 raise ValueError(f"Unrecognized single argument: {arg}")
         elif len(args) == 2:
             origin, direction = args
+
+        # Convert end point to direction
+        if end_point is not None:
+            if direction is not None:
+                raise ValueError("Axis end_point cannot be used with direction")
+            direction = Vector(end_point) - Vector(origin)
 
         # Handle edge-based construction
         if edge is not None:

--- a/tests/test_direct_api/test_axis.py
+++ b/tests/test_direct_api/test_axis.py
@@ -57,6 +57,14 @@ class TestAxis(unittest.TestCase):
         self.assertAlmostEqual(test_axis.position, (1, 2, 3), 5)
         self.assertAlmostEqual(test_axis.direction, (0, 0, 1), 5)
 
+        test_axis = Axis((1, 2, 3), end_point=(1, 2, 4))
+        self.assertAlmostEqual(test_axis.position, (1, 2, 3), 5)
+        self.assertAlmostEqual(test_axis.direction, (0, 0, 1), 5)
+
+        test_axis = Axis(origin=(1, 2, 3), end_point=(2, 3, 3))
+        self.assertAlmostEqual(test_axis.position, (1, 2, 3), 5)
+        self.assertAlmostEqual(test_axis.direction, Vector(1, 1, 0).normalized(), 5)
+
         test_axis = Axis(Edge.make_line((1, 2, 3), (1, 2, 4)))
         self.assertAlmostEqual(test_axis.position, (1, 2, 3), 5)
         self.assertAlmostEqual(test_axis.direction, (0, 0, 1), 5)
@@ -71,6 +79,12 @@ class TestAxis(unittest.TestCase):
             Axis("one", "up")
         with self.assertRaises(ValueError):
             Axis(one="up")
+        with self.assertRaises(ValueError):
+            Axis(
+                (1, 2, 3), direction=(0, 0, 1), end_point=(1, 2, 4)
+            )  # pyright: ignore[reportCallIssue]
+        with self.assertRaises(ValueError):
+            Axis((1, 2, 3), end_point=(1, 2, 3))
         with self.assertRaises(ValueError):
             bad_edge = Edge()
             bad_edge.wrapped = Vertex(0, 1, 2).wrapped


### PR DESCRIPTION
## Summary
- Add `Axis(origin, end_point=...)` construction for point-to-point axis definitions
- Keep `end_point` keyword-only so existing `Axis(origin, direction)` behavior is unchanged
- Add tests for positional/keyword origin usage, normalized direction, conflicting direction/end_point input, and zero-length point pairs

Closes #1214

## Tests
- `uv run python -m pytest tests/test_direct_api/test_axis.py -q`
- `uv run black --check src/build123d/geometry.py tests/test_direct_api/test_axis.py`
- `git diff --check`
