### PR TITLE
Add implicit fields: marching cubes + signed-distance fields (build123d.implicit)

### DIFF
--- a/examples/conformal_shell.py
+++ b/examples/conformal_shell.py
@@ -1,0 +1,94 @@
+"""
+Robust uniform shelling + conformal infill, shown as a cutaway
+
+name: conformal_shell.py
+by:   Joshua Gibbins (GibbinsJosh)
+date: June 3, 2026
+
+desc:
+    Why implicits? Two things the B-rep kernel struggles with become trivial:
+
+      1. SHELLING / OFFSET. Hollowing a curved solid to a uniform wall is a
+         classic place B-rep `offset`/`shell` self-intersects -- especially in
+         concave regions like the neck of this "peanut". As a field, a uniform
+         shell of ANY geometry is just `abs(f) - thickness`, and it cannot fail.
+      2. CONFORMAL INFILL. The cavity is filled with a gyroid that follows the
+         curved wall exactly, because the infill is clipped by the same field.
+
+    The peanut here is the union of two overlapping spheres, built directly as a
+    signed-distance field. The identical shell/infill algebra works on a B-rep
+    part too -- just replace `peanut` with `mesh_to_sdf(my_part)` (see
+    gyroid_infill.py) to hollow and lattice an imported STEP/STL.
+
+    The model is cut in half so the uniform wall and the infill are visible.
+
+    Field algebra (signed-distance convention: f < 0 is solid):
+        C     = peanut field
+        shell = max(C, -t - C)            # solid wall band, thickness t
+        infill= max(|gyroid| - w, C + t)  # gyroid in the cavity (deeper than t)
+        solid = min(shell, infill)        # wall + infill
+        cut   = max(solid, y)             # keep y <= 0 to reveal the section
+
+license: Apache-2.0 (see build123d/src/build123d/implicit.py)
+"""
+
+# [Code]
+import numpy as np
+
+from build123d import implicit_stl, import_stl
+
+try:
+    from ocp_vscode import Render, show
+except ImportError:  # viewer is optional
+    Render = show = None
+
+# ---- Parameters ------------------------------------------------------------
+wall = 1.6  # shell wall thickness (mm)
+cell = 7.0  # gyroid infill unit-cell size (mm)
+sheet = 0.6  # gyroid sheet half-thickness (field units)
+resolution = 0.5  # marching-cubes grid spacing (mm)
+
+
+def sphere(points: np.ndarray, center, radius: float) -> np.ndarray:
+    """Signed-distance field of a sphere."""
+    return np.linalg.norm(points - np.asarray(center), axis=1) - radius
+
+
+def peanut(points: np.ndarray) -> np.ndarray:
+    """Two overlapping spheres unioned into a peanut (note the concave neck)."""
+    return np.minimum(sphere(points, (-8, 0, 0), 11), sphere(points, (8, 0, 0), 11))
+
+
+def gyroid(points: np.ndarray) -> np.ndarray:
+    """Gyroid TPMS scalar field."""
+    s = 2.0 * np.pi / cell
+    x, y, z = points[:, 0], points[:, 1], points[:, 2]
+    return (
+        np.sin(x * s) * np.cos(y * s)
+        + np.sin(y * s) * np.cos(z * s)
+        + np.sin(z * s) * np.cos(x * s)
+    )
+
+
+def hollow_part(points: np.ndarray) -> np.ndarray:
+    """Uniform shell + conformal gyroid infill, cut in half for viewing."""
+    c = peanut(points)
+    shell = np.maximum(c, -wall - c)  # solid band -wall <= c <= 0
+    infill = np.maximum(np.abs(gyroid(points)) - sheet, c + wall)  # in cavity
+    solid = np.minimum(shell, infill)
+    return np.maximum(solid, points[:, 1])  # keep the y <= 0 half
+
+
+bounds = ((-20.0, -12.0, -12.0), (20.0, 1.0, 12.0))  # y clipped to the cut half
+
+_, faces = implicit_stl(hollow_part, bounds, resolution, "conformal_shell.stl")
+print(f"conformal_shell.stl written: {len(faces)} triangles")
+
+if show is not None:
+    # modes=[Render.FACES] hides the triangulation wireframe (the viewer draws
+    # every mesh edge otherwise); default_facecolor overrides the magenta.
+    show(
+        import_stl("conformal_shell.stl"),
+        modes=[Render.FACES],
+        default_facecolor="#9fb4d4",
+    )

--- a/examples/graded_lattice.py
+++ b/examples/graded_lattice.py
@@ -1,0 +1,89 @@
+"""
+Functionally graded lattice (spatially varying strut thickness)
+
+name: graded_lattice.py
+by:   Joshua Gibbins (GibbinsJosh)
+date: June 3, 2026
+
+desc:
+    Why implicits? Because the *parameters* of a structure can be functions of
+    position. Here a cubic strut lattice has a strut radius that grows linearly
+    along Z -- thin and light at the top, thick and stiff at the bottom -- so
+    the part can put material exactly where the loads are (functional grading,
+    a core technique in additive manufacturing and lightweighting).
+
+    There is no practical B-rep equivalent: you would have to model every strut
+    individually at its own radius and union thousands of bodies. As a field it
+    is one expression -- `radius` simply depends on `points[:, 2]` -- and the
+    whole lattice is meshed in a single pass.
+
+license: Apache-2.0 (see build123d/src/build123d/implicit.py)
+"""
+
+# [Code]
+import numpy as np
+
+from build123d import implicit_stl, import_stl
+
+try:
+    from ocp_vscode import Render, show
+except ImportError:  # viewer is optional
+    Render = show = None
+
+# ---- Parameters ------------------------------------------------------------
+size = (24.0, 24.0, 48.0)  # bar dimensions (mm)
+cell = 8.0  # lattice unit-cell size (mm)
+r_min = 0.6  # strut radius at the top  (mm)
+r_max = 2.4  # strut radius at the bottom (mm)
+resolution = 0.4  # marching-cubes grid spacing (mm)
+
+half = np.array(size) / 2.0
+bounds = ((-half[0], -half[1], -half[2]), (half[0], half[1], half[2]))
+
+
+def _wrap(t: np.ndarray, period: float) -> np.ndarray:
+    """Signed distance from t to the nearest multiple of `period`."""
+    return (t + period / 2.0) % period - period / 2.0
+
+
+def strut_radius(z: np.ndarray) -> np.ndarray:
+    """Strut radius graded linearly from r_max (bottom) to r_min (top)."""
+    frac = (z + half[2]) / size[2]  # 0 at bottom, 1 at top
+    return r_max + (r_min - r_max) * frac
+
+
+def graded_struts(points: np.ndarray) -> np.ndarray:
+    """Cubic strut lattice whose radius varies with height."""
+    x, y, z = points[:, 0], points[:, 1], points[:, 2]
+    wx, wy, wz = _wrap(x, cell), _wrap(y, cell), _wrap(z, cell)
+    radius = strut_radius(z)
+    along_z = np.sqrt(wx * wx + wy * wy) - radius
+    along_x = np.sqrt(wy * wy + wz * wz) - radius
+    along_y = np.sqrt(wx * wx + wz * wz) - radius
+    return np.minimum(np.minimum(along_x, along_y), along_z)
+
+
+def box_sdf(points: np.ndarray) -> np.ndarray:
+    """Signed-distance field of the axis-aligned bounding bar."""
+    q = np.abs(points) - half
+    outside = np.linalg.norm(np.maximum(q, 0.0), axis=1)
+    inside = np.minimum(np.max(q, axis=1), 0.0)
+    return outside + inside
+
+
+def graded_field(points: np.ndarray) -> np.ndarray:
+    """Graded lattice clipped to the bar: max(lattice, box)."""
+    return np.maximum(graded_struts(points), box_sdf(points)).reshape(-1, 1)
+
+
+_, faces = implicit_stl(graded_field, bounds, resolution, "graded_lattice.stl")
+print(f"graded_lattice.stl written: {len(faces)} triangles")
+
+if show is not None:
+    # modes=[Render.FACES] hides the triangulation wireframe (the viewer draws
+    # every mesh edge otherwise); default_facecolor overrides the magenta.
+    show(
+        import_stl("graded_lattice.stl"),
+        modes=[Render.FACES],
+        default_facecolor="#9fb4d4",
+    )

--- a/examples/gyroid_infill.py
+++ b/examples/gyroid_infill.py
@@ -1,0 +1,99 @@
+"""
+Gyroid TPMS infill inside a build123d part
+
+name: gyroid_infill.py
+by:   Joshua Gibbins (GibbinsJosh)
+date: June 3, 2026
+
+desc:
+    Demonstrates the bidirectional implicit-field API (build123d.implicit):
+
+      1. REVERSE  -- a traditional B-rep part (here a Box, but it could be any
+         Solid or an imported STEP/STL) is converted into a signed-distance
+         field with ``mesh_to_sdf``.
+      2. FORWARD  -- that field is combined with an analytic gyroid field and
+         meshed back into geometry with ``implicit_stl`` / ``implicit_solid``.
+
+    The result is a gyroid triple-periodic-minimal-surface (TPMS) infill
+    clipped to the part -- built by composing scalar fields and meshing once,
+    so there are no fragile B-rep booleans on the lattice itself.
+
+    Field algebra (signed-distance convention: f < 0 is solid):
+        C      = mesh_to_sdf(container)          # the part as a field
+        sheet  = |gyroid| - wall                 # thick the minimal surface
+        infill = max(sheet, C)                   # clip the sheet inside C
+
+    To turn this into a closed part with solid outer walls, union a wall band
+    onto the infill (see the commented `skin` lines below).
+
+license: Apache-2.0 (see build123d/src/build123d/implicit.py)
+"""
+
+# [Code]
+import numpy as np
+
+from build123d import Box, implicit_stl, import_stl, mesh_to_sdf
+
+try:
+    from ocp_vscode import Render, show
+except ImportError:  # viewer is optional
+    Render = show = None
+
+# ---- Parameters ------------------------------------------------------------
+size = (40.0, 40.0, 16.0)  # outer dimensions of the part (mm)
+cell = 8.0  # gyroid unit-cell size / period (mm)
+wall = 0.55  # gyroid sheet half-thickness (field units)
+resolution = 0.4  # marching-cubes grid spacing (mm); smaller = finer
+
+# ---- 1. REVERSE: part B-rep -> signed-distance field -----------------------
+# Swap Box(*size) for mesh_to_sdf("my_part.step") to infill any imported part.
+container = Box(*size)
+csdf = mesh_to_sdf(container)
+
+
+# ---- The analytic gyroid field --------------------------------------------
+def gyroid(points: np.ndarray) -> np.ndarray:
+    """Gyroid TPMS scalar field; the zero level set is the minimal surface."""
+    s = 2.0 * np.pi / cell
+    x, y, z = points[:, 0], points[:, 1], points[:, 2]
+    g = (
+        np.sin(x * s) * np.cos(y * s)
+        + np.sin(y * s) * np.cos(z * s)
+        + np.sin(z * s) * np.cos(x * s)
+    )
+    return g.reshape(-1, 1)
+
+
+# ---- 2. FORWARD: compose fields, then mesh ---------------------------------
+def part_field(points: np.ndarray) -> np.ndarray:
+    """Gyroid sheet clipped to the container: max(|gyroid| - wall, C)."""
+    c = csdf(points)
+    infill = np.maximum(np.abs(gyroid(points)) - wall, c)  # sheet inside part
+    # For a closed part with solid 1.6 mm walls, union a wall band instead:
+    #     skin = np.maximum(c, -1.6 - c)   # solid band -1.6 <= c <= 0
+    #     return np.minimum(skin, infill)
+    return infill
+
+
+# Fast path: mesh straight to a printable STL (recommended for lattices --
+# hundreds of thousands of triangles in a couple of seconds).
+verts, faces = implicit_stl(
+    part_field,
+    bounds=csdf.bounds,
+    resolution=resolution,
+    file_path="gyroid_infill.stl",
+)
+print(f"gyroid_infill.stl written: {len(faces)} triangles")
+
+# Preview the result by re-importing the mesh (fast). If you need a true B-rep
+# Solid for boolean composition or STEP export, use instead:
+#     from build123d import implicit_solid
+#     part = implicit_solid(part_field, bounds=csdf.bounds, resolution=0.7)
+if show is not None:
+    # modes=[Render.FACES] hides the triangulation wireframe (the viewer draws
+    # every mesh edge otherwise); default_facecolor overrides the magenta.
+    show(
+        import_stl("gyroid_infill.stl"),
+        modes=[Render.FACES],
+        default_facecolor="#9fb4d4",
+    )

--- a/examples/lattice_infill.py
+++ b/examples/lattice_infill.py
@@ -1,0 +1,104 @@
+"""
+Periodic strut lattice infill from analytic signed-distance fields
+
+name: lattice_infill.py
+by:   Joshua Gibbins (GibbinsJosh)
+date: June 3, 2026
+
+desc:
+    Builds a repeating strut lattice purely from analytic signed-distance
+    fields and clips it to a bounding shape, then meshes it with
+    build123d.implicit.
+
+    The lattice is a body-centred-cubic-style network: round struts running
+    along X, Y and Z through every grid node (their union), produced by
+    "folding" space into a single unit cell with a modulo and taking the
+    distance to the cell axes. Clipping is just a field ``max`` against the
+    container's signed-distance field.
+
+    Two clip regions are shown:
+      - an analytic sphere (fast, self-contained), used for the output, and
+      - a commented ``mesh_to_sdf(...)`` line showing how to clip the same
+        lattice to ANY build123d Solid or imported STEP/STL instead -- the
+        reverse half of the bidirectional workflow.
+
+    Field algebra (signed-distance convention: f < 0 is solid):
+        lattice = min(strut_x, strut_y, strut_z)   # union of strut families
+        part    = max(lattice, container_sdf)       # intersect with region
+
+license: Apache-2.0 (see build123d/src/build123d/implicit.py)
+"""
+
+# [Code]
+import numpy as np
+
+from build123d import implicit_stl, import_stl
+
+# from build123d import mesh_to_sdf, Cylinder  # for the reverse-clip variant
+
+try:
+    from ocp_vscode import Render, show
+except ImportError:  # viewer is optional
+    Render = show = None
+
+# ---- Parameters ------------------------------------------------------------
+cell = 6.0  # lattice unit-cell size (mm)
+strut_r = 1.1  # strut radius (mm)
+radius = 18.0  # radius of the spherical container (mm)
+resolution = 0.35  # marching-cubes grid spacing (mm)
+
+bounds = ((-radius, -radius, -radius), (radius, radius, radius))
+
+
+def _wrap(t: np.ndarray, period: float) -> np.ndarray:
+    """Signed distance from t to the nearest multiple of `period`."""
+    return (t + period / 2.0) % period - period / 2.0
+
+
+def strut_lattice(points: np.ndarray) -> np.ndarray:
+    """Cubic strut lattice: round bars along X, Y, Z through every node."""
+    x, y, z = points[:, 0], points[:, 1], points[:, 2]
+    wx, wy, wz = _wrap(x, cell), _wrap(y, cell), _wrap(z, cell)
+    along_z = np.sqrt(wx * wx + wy * wy) - strut_r
+    along_x = np.sqrt(wy * wy + wz * wz) - strut_r
+    along_y = np.sqrt(wx * wx + wz * wz) - strut_r
+    return np.minimum(np.minimum(along_x, along_y), along_z).reshape(-1, 1)
+
+
+# ---- Container field -------------------------------------------------------
+# Analytic sphere SDF (fast). To clip to a real part instead, replace these two
+# lines with, e.g.:
+#     from build123d import mesh_to_sdf, Cylinder
+#     container = mesh_to_sdf(Cylinder(radius=18, height=30))
+#     bounds = container.bounds
+def container(points: np.ndarray) -> np.ndarray:
+    """Signed-distance field of the spherical bounding region."""
+    return (np.linalg.norm(points, axis=1) - radius).reshape(-1, 1)
+
+
+def lattice_field(points: np.ndarray) -> np.ndarray:
+    """Strut lattice clipped to the container: max(lattice, container)."""
+    return np.maximum(strut_lattice(points), container(points))
+
+
+# ---- Mesh it ---------------------------------------------------------------
+verts, faces = implicit_stl(
+    lattice_field,
+    bounds=bounds,
+    resolution=resolution,
+    file_path="lattice_infill.stl",
+)
+print(f"lattice_infill.stl written: {len(faces)} triangles")
+
+# Preview by re-importing the mesh (fast). For a true B-rep Solid (boolean
+# composition / STEP export) use instead:
+#     from build123d import implicit_solid
+#     part = implicit_solid(lattice_field, bounds=bounds, resolution=0.6)
+if show is not None:
+    # modes=[Render.FACES] hides the triangulation wireframe (the viewer draws
+    # every mesh edge otherwise); default_facecolor overrides the magenta.
+    show(
+        import_stl("lattice_infill.stl"),
+        modes=[Render.FACES],
+        default_facecolor="#9fb4d4",
+    )

--- a/examples/smooth_blend.py
+++ b/examples/smooth_blend.py
@@ -1,0 +1,99 @@
+"""
+Smooth blending of solids (the smooth-minimum operator)
+
+name: smooth_blend.py
+by:   Joshua Gibbins (GibbinsJosh)
+date: June 3, 2026
+
+desc:
+    Why implicits? Because a *field* can be combined with a smooth minimum, not
+    just a hard boolean. Replacing min(a, b) (a sharp union) with a polynomial
+    smooth-minimum blends two solids into one organic body with a fillet of a
+    chosen radius -- everywhere they meet, at once.
+
+    In traditional B-rep you would union the primitives and then chase the
+    result with fillet operations on each resulting edge. At a multi-way
+    junction (several bodies meeting at a point) those fillets are exactly where
+    the kernel tends to fail or self-intersect. With a signed-distance field it
+    is a single, unconditionally robust operation.
+
+    This example renders the SAME cluster of spheres twice, side by side:
+      left  -- hard union  (np.minimum): visible creases where spheres meet
+      right -- smooth union (smin):       one organic blob, fillets for free
+
+license: Apache-2.0 (see build123d/src/build123d/implicit.py)
+"""
+
+# [Code]
+import numpy as np
+
+from build123d import implicit_stl, import_stl
+
+try:
+    from ocp_vscode import Render, show
+except ImportError:  # viewer is optional
+    Render = show = None
+
+# ---- Parameters ------------------------------------------------------------
+blend = 3.5  # blend radius of the smooth minimum (mm)
+gap = 20.0  # half-distance between the two copies (mm)
+resolution = 0.5  # marching-cubes grid spacing (mm)
+
+# A cluster of overlapping spheres: (center, radius)
+blobs = [
+    ((0.0, 0.0, 0.0), 6.0),
+    ((7.0, 2.0, 0.0), 5.0),
+    ((3.0, 7.0, 1.0), 4.5),
+    ((5.0, -4.0, 3.0), 5.0),
+]
+
+
+def sphere(points: np.ndarray, center, radius: float) -> np.ndarray:
+    """Signed-distance field of a sphere."""
+    return np.linalg.norm(points - np.asarray(center), axis=1) - radius
+
+
+def smin(field_a: np.ndarray, field_b: np.ndarray, k: float) -> np.ndarray:
+    """Polynomial smooth minimum: a soft union with a fillet of radius ~k."""
+    h = np.clip(0.5 + 0.5 * (field_b - field_a) / k, 0.0, 1.0)
+    return field_b * (1.0 - h) + field_a * h - k * h * (1.0 - h)
+
+
+def cluster_hard(points: np.ndarray) -> np.ndarray:
+    """Hard union (np.minimum) of the sphere cluster -- sharp creases."""
+    dist = None
+    for center, radius in blobs:
+        s = sphere(points, center, radius)
+        dist = s if dist is None else np.minimum(dist, s)
+    return dist
+
+
+def cluster_smooth(points: np.ndarray) -> np.ndarray:
+    """Smooth union (smin) of the sphere cluster -- organic fillets."""
+    dist = None
+    for center, radius in blobs:
+        s = sphere(points, center, radius)
+        dist = s if dist is None else smin(dist, s, blend)
+    return dist
+
+
+def field(points: np.ndarray) -> np.ndarray:
+    """Hard-union copy at x = -gap, smooth-union copy at x = +gap."""
+    left = cluster_hard(points + np.array([gap, 0.0, 0.0]))
+    right = cluster_smooth(points - np.array([gap, 0.0, 0.0]))
+    return np.minimum(left, right).reshape(-1, 1)
+
+
+bounds = ((-29.0, -12.0, -9.0), (35.0, 14.0, 11.0))
+
+_, faces = implicit_stl(field, bounds, resolution, "smooth_blend.stl")
+print(f"smooth_blend.stl written: {len(faces)} triangles")
+
+if show is not None:
+    # modes=[Render.FACES] hides the triangulation wireframe (the viewer draws
+    # every mesh edge otherwise); default_facecolor overrides the magenta.
+    show(
+        import_stl("smooth_blend.stl"),
+        modes=[Render.FACES],
+        default_facecolor="#9fb4d4",
+    )

--- a/src/build123d/__init__.py
+++ b/src/build123d/__init__.py
@@ -7,6 +7,7 @@ from build123d.build_part import *
 from build123d.build_sketch import *
 from build123d.exporters import *
 from build123d.geometry import *
+from build123d.implicit import *
 from build123d.importers import *
 from build123d.import_dxf import import_dxf
 from build123d.joints import *
@@ -188,6 +189,12 @@ __all__ = [
     "LineType",
     "DotLength",
     "Mesher",
+    # Implicit / signed-distance fields
+    "implicit_solid",
+    "implicit_mesh",
+    "implicit_stl",
+    "mesh_to_sdf",
+    "SignedDistanceField",
     # Importer functions
     "detect_primitives",
     "import_brep",

--- a/src/build123d/implicit.py
+++ b/src/build123d/implicit.py
@@ -1,0 +1,549 @@
+"""
+build123d implicit fields
+
+name: implicit.py
+by:   Joshua Gibbins (GibbinsJosh)
+date: June 3, 2026
+
+desc:
+    A bidirectional bridge between implicit/scalar fields and build123d B-rep
+    solids:
+
+        implicit field  --implicit_solid()-->  Solid          (marching cubes)
+        Solid / STEP / STL  --mesh_to_sdf()-->  implicit field (signed distance)
+
+    Both directions share the signed-distance convention for the scalar field:
+
+        f < 0  -> interior
+        f = 0  -> surface
+        f > 0  -> exterior
+
+    Because ``mesh_to_sdf`` returns a callable in exactly the form
+    ``implicit_solid`` consumes, the workflow round-trips: a traditional B-rep
+    part can be converted to a field, combined with analytic fields (TPMS
+    lattices, blends, offsets, shells), and meshed back into a solid. This is
+    the basis for implicit infill, lattice structures, and field-driven design.
+
+    Public API:
+        implicit_solid  -- evaluate a field on a grid -> watertight Solid
+        implicit_mesh   -- same, but return raw (vertices, faces) arrays
+        mesh_to_sdf     -- B-rep / mesh -> SignedDistanceField callable
+        SignedDistanceField -- the callable returned by mesh_to_sdf
+
+    Marching cubes is performed with VTK (already a build123d dependency, see
+    vtk_tools.py); the signed-distance reconstruction is pure NumPy.
+
+license:
+
+    Copyright 2026 Joshua Gibbins
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+"""
+
+from __future__ import annotations
+
+import os
+import struct
+import tempfile
+from typing import Callable, Tuple, Union
+
+import numpy as np
+from vtkmodules.util.numpy_support import numpy_to_vtk, vtk_to_numpy
+from vtkmodules.vtkCommonDataModel import vtkImageData
+from vtkmodules.vtkFiltersCore import vtkMarchingCubes
+from OCP.BRepBuilderAPI import BRepBuilderAPI_MakeSolid, BRepBuilderAPI_Sewing
+from OCP.StlAPI import StlAPI_Reader
+from OCP.TopAbs import TopAbs_SHELL
+from OCP.TopExp import TopExp_Explorer
+from OCP.TopoDS import TopoDS, TopoDS_Shape
+
+from build123d.importers import import_step, import_stl
+from build123d.topology import Shape, Solid
+
+__all__ = [
+    "implicit_solid",
+    "implicit_mesh",
+    "implicit_stl",
+    "mesh_to_sdf",
+    "SignedDistanceField",
+]
+
+Bounds = Tuple[Tuple[float, float, float], Tuple[float, float, float]]
+ImplicitFunc = Callable[[np.ndarray], np.ndarray]
+MeshSource = Union[Shape, str, os.PathLike]
+
+
+class SignedDistanceField:
+    """A callable signed-distance field derived from a triangle mesh.
+
+    Call it with an ``(N, 3)`` array of query points; it returns an ``(N, 1)``
+    array of signed distances (negative inside, positive outside) -- the same
+    convention :func:`implicit_solid` consumes, so an instance can be passed
+    straight back in as ``func``.
+
+    Args:
+        triangles (np.ndarray): ``(F, 3, 3)`` array of triangle vertex coords.
+        batch_size (int, optional): query points evaluated per chunk. Defaults
+            to an automatic value that bounds peak memory.
+
+    Attributes:
+        bounds: ``((x0, y0, z0), (x1, y1, z1))`` tight bounding box of the
+            source mesh, convenient for feeding ``implicit_solid(..., bounds=)``.
+        triangles: ``(F, 3, 3)`` array of triangle vertex coordinates.
+    """
+
+    def __init__(self, triangles: np.ndarray, batch_size: int | None = None):
+        self.triangles = triangles
+        self._v0 = triangles[:, 0, :]
+        self._v1 = triangles[:, 1, :]
+        self._v2 = triangles[:, 2, :]
+        lo = triangles.reshape(-1, 3).min(axis=0)
+        hi = triangles.reshape(-1, 3).max(axis=0)
+        self.bounds = (tuple(lo.tolist()), tuple(hi.tolist()))
+        self._batch_size = batch_size
+
+    def __call__(self, points: np.ndarray) -> np.ndarray:
+        points = np.asarray(points, dtype=np.float64).reshape(-1, 3)
+        n_tri = len(self._v0)
+        # Keep the (batch x triangles x 3) broadcast within ~16M floats.
+        batch = self._batch_size or max(1, 16_000_000 // max(n_tri, 1))
+        out = np.empty(len(points), dtype=np.float64)
+        for i in range(0, len(points), batch):
+            out[i : i + batch] = _signed_distance_batch(
+                points[i : i + batch], self._v0, self._v1, self._v2
+            )
+        return out.reshape((-1, 1))
+
+
+def implicit_solid(
+    func: ImplicitFunc,
+    bounds: Bounds,
+    resolution: float,
+    *,
+    level: float = 0.0,
+    close_boundary: bool = True,
+) -> Solid:
+    """implicit_solid
+
+    Evaluate an implicit function on a grid and return a watertight build123d
+    Solid via marching cubes.
+
+    Args:
+        func (Callable): ``f(points) -> values`` where points is ``(N, 3)`` and
+            values is ``(N,)`` or ``(N, 1)``. Negative = inside, positive =
+            outside (signed-distance convention).
+        bounds (tuple): ``((x0, y0, z0), (x1, y1, z1))`` axis-aligned box to
+            sample within.
+        resolution (float): grid spacing in model units. Smaller = finer mesh.
+        level (float, optional): isosurface value to extract. Defaults to 0.0.
+        close_boundary (bool, optional): if True (default), pad the sampling
+            grid with an "outside" border so any surface reaching the bounding
+            box is capped. Guarantees a watertight solid (required for correct
+            volume and boolean operations) when the field is not already closed
+            inside the bounds -- e.g. a TPMS lattice clipped to a box.
+
+    Returns:
+        Solid: a watertight solid built from the marching-cubes mesh.
+    """
+    verts, faces = _marching_cubes(func, bounds, resolution, level, close_boundary)
+    return _mesh_to_solid(verts, faces)
+
+
+def implicit_mesh(
+    func: ImplicitFunc,
+    bounds: Bounds,
+    resolution: float,
+    *,
+    level: float = 0.0,
+    close_boundary: bool = True,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """implicit_mesh
+
+    Return the raw marching-cubes ``(vertices, faces)`` arrays without
+    converting to a Solid -- useful for inspection or alternative export
+    pipelines. See :func:`implicit_solid` for argument semantics.
+
+    Returns:
+        tuple[np.ndarray, np.ndarray]: ``(vertices (V, 3), faces (F, 3))``.
+    """
+    return _marching_cubes(func, bounds, resolution, level, close_boundary)
+
+
+def implicit_stl(
+    func: ImplicitFunc,
+    bounds: Bounds,
+    resolution: float,
+    file_path: str | os.PathLike,
+    *,
+    level: float = 0.0,
+    close_boundary: bool = True,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """implicit_stl
+
+    Mesh an implicit field and write it straight to a binary STL file, skipping
+    B-rep reconstruction. This is the fast, practical path for 3D-printable
+    implicit geometry (infill, TPMS lattices, struts): for meshes with tens to
+    hundreds of thousands of triangles it is orders of magnitude faster than
+    :func:`implicit_solid`, which must sew every triangle into an OCC solid.
+
+    Use :func:`implicit_solid` instead when you need a B-rep ``Solid`` for
+    boolean composition with other CAD parts or for STEP export.
+
+    Args:
+        func, bounds, resolution, level, close_boundary: see
+            :func:`implicit_solid`.
+        file_path: destination ``.stl`` path.
+
+    Returns:
+        tuple[np.ndarray, np.ndarray]: the ``(vertices, faces)`` that were
+        written, for any further inspection.
+    """
+    verts, faces = _marching_cubes(func, bounds, resolution, level, close_boundary)
+    _write_binary_stl(os.fspath(file_path), verts, faces)
+    return verts, faces
+
+
+# ---- Reverse direction: B-rep / mesh -> signed-distance field --------------
+
+
+def mesh_to_sdf(
+    source: MeshSource,
+    *,
+    tolerance: float | None = None,
+    angular_tolerance: float = 0.2,
+    batch_size: int | None = None,
+) -> SignedDistanceField:
+    """mesh_to_sdf
+
+    Convert a build123d solid / STEP / STL into a signed-distance field. This
+    is the inverse of :func:`implicit_solid`: it turns traditional B-rep
+    geometry into an implicit field callable that can be combined with analytic
+    fields and re-meshed, so the workflow goes both ways.
+
+    Args:
+        source (Shape | str | PathLike): a build123d ``Shape`` / ``Solid``, or
+            a path to a ``.step`` / ``.stp`` / ``.stl`` file.
+        tolerance (float, optional): linear deflection for tessellating B-rep
+            input. Defaults to ~0.1% of the bounding-box diagonal. Ignored for
+            STL (already triangulated). Smaller = more faithful, slower.
+        angular_tolerance (float, optional): angular deflection for
+            tessellation, in radians. Defaults to 0.2.
+        batch_size (int, optional): query points evaluated per chunk. Defaults
+            to an automatic value that bounds peak memory.
+
+    Returns:
+        SignedDistanceField: call it with ``(N, 3)`` points to get signed
+        distances (negative inside). Its ``.bounds`` attribute feeds straight
+        into ``implicit_solid(..., bounds=sdf.bounds)``.
+
+    Raises:
+        ValueError: if the source produces no triangles or is an unsupported
+            file type.
+
+    Note:
+        The field is reconstructed from a triangulation, so sharp edges and
+        corners round off at the scale of ``tolerance`` / the meshing grid.
+        B-rep -> field -> B-rep is therefore not bit-exact; choose a tolerance
+        well below the smallest feature you need to preserve.
+
+    Performance:
+        Evaluation is ``O(n_points * n_triangles)``. It is cheap for low-poly
+        inputs (e.g. a box) or sparse queries, but meshing the field of a
+        densely tessellated part over a fine grid can be slow. Keep the input
+        triangle count modest, or reuse the returned field for many queries.
+    """
+    triangles = _extract_triangles(source, tolerance, angular_tolerance)
+    if len(triangles) == 0:
+        raise ValueError("Mesh source produced no triangles")
+    return SignedDistanceField(triangles, batch_size=batch_size)
+
+
+def _extract_triangles(
+    source: MeshSource,
+    tolerance: float | None,
+    angular_tolerance: float,
+) -> np.ndarray:
+    """Return an ``(F, 3, 3)`` array of triangle vertex coordinates."""
+    shape = _as_shape(source)
+
+    if tolerance is None:
+        (x0, y0, z0), (x1, y1, z1) = _shape_bounds(shape)
+        diag = float(np.linalg.norm([x1 - x0, y1 - y0, z1 - z0]))
+        tolerance = max(diag * 1e-3, 1e-6)
+
+    vertices, faces = shape.tessellate(tolerance, angular_tolerance)
+    verts = np.array([(v.X, v.Y, v.Z) for v in vertices], dtype=np.float64)
+    idx = np.array(faces, dtype=np.int64)
+    return verts[idx]  # (F, 3, 3)
+
+
+def _as_shape(source: MeshSource) -> Shape:
+    if isinstance(source, Shape):
+        return source
+    if hasattr(source, "wrapped"):  # build123d object exposing an OCP shape
+        return source  # type: ignore[return-value]
+    path = os.fspath(source)
+    ext = os.path.splitext(path)[1].lower()
+    if ext in (".step", ".stp"):
+        return import_step(path)
+    if ext == ".stl":
+        return import_stl(path)
+    raise ValueError(
+        f"Unsupported mesh source '{path}': expected a build123d Shape or a "
+        f".step/.stp/.stl file"
+    )
+
+
+def _shape_bounds(shape: Shape) -> Bounds:
+    bb = shape.bounding_box()
+    return (
+        (bb.min.X, bb.min.Y, bb.min.Z),
+        (bb.max.X, bb.max.Y, bb.max.Z),
+    )
+
+
+def _signed_distance_batch(p, v0, v1, v2):
+    """Signed distance from each point in ``p`` (B, 3) to the triangle soup.
+
+    Magnitude is the exact point-to-triangle distance (closest-feature
+    algorithm, Ericson, Real-Time Collision Detection, sec. 5.1.5); sign comes
+    from the generalized winding number (Jacobson et al. 2013), which is robust
+    for watertight meshes regardless of triangle orientation.
+    """
+    p = p[:, None, :]  # (B, 1, 3)
+    a, b, c = v0[None], v1[None], v2[None]  # (1, M, 3)
+
+    ab = b - a
+    ac = c - a
+    ap = p - a
+    d1 = np.sum(ab * ap, axis=2)
+    d2 = np.sum(ac * ap, axis=2)
+    bp = p - b
+    d3 = np.sum(ab * bp, axis=2)
+    d4 = np.sum(ac * bp, axis=2)
+    cp = p - c
+    d5 = np.sum(ab * cp, axis=2)
+    d6 = np.sum(ac * cp, axis=2)
+
+    va = d3 * d6 - d5 * d4
+    vb = d5 * d2 - d1 * d6
+    vc = d1 * d4 - d3 * d2
+
+    # Barycentric (v, w) of the closest point, start with the face-interior case.
+    denom = va + vb + vc
+    inv = np.divide(1.0, denom, out=np.zeros_like(denom), where=denom != 0)
+    v = vb * inv
+    w = vc * inv
+
+    def _safe(num, den):
+        return np.divide(num, den, out=np.zeros_like(num), where=den != 0)
+
+    # Edge BC: closest = b + t(c - b)  ->  v = 1 - t, w = t
+    region_bc = (va <= 0) & ((d4 - d3) >= 0) & ((d5 - d6) >= 0)
+    t_bc = _safe(d4 - d3, (d4 - d3) + (d5 - d6))
+    v = np.where(region_bc, 1.0 - t_bc, v)
+    w = np.where(region_bc, t_bc, w)
+
+    # Edge AC: v = 0, w = d2 / (d2 - d6)
+    region_ac = (vb <= 0) & (d2 >= 0) & (d6 <= 0)
+    w_ac = _safe(d2, d2 - d6)
+    v = np.where(region_ac, 0.0, v)
+    w = np.where(region_ac, w_ac, w)
+
+    # Edge AB: v = d1 / (d1 - d3), w = 0
+    region_ab = (vc <= 0) & (d1 >= 0) & (d3 <= 0)
+    v_ab = _safe(d1, d1 - d3)
+    v = np.where(region_ab, v_ab, v)
+    w = np.where(region_ab, 0.0, w)
+
+    # Vertex regions (take precedence over edges).
+    region_a = (d1 <= 0) & (d2 <= 0)
+    region_b = (d3 >= 0) & (d4 <= d3)
+    region_c = (d6 >= 0) & (d5 <= d6)
+    v = np.where(region_a, 0.0, v)
+    w = np.where(region_a, 0.0, w)
+    v = np.where(region_b, 1.0, v)
+    w = np.where(region_b, 0.0, w)
+    v = np.where(region_c, 0.0, v)
+    w = np.where(region_c, 1.0, w)
+
+    closest = a + ab * v[..., None] + ac * w[..., None]  # (B, M, 3)
+    dist2 = np.sum((p - closest) ** 2, axis=2)  # (B, M)
+    unsigned = np.sqrt(dist2.min(axis=1))  # (B,)
+
+    # Generalized winding number for the inside/outside sign.
+    av = a - p
+    bv = b - p
+    cv = c - p
+    la = np.linalg.norm(av, axis=2)
+    lb = np.linalg.norm(bv, axis=2)
+    lc = np.linalg.norm(cv, axis=2)
+    num = np.sum(av * np.cross(bv, cv), axis=2)
+    den = (
+        la * lb * lc
+        + np.sum(av * bv, axis=2) * lc
+        + np.sum(av * cv, axis=2) * lb
+        + np.sum(bv * cv, axis=2) * la
+    )
+    winding = np.sum(np.arctan2(num, den), axis=1) / (2.0 * np.pi)
+    inside = np.abs(winding) > 0.5  # orientation-independent
+
+    return np.where(inside, -unsigned, unsigned)
+
+
+# ---- Marching cubes via VTK ------------------------------------------------
+
+
+def _marching_cubes(
+    func: ImplicitFunc,
+    bounds: Bounds,
+    resolution: float,
+    level: float,
+    close_boundary: bool,
+) -> Tuple[np.ndarray, np.ndarray]:
+    (x0, y0, z0), (x1, y1, z1) = bounds
+
+    nx = max(int(np.ceil((x1 - x0) / resolution)), 2)
+    ny = max(int(np.ceil((y1 - y0) / resolution)), 2)
+    nz = max(int(np.ceil((z1 - z0) / resolution)), 2)
+
+    xs = np.linspace(x0, x1, nx)
+    ys = np.linspace(y0, y1, ny)
+    zs = np.linspace(z0, z1, nz)
+
+    dx = (x1 - x0) / (nx - 1)
+    dy = (y1 - y0) / (ny - 1)
+    dz = (z1 - z0) / (nz - 1)
+
+    grid = np.stack(np.meshgrid(xs, ys, zs, indexing="ij"), axis=-1)
+    points = grid.reshape(-1, 3)
+    # vol[i, j, k] == func(xs[i], ys[j], zs[k])  (C-order reshape matches the
+    # meshgrid 'ij' iteration order, where the last axis varies fastest).
+    vol: np.ndarray = np.asarray(func(points), dtype=np.float64).reshape(nx, ny, nz)
+
+    origin = (x0, y0, z0)
+    if close_boundary:
+        # Pad with one layer of "outside" (positive) values on every face so
+        # marching cubes caps any surface that reaches the bounding box,
+        # yielding a watertight mesh. The pad value must exceed `level`.
+        pad_value = max(float(np.nanmax(vol)), level) + abs(level) + 1.0
+        vol = np.pad(vol, 1, mode="constant", constant_values=pad_value)
+        origin = (x0 - dx, y0 - dy, z0 - dz)
+
+    dims = vol.shape  # (Nx, Ny, Nz) after optional padding
+
+    image_data = vtkImageData()
+    image_data.SetDimensions(*dims)
+    image_data.SetOrigin(*origin)
+    image_data.SetSpacing(dx, dy, dz)
+
+    # VTK vtkImageData expects the scalar array flattened x-fastest (Fortran
+    # order over (Nx, Ny, Nz)); a plain C-order ravel would transpose the field.
+    vtk_arr = numpy_to_vtk(vol.ravel(order="F"), deep=True)
+    vtk_arr.SetName("implicit")
+    image_data.GetPointData().SetScalars(vtk_arr)
+
+    mc = vtkMarchingCubes()
+    mc.SetInputData(image_data)
+    mc.SetValue(0, level)
+    mc.ComputeNormalsOff()
+    mc.Update()
+
+    polydata = mc.GetOutput()
+    if polydata.GetNumberOfCells() == 0:
+        raise ValueError(
+            "Marching cubes produced no triangles. Check that the isosurface "
+            f"at level={level} intersects the bounds."
+        )
+
+    vtk_pts = vtk_to_numpy(polydata.GetPoints().GetData()).copy()
+    n_cells = polydata.GetNumberOfCells()
+    faces_list = []
+    for i in range(n_cells):
+        cell = polydata.GetCell(i)
+        ids = cell.GetPointIds()
+        faces_list.append([ids.GetId(j) for j in range(ids.GetNumberOfIds())])
+    vtk_faces = np.array(faces_list, dtype=np.int64)
+
+    # SDF convention: negative = inside. VTK marching cubes generates outward
+    # normals for the "high" side, so flip winding to get correct orientation.
+    vtk_faces = vtk_faces[:, ::-1]
+
+    return vtk_pts, vtk_faces
+
+
+# ---- Mesh -> build123d Solid via OCP sewing --------------------------------
+
+
+def _mesh_to_solid(verts: np.ndarray, faces: np.ndarray) -> Solid:
+    stl_path = os.path.join(tempfile.mkdtemp(), "_implicit.stl")
+    _write_binary_stl(stl_path, verts, faces)
+
+    reader = StlAPI_Reader()
+    shape = TopoDS_Shape()
+    reader.Read(shape, stl_path)
+
+    sewing = BRepBuilderAPI_Sewing(1e-6)
+    sewing.Add(shape)
+    sewing.Perform()
+    sewn = sewing.SewedShape()
+
+    maker = BRepBuilderAPI_MakeSolid()
+    if sewn.ShapeType() == TopAbs_SHELL:
+        maker.Add(TopoDS.Shell(sewn))
+    else:
+        explorer = TopExp_Explorer(sewn, TopAbs_SHELL)
+        while explorer.More():
+            maker.Add(TopoDS.Shell(explorer.Current()))
+            explorer.Next()
+
+    maker.Build()
+    if not maker.IsDone():
+        raise RuntimeError(
+            "Failed to build solid from mesh -- mesh may not be watertight"
+        )
+
+    os.unlink(stl_path)
+    return Solid(maker.Solid())
+
+
+def _write_binary_stl(path: str, verts: np.ndarray, faces: np.ndarray) -> None:
+    """Write a binary STL, fully vectorized (no per-triangle Python loop)."""
+    tris = verts[faces].astype(np.float32)  # (F, 3, 3)
+    v0, v1, v2 = tris[:, 0], tris[:, 1], tris[:, 2]
+    normals = np.cross(v1 - v0, v2 - v0)
+    lengths = np.linalg.norm(normals, axis=1, keepdims=True)
+    np.divide(normals, lengths, out=normals, where=lengths != 0)
+
+    n_tri = len(tris)
+    record = np.dtype(
+        [
+            ("normal", "<3f4"),
+            ("v0", "<3f4"),
+            ("v1", "<3f4"),
+            ("v2", "<3f4"),
+            ("attr", "<u2"),
+        ]
+    )
+    data = np.empty(n_tri, dtype=record)
+    data["normal"] = normals.astype(np.float32)
+    data["v0"] = v0
+    data["v1"] = v1
+    data["v2"] = v2
+    data["attr"] = 0
+
+    with open(path, "wb") as f:
+        f.write(b"\0" * 80)
+        f.write(struct.pack("<I", n_tri))
+        f.write(data.tobytes())

--- a/tests/test_implicit.py
+++ b/tests/test_implicit.py
@@ -1,0 +1,183 @@
+"""
+build123d implicit field tests
+
+name: test_implicit.py
+by:   Joshua Gibbins (GibbinsJosh)
+date: June 3, 2026
+
+desc: Unit tests for build123d.implicit -- the bidirectional bridge between
+      implicit/scalar fields and B-rep solids (implicit_solid, implicit_mesh,
+      implicit_stl, mesh_to_sdf, SignedDistanceField).
+
+license: Apache-2.0 (see build123d/src/build123d/implicit.py)
+"""
+
+import math
+import struct
+import tempfile
+import unittest
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+
+from build123d.exporters3d import export_step, export_stl
+from build123d.implicit import (
+    SignedDistanceField,
+    implicit_mesh,
+    implicit_solid,
+    implicit_stl,
+    mesh_to_sdf,
+)
+from build123d.importers import import_stl
+from build123d.objects_part import Box
+from build123d.topology import Solid
+
+
+def sphere_sdf(radius=10.0, center=(0.0, 0.0, 0.0)):
+    """Analytic signed-distance field of a sphere (negative inside)."""
+    c = np.asarray(center, dtype=float)
+    return lambda p: np.linalg.norm(p - c, axis=1) - radius
+
+
+def is_watertight(faces):
+    """True if every edge is shared by exactly two triangles."""
+    edge_count = defaultdict(int)
+    for tri in faces:
+        for a, b in ((tri[0], tri[1]), (tri[1], tri[2]), (tri[2], tri[0])):
+            edge_count[(min(a, b), max(a, b))] += 1
+    return all(count == 2 for count in edge_count.values())
+
+
+class TestImplicitSolid(unittest.TestCase):
+    """Forward direction: implicit field -> Solid."""
+
+    def test_sphere_volume(self):
+        solid = implicit_solid(sphere_sdf(10), ((-12,) * 3, (12,) * 3), 0.6)
+        self.assertIsInstance(solid, Solid)
+        # within ~4% of the analytic volume (marching-cubes discretisation)
+        self.assertAlmostEqual(solid.volume, 4.0 / 3.0 * math.pi * 10**3, delta=180)
+
+    def test_returns_valid_solid(self):
+        solid = implicit_solid(sphere_sdf(8), ((-10,) * 3, (10,) * 3), 0.6)
+        self.assertTrue(solid.is_valid)
+        self.assertGreater(solid.volume, 0)
+
+    def test_level_offset_grows_surface(self):
+        bounds = ((-15,) * 3, (15,) * 3)
+        small = implicit_solid(sphere_sdf(8), bounds, 0.8, level=0.0).volume
+        big = implicit_solid(sphere_sdf(8), bounds, 0.8, level=3.0).volume
+        self.assertGreater(big, small)  # level shifts the isosurface outward
+
+    def test_close_boundary_caps_to_watertight(self):
+        # A sphere larger than the box pokes through its faces; capping the
+        # padded grid must close those openings into a watertight mesh.
+        _, faces = implicit_mesh(
+            sphere_sdf(10), ((-8,) * 3, (8,) * 3), 0.5, close_boundary=True
+        )
+        self.assertTrue(is_watertight(faces))
+
+    def test_no_surface_raises(self):
+        with self.assertRaises(ValueError):
+            implicit_solid(lambda p: np.ones(len(p)), ((-1,) * 3, (1,) * 3), 0.5)
+
+
+class TestImplicitMesh(unittest.TestCase):
+    def test_array_shapes(self):
+        verts, faces = implicit_mesh(sphere_sdf(10), ((-12,) * 3, (12,) * 3), 0.8)
+        self.assertEqual(verts.ndim, 2)
+        self.assertEqual(verts.shape[1], 3)
+        self.assertEqual(faces.shape[1], 3)
+        self.assertTrue(faces.max() < len(verts))  # indices reference vertices
+
+
+class TestImplicitStl(unittest.TestCase):
+    def test_writes_readable_stl(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "sphere.stl"
+            _, faces = implicit_stl(sphere_sdf(10), ((-12,) * 3, (12,) * 3), 0.8, path)
+            self.assertTrue(path.exists())
+            # binary STL header stores the triangle count
+            with open(path, "rb") as f:
+                f.seek(80)
+                n_tri = struct.unpack("<I", f.read(4))[0]
+            self.assertEqual(n_tri, len(faces))
+            # OCC can read it back
+            self.assertGreater(import_stl(str(path)).area, 0)
+
+
+class TestMeshToSdf(unittest.TestCase):
+    """Reverse direction: Solid / STEP / STL -> signed-distance field."""
+
+    def setUp(self):
+        self.box = Box(20, 14, 8)
+        self.sdf = mesh_to_sdf(self.box)
+
+    def test_returns_field(self):
+        self.assertIsInstance(self.sdf, SignedDistanceField)
+
+    def test_call_returns_column(self):
+        out = self.sdf(np.zeros((5, 3)))
+        self.assertEqual(out.shape, (5, 1))
+
+    def test_bounds_match_box(self):
+        (x0, y0, z0), (x1, y1, z1) = self.sdf.bounds
+        self.assertAlmostEqual(x0, -10, places=5)
+        self.assertAlmostEqual(y0, -7, places=5)
+        self.assertAlmostEqual(z0, -4, places=5)
+        self.assertAlmostEqual(x1, 10, places=5)
+        self.assertAlmostEqual(y1, 7, places=5)
+        self.assertAlmostEqual(z1, 4, places=5)
+
+    def test_sign_inside_outside(self):
+        self.assertLess(self.sdf(np.array([[0, 0, 0]]))[0, 0], 0)  # inside
+        self.assertGreater(self.sdf(np.array([[0, 0, 20]]))[0, 0], 0)  # outside
+
+    def test_exact_distance(self):
+        # Distances to the flat faces of the box are exact (no curvature error).
+        vals = self.sdf(np.array([[0, 0, 0], [9, 0, 0], [11, 0, 0]])).ravel()
+        self.assertAlmostEqual(vals[0], -4.0, places=3)  # center to nearest face
+        self.assertAlmostEqual(vals[1], -1.0, places=3)  # 1 mm inside +x face
+        self.assertAlmostEqual(vals[2], 1.0, places=3)  # 1 mm outside +x face
+
+    def test_roundtrip_volume(self):
+        # Solid -> field -> Solid reproduces the volume within discretisation.
+        rebuilt = implicit_solid(self.sdf, bounds=self.sdf.bounds, resolution=0.5)
+        self.assertAlmostEqual(
+            rebuilt.volume, self.box.volume, delta=self.box.volume * 0.03
+        )
+
+    def test_offset_behaves_as_metric_sdf(self):
+        # f + d erodes, f - d dilates: only true for a real distance field.
+        eroded = implicit_solid(
+            lambda p: self.sdf(p) + 2.0, bounds=self.sdf.bounds, resolution=0.7
+        ).volume
+        dilated = implicit_solid(
+            lambda p: self.sdf(p) - 2.0,
+            bounds=((-13, -10, -7), (13, 10, 7)),
+            resolution=0.7,
+        ).volume
+        self.assertLess(eroded, self.box.volume)
+        self.assertLess(self.box.volume, dilated)
+
+    def test_step_file_input(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "box.step"
+            export_step(self.box, str(path))
+            sdf = mesh_to_sdf(str(path), tolerance=0.1)
+            self.assertLess(sdf(np.array([[0, 0, 0]]))[0, 0], 0)
+
+    def test_stl_file_input(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "box.stl"
+            export_stl(self.box, str(path))
+            sdf = mesh_to_sdf(str(path))
+            self.assertLess(sdf(np.array([[0, 0, 0]]))[0, 0], 0)
+
+    def test_unsupported_source_raises(self):
+        with self.assertRaises(ValueError):
+            mesh_to_sdf("not_a_mesh.obj")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `build123d.implicit` — a bidirectional bridge between implicit/scalar fields and B-rep solids:

```
implicit field  --implicit_solid()-->  Solid          (VTK marching cubes)
Solid/STEP/STL  --mesh_to_sdf()---->    signed-distance field
```

Both directions share the signed-distance convention (`f < 0` inside), so a `mesh_to_sdf()` field plugs straight back into `implicit_solid()` — combine a B-rep part with analytic fields, then re-mesh. This enables modelling that is awkward or impossible with B-rep booleans alone: TPMS infill, lattice structures, smooth (metaball) blends, functionally graded structures, and robust uniform shelling.

## Public API (exported from `build123d`)

| Function | Purpose |
|---|---|
| `implicit_solid(func, bounds, resolution, *, level=0, close_boundary=True)` | field → watertight `Solid` |
| `implicit_mesh(...)` | field → raw `(vertices, faces)` |
| `implicit_stl(..., file_path)` | field → binary STL (fast path, no OCC sewing) |
| `mesh_to_sdf(source, *, tolerance=…)` | `Shape`/STEP/STL → `SignedDistanceField` callable |
| `SignedDistanceField` | the callable returned by `mesh_to_sdf` (carries `.bounds`) |

## How it works

- **Marching cubes** via VTK (already a build123d dependency — see `vtk_tools.py`). The sampling grid is padded with an "outside" border so any surface reaching the bounds is capped → guaranteed watertight output.
- **`mesh_to_sdf`** reconstructs the field from a triangulation with the exact point-to-triangle distance (Ericson closest-feature) for magnitude and the generalized winding number (Jacobson et al.) for sign — orientation-independent and robust for watertight tessellations. Pure NumPy, no new dependencies.

## Examples (`examples/`)

Each targets something B-rep handles poorly:

- **smooth_blend.py** — smooth-minimum (organic fillets / metaballs); renders a hard union beside a smooth union of the same spheres.
- **graded_lattice.py** — functionally graded lattice whose strut radius varies with height; one expression, no per-strut modelling.
- **conformal_shell.py** — uniform `abs(f) - t` shell of a curved "peanut" with a gyroid infill that follows the wall, shown as a cutaway.
- **gyroid_infill.py** — gyroid TPMS infill clipped to a part via `mesh_to_sdf`.
- **lattice_infill.py** — periodic strut lattice clipped to a sphere.

## Tests

`tests/test_implicit.py` — 17 cases covering both directions: sphere volume accuracy, valid `Solid`, level offset, `close_boundary` → watertight, empty-field `ValueError`; STL written and re-readable; `SignedDistanceField` type/shape/bounds, inside-outside sign, exact face distances, `Solid → field → Solid` round-trip, metric offset (erode/dilate), STEP + STL file inputs, unsupported-source `ValueError`. The five examples are exercised by the existing `tests/test_examples.py` harness.

## Verification (run natively against the dev source)

- `pylint --rcfile=.pylintrc src/build123d/implicit.py` → **10.00/10**
- `mypy --config-file mypy.ini src/build123d/implicit.py` → **clean**
- `black --check` → clean
- `pytest tests/test_implicit.py` → **17 passed**; all five examples pass `tests/test_examples.py`

## Known limitation

`mesh_to_sdf` evaluation is `O(n_points × n_triangles)` — cheap for low-poly inputs or sparse queries, but meshing the field of a densely tessellated part over a fine grid is slow. This is documented in the docstring. A spatial-acceleration follow-up (KD-tree distance + angle-weighted-pseudonormal sign) would make it `O(n log m)`; happy to do it in a follow-up if there's interest.

## Notes

- No new runtime dependencies (VTK and NumPy are already required).
- New file `src/build123d/implicit.py`; `__init__.py` gains one import and five `__all__` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
