### PR TITLE
fix(drafting): DimensionLine crash fix + ExtensionLine side parameter

### DIFF
--- a/src/build123d/drafting.py
+++ b/src/build123d/drafting.py
@@ -152,6 +152,14 @@ PathDescriptor: TypeAlias = Wire | Edge | list[PointLike]
 """General type for a path in 3D space"""
 
 
+_SIDE_VECTORS = {
+    "above": Vector(0, 1, 0),
+    "below": Vector(0, -1, 0),
+    "right": Vector(1, 0, 0),
+    "left": Vector(-1, 0, 0),
+}
+
+
 @dataclass
 class Draft:
     """Draft
@@ -400,8 +408,8 @@ class DimensionLine(BaseSketchObject):
         # Calculate the arrow shaft length for up to three types
         if arrows.count(True) == 0:
             raise ValueError("No output - no arrows selected")
-        if label_length + arrows.count(True) * draft.arrow_length < path_length:
-            shaft_length = (path_length - label_length) / 2 - draft.pad_around_text
+        shaft_length = max(0.0, (path_length - label_length) / 2 - draft.pad_around_text)
+        if label_length + arrows.count(True) * draft.arrow_length < path_length and shaft_length > 0:
             shaft_pair = [
                 path_obj.trim(0.0, shaft_length / path_length),
                 path_obj.trim(1.0 - shaft_length / path_length, 1.0),
@@ -489,7 +497,8 @@ class ExtensionLine(BaseSketchObject):
         border (PathDescriptor): a very general type of input defining the object to
             be dimensioned. Typically this value would be extracted from the part but is
             not restricted to this use.
-        offset (float): a distance to displace the dimension line from the edge of the object
+        offset (float): a distance to displace the dimension line from the edge of the object.
+            Ignored when ``side`` is provided.
         draft (Draft): instance of Draft dataclass
         label (str, optional): a text string which will replace the length (or arc length)
             that would otherwise be extracted from the provided path. Providing a label is
@@ -507,6 +516,11 @@ class ExtensionLine(BaseSketchObject):
         measurement_direction (VectorLike, optional): Vector line which to project the dimension
             against. Offset start point is the position of the start of border.
             Defaults to None.
+        side (str | VectorLike, optional): world-space direction for the dimension line —
+            ``"above"``, ``"below"``, ``"left"``, ``"right"``, or an explicit direction
+            vector. When provided, the sign of ``offset`` is computed automatically so
+            callers don't need to know the path orientation. For curved or multi-segment
+            borders the direction is inferred from the midpoint tangent. Defaults to None.
         mode (Mode, optional): combination mode. Defaults to Mode.ADD.
 
     """
@@ -522,6 +536,7 @@ class ExtensionLine(BaseSketchObject):
         tolerance: float | tuple[float, float] | None = None,
         label_angle: bool = False,
         measurement_direction: VectorLike | None = None,
+        side: str | VectorLike | None = None,
         mode: Mode = Mode.ADD,
     ):
         # pylint: disable=too-many-locals
@@ -552,6 +567,43 @@ class ExtensionLine(BaseSketchObject):
             )
         else:
             object_to_dimension = object_to_measure
+
+        if side is not None:
+            if isinstance(side, str):
+                side_key = side.lower()
+                if side_key not in _SIDE_VECTORS:
+                    raise ValueError(
+                        f"side must be one of {list(_SIDE_VECTORS)!r} or a VectorLike,"
+                        f" got {side!r}"
+                    )
+                world_dir = _SIDE_VECTORS[side_key]
+            else:
+                try:
+                    world_dir = Vector(side).normalized()
+                except Exception as exc:
+                    raise ValueError(
+                        f"side must be one of {list(_SIDE_VECTORS)!r} or a non-zero"
+                        f" VectorLike, got {side!r}"
+                    ) from exc
+            # Midpoint tangent is representative for straight edges, arcs, and
+            # multi-segment wires (better than start tangent for curved borders).
+            path_dir = object_to_dimension.tangent_at(0.5)
+            # normal = path direction rotated 90° CW (what Side.RIGHT maps to)
+            xy_mag = (path_dir.X**2 + path_dir.Y**2) ** 0.5
+            if xy_mag < 1e-9:
+                raise ValueError(
+                    "side cannot be used with a border edge that has no XY component"
+                    " (the edge runs along the Z axis)"
+                )
+            normal = Vector(path_dir.Y / xy_mag, -path_dir.X / xy_mag, 0)
+            dot = normal.dot(world_dir)
+            if abs(dot) < 1e-9:
+                raise ValueError(
+                    f"side={side!r} is ambiguous for this edge — the requested"
+                    " direction is parallel to the edge; use a different side or"
+                    " pass offset with an explicit sign instead"
+                )
+            offset = abs(offset) * copysign(1, dot)
 
         side_lut = {1: Side.RIGHT, -1: Side.LEFT}
 

--- a/tests/test_drafting.py
+++ b/tests/test_drafting.py
@@ -441,6 +441,90 @@ class ExtensionLineTestCase(unittest.TestCase):
                 measurement_direction=Vector(0, 1, 0),
             )
 
+    def test_side_above_places_dimension_above(self):
+        """side='above' on a horizontal edge should produce a bbox above the edge."""
+        edge = Edge.make_line((0, 0), (40, 0))
+        ext = ExtensionLine(border=edge, offset=10, draft=metric, side="above")
+        self.assertIsNotNone(ext)
+        self.assertGreater(ext.bounding_box().min.Y, -0.1)
+
+    def test_side_below_places_dimension_below(self):
+        """side='below' on a horizontal edge should produce a bbox below the edge."""
+        edge = Edge.make_line((0, 0), (40, 0))
+        ext = ExtensionLine(border=edge, offset=10, draft=metric, side="below")
+        self.assertIsNotNone(ext)
+        self.assertLess(ext.bounding_box().max.Y, 0.1)
+
+    def test_side_above_and_below_are_mirrored(self):
+        """side='above' and side='below' should be symmetric about y=0."""
+        edge = Edge.make_line((0, 0), (40, 0))
+        above = ExtensionLine(border=edge, offset=10, draft=metric, side="above")
+        below = ExtensionLine(border=edge, offset=10, draft=metric, side="below")
+        self.assertAlmostEqual(
+            above.bounding_box().max.Y, -below.bounding_box().min.Y, places=4
+        )
+
+    def test_side_right_places_dimension_right_of_vertical_edge(self):
+        """side='right' on a vertical edge should produce a bbox to the right."""
+        edge = Edge.make_line((0, 0), (0, 40))
+        ext = ExtensionLine(border=edge, offset=10, draft=metric, side="right")
+        self.assertGreater(ext.bounding_box().min.X, -0.1)
+
+    def test_side_left_places_dimension_left_of_vertical_edge(self):
+        """side='left' on a vertical edge should produce a bbox to the left."""
+        edge = Edge.make_line((0, 0), (0, 40))
+        ext = ExtensionLine(border=edge, offset=10, draft=metric, side="left")
+        self.assertLess(ext.bounding_box().max.X, 0.1)
+
+    def test_side_as_vectorlike(self):
+        """side as a VectorLike tuple should work identically to the string form."""
+        edge = Edge.make_line((0, 0), (40, 0))
+        by_string = ExtensionLine(border=edge, offset=10, draft=metric, side="above")
+        by_vector = ExtensionLine(border=edge, offset=10, draft=metric, side=(0, 1, 0))
+        self.assertAlmostEqual(
+            by_string.bounding_box().max.Y, by_vector.bounding_box().max.Y, places=4
+        )
+        # Also confirm the VectorLike path actually places the dimension above the edge
+        self.assertGreater(by_vector.bounding_box().min.Y, -0.1)
+
+    def test_side_invalid_string_raises(self):
+        """An unrecognised side string should raise ValueError with a helpful message."""
+        edge = Edge.make_line((0, 0), (40, 0))
+        with self.assertRaises(ValueError) as ctx:
+            ExtensionLine(border=edge, offset=10, draft=metric, side="up")
+        self.assertIn("up", str(ctx.exception))
+
+    def test_side_zero_vectorlike_raises(self):
+        """A zero VectorLike passed as side should raise ValueError, not an OCC error."""
+        edge = Edge.make_line((0, 0), (40, 0))
+        with self.assertRaises(ValueError):
+            ExtensionLine(border=edge, offset=10, draft=metric, side=(0, 0, 0))
+
+    def test_side_parallel_to_edge_raises(self):
+        """side='above' on a vertical edge is ambiguous and should raise ValueError."""
+        edge = Edge.make_line((0, 0), (0, 40))
+        with self.assertRaises(ValueError) as ctx:
+            ExtensionLine(border=edge, offset=10, draft=metric, side="above")
+        self.assertIn("ambiguous", str(ctx.exception))
+
+    def test_side_z_axis_edge_raises(self):
+        """A border edge with no XY component should raise ValueError when side is set."""
+        edge = Edge.make_line((0, 0, 0), (0, 0, 40))
+        with self.assertRaises(ValueError) as ctx:
+            ExtensionLine(border=edge, offset=10, draft=metric, side="above")
+        self.assertIn("Z axis", str(ctx.exception))
+
+
+class DimensionLineRobustnessTestCase(unittest.TestCase):
+    def test_label_wider_than_path_does_not_crash(self):
+        """DimensionLine must not raise when the label is wider than the path."""
+        short_edge = Edge.make_line((0, 0), (1, 0))
+        d_line = DimensionLine(
+            short_edge, draft=metric, label="very_long_label_that_wont_fit"
+        )
+        self.assertIsNotNone(d_line)
+        self.assertGreater(len(d_line.edges()), 0)
+
 
 @pytest.mark.parametrize("design_date", [date(2023, 9, 17), None])
 def test_basic_drawing(design_date):


### PR DESCRIPTION
## Summary

Two improvements to the existing dimension line classes in `drafting.py`:

**1. `DimensionLine` — crash fix**

`DimensionLine` raised `ValueError("Can't get geom adaptor of empty wire")` when `pad_around_text` made `shaft_length` go negative even though the label nominally fit within the path. This happened with single-arrow dimensions at borderline path lengths (a real 1-unit window with default `Draft` values).

Fix: compute `shaft_length = max(0.0, ...)` unconditionally and add `and shaft_length > 0` to the existing condition, routing the edge case to the external-arrow branch instead of crashing.

**2. `ExtensionLine` — `side` parameter**

Adds an optional `side` parameter accepting `"above"`, `"below"`, `"left"`, `"right"`, or an explicit `VectorLike`. When provided, the sign of `offset` is computed automatically from the path orientation so callers don't need to manually determine the correct sign.

```python
# Before — caller must know the sign convention
ExtensionLine(border=edge, offset=6, draft=d)   # positive = above for this edge?

# After
ExtensionLine(border=edge, offset=6, draft=d, side="above")
```

The sign is derived from the midpoint tangent (better than start tangent for arcs and multi-segment wires). Input validation covers: unknown string keys, zero/invalid VectorLike, edges with no XY component, and ambiguous (parallel) directions — all with clear `ValueError` messages. Fully backward-compatible; existing code using raw `offset` is unchanged.

## Test plan

- [x] `test_side_above_places_dimension_above` — horizontal edge, bbox above
- [x] `test_side_below_places_dimension_below` — horizontal edge, bbox below
- [x] `test_side_above_and_below_are_mirrored` — symmetry check
- [x] `test_side_right_places_dimension_right_of_vertical_edge`
- [x] `test_side_left_places_dimension_left_of_vertical_edge`
- [x] `test_side_as_vectorlike` — VectorLike input matches string form, placement asserted
- [x] `test_side_invalid_string_raises` — bad string → `ValueError` with key in message
- [x] `test_side_zero_vectorlike_raises` — zero vector → `ValueError`
- [x] `test_side_parallel_to_edge_raises` — ambiguous direction → `ValueError`
- [x] `test_side_z_axis_edge_raises` — Z-axis border → `ValueError`
- [x] `test_label_wider_than_path_does_not_crash` — crash fix regression test
- All 40 drafting tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)