### PR TITLE
Add export_to_pcbway function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "scipy",
     "scikit-learn >= 1.5, < 2",
     "webcolors ~= 24.8.0",
+    "requests >= 2.32, < 3",
 
     # Install standard official lib3mf on everything EXCEPT linux aarch64
     "lib3mf >= 2.4.1; sys_platform != 'linux' or platform_machine != 'aarch64'",

--- a/src/build123d/__init__.py
+++ b/src/build123d/__init__.py
@@ -246,4 +246,5 @@ __all__ = [
     "export_gltf",
     "export_stl",
     "export_brep",
+    "export_to_pcbway",
 ]

--- a/src/build123d/exporters3d.py
+++ b/src/build123d/exporters3d.py
@@ -29,13 +29,17 @@ license:
 # pylint has trouble with the OCP imports
 # pylint: disable=no-name-in-module, import-error
 
-from datetime import datetime
+import tempfile
 import warnings
+import webbrowser
+from datetime import datetime
 from io import BytesIO
-from os import PathLike, fsdecode, fspath
+from os import PathLike, fsdecode
+from pathlib import Path
 from typing import BinaryIO, cast
 
 import OCP.TopAbs as ta
+import requests
 from anytree import PreOrderIter
 from OCP.APIHeaderSection import APIHeaderSection_MakeHeader
 from OCP.BRepMesh import BRepMesh_IncrementalMesh
@@ -452,3 +456,77 @@ def export_stl(
 
     writer.ASCIIMode = ascii_format
     return writer.Write(to_export.wrapped, fsdecode(file_path))
+
+
+def export_to_pcbway(
+    to_export: Shape,
+    unit: Unit = Unit.MM,
+    write_pcurves: bool = True,
+    precision_mode: PrecisionMode = PrecisionMode.AVERAGE,
+) -> str:
+    """Export a shape to PCBWay for quoting.
+
+    This function writes ``to_export`` to a temporary STEP file, uploads that file
+    to PCBWay's external web service, opens the returned pricing page in the
+    default browser, and returns the pricing page URL.
+
+    Args:
+        to_export (Shape): object or assembly
+        unit (Unit, optional): shape units. Defaults to Unit.MM.
+        write_pcurves (bool, optional): write parametric curves to the STEP file.
+            Defaults to True.
+        precision_mode (PrecisionMode, optional): geometric data precision.
+            Defaults to PrecisionMode.AVERAGE.
+
+    Returns:
+        str: URL of the pricing page
+    """
+    # PCBWay specific URLs for build123d uploads
+    upload_url = "https://www.pcbway.com/common/Build123dUpFile"
+    redirect_url = ""
+
+    # Export the part to a temp file
+    step_file = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".step", delete=False) as tmp:
+            step_file = Path(tmp.name)
+
+        # Re-open the tmp file to help with Windows compatibility
+        export_step(
+            to_export,
+            step_file,
+            unit=unit,
+            write_pcurves=write_pcurves,
+            precision_mode=precision_mode,
+        )
+
+        # Transfer the step file
+        with open(step_file, "rb") as f:
+            response = requests.post(
+                upload_url,
+                files={"file": (step_file.name, f, "application/step")},
+                timeout=(10, 120),
+            )
+        response.raise_for_status()
+
+        try:
+            result = response.json()
+        except ValueError as exc:
+            raise RuntimeError(
+                f"PCBWay returned a non-JSON response: {response.text[:500]}"
+            ) from exc
+        redirect_url = result.get("redirect")
+        if result.get("state") != "SUCCESS" or not isinstance(redirect_url, str):
+            raise RuntimeError(
+                f"PCBWay upload failed or returned no redirect: {result}"
+            )
+
+    # Always remove the tmp file
+    finally:
+        if step_file is not None:
+            step_file.unlink(missing_ok=True)
+
+    if not webbrowser.open(redirect_url, new=2):
+        warnings.warn(f"webbrowser failed to open on pricing page {redirect_url}")
+
+    return redirect_url

--- a/tests/test_exporters3d.py
+++ b/tests/test_exporters3d.py
@@ -35,15 +35,23 @@ from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryFile
 from typing import Optional
+from unittest.mock import Mock, patch
 from zoneinfo import ZoneInfo
 
 import pytest
+import requests
 
 from build123d.build_common import GridLocations
 from build123d.build_enums import Unit
 from build123d.build_line import BuildLine
 from build123d.build_sketch import BuildSketch
-from build123d.exporters3d import export_brep, export_gltf, export_step, export_stl
+from build123d.exporters3d import (
+    export_brep,
+    export_gltf,
+    export_step,
+    export_stl,
+    export_to_pcbway,
+)
 from build123d.geometry import Color, Pos, Vector, VectorLike
 from build123d.objects_curve import Line
 from build123d.objects_part import Box, Sphere
@@ -224,6 +232,133 @@ class TestExportStep(DirectApiTestCase):
         self.assertNotEqual(step_data.find("PRODUCT('child_blue',"), -1)
         self.assertNotEqual(step_data.find("DRAUGHTING_PRE_DEFINED_COLOUR('red')"), -1)
         self.assertNotEqual(step_data.find("DRAUGHTING_PRE_DEFINED_COLOUR('blue')"), -1)
+
+
+class TestExportToPcbWay(DirectApiTestCase):
+    def _mock_response(self, payload=None, json_error=None, http_error=None):
+        response = Mock()
+        response.text = "response body"
+        if http_error is None:
+            response.raise_for_status.return_value = None
+        else:
+            response.raise_for_status.side_effect = http_error
+        if json_error is None:
+            response.json.return_value = payload
+        else:
+            response.json.side_effect = json_error
+        return response
+
+    def _post_side_effect(self, response, uploaded_paths):
+        def post(_url, files, timeout):
+            uploaded_paths.append(Path(files["file"][1].name))
+            return response
+
+        return post
+
+    @patch("build123d.exporters3d.webbrowser.open", return_value=True)
+    @patch("build123d.exporters3d.export_step")
+    @patch("build123d.exporters3d.requests.post")
+    def test_export_to_pcbway_success(
+        self,
+        mock_post,
+        mock_export_step,
+        mock_browser_open,
+    ):
+        redirect_url = "https://www.pcbway.com/rapid-prototyping/manufacture/test"
+        response = self._mock_response({"state": "SUCCESS", "redirect": redirect_url})
+        uploaded_paths = []
+        mock_post.side_effect = self._post_side_effect(response, uploaded_paths)
+
+        result = export_to_pcbway(Box(1, 1, 1))
+
+        self.assertEqual(result, redirect_url)
+        mock_export_step.assert_called_once()
+        mock_post.assert_called_once()
+        self.assertEqual(mock_post.call_args.kwargs["timeout"], (10, 120))
+        mock_browser_open.assert_called_once_with(redirect_url, new=2)
+        self.assertEqual(len(uploaded_paths), 1)
+        self.assertFalse(uploaded_paths[0].exists())
+
+    @patch("build123d.exporters3d.webbrowser.open")
+    @patch("build123d.exporters3d.export_step")
+    @patch("build123d.exporters3d.requests.post")
+    def test_export_to_pcbway_http_error_removes_temp_file(
+        self,
+        mock_post,
+        _mock_export_step,
+        mock_browser_open,
+    ):
+        response = self._mock_response(http_error=requests.HTTPError("bad status"))
+        uploaded_paths = []
+        mock_post.side_effect = self._post_side_effect(response, uploaded_paths)
+
+        with self.assertRaises(requests.HTTPError):
+            export_to_pcbway(Box(1, 1, 1))
+
+        mock_browser_open.assert_not_called()
+        self.assertEqual(len(uploaded_paths), 1)
+        self.assertFalse(uploaded_paths[0].exists())
+
+    @patch("build123d.exporters3d.webbrowser.open")
+    @patch("build123d.exporters3d.export_step")
+    @patch("build123d.exporters3d.requests.post")
+    def test_export_to_pcbway_non_json_response_removes_temp_file(
+        self,
+        mock_post,
+        _mock_export_step,
+        mock_browser_open,
+    ):
+        response = self._mock_response(json_error=ValueError("not json"))
+        uploaded_paths = []
+        mock_post.side_effect = self._post_side_effect(response, uploaded_paths)
+
+        with self.assertRaisesRegex(RuntimeError, "non-JSON response"):
+            export_to_pcbway(Box(1, 1, 1))
+
+        mock_browser_open.assert_not_called()
+        self.assertEqual(len(uploaded_paths), 1)
+        self.assertFalse(uploaded_paths[0].exists())
+
+    @patch("build123d.exporters3d.webbrowser.open")
+    @patch("build123d.exporters3d.export_step")
+    @patch("build123d.exporters3d.requests.post")
+    def test_export_to_pcbway_failure_response_removes_temp_file(
+        self,
+        mock_post,
+        _mock_export_step,
+        mock_browser_open,
+    ):
+        response = self._mock_response({"state": "FAILED", "message": "no file"})
+        uploaded_paths = []
+        mock_post.side_effect = self._post_side_effect(response, uploaded_paths)
+
+        with self.assertRaisesRegex(RuntimeError, "returned no redirect"):
+            export_to_pcbway(Box(1, 1, 1))
+
+        mock_browser_open.assert_not_called()
+        self.assertEqual(len(uploaded_paths), 1)
+        self.assertFalse(uploaded_paths[0].exists())
+
+    @patch("build123d.exporters3d.webbrowser.open", return_value=False)
+    @patch("build123d.exporters3d.export_step")
+    @patch("build123d.exporters3d.requests.post")
+    def test_export_to_pcbway_browser_warning(
+        self,
+        mock_post,
+        _mock_export_step,
+        _mock_browser_open,
+    ):
+        redirect_url = "https://www.pcbway.com/rapid-prototyping/manufacture/test"
+        response = self._mock_response({"state": "SUCCESS", "redirect": redirect_url})
+        uploaded_paths = []
+        mock_post.side_effect = self._post_side_effect(response, uploaded_paths)
+
+        with self.assertWarnsRegex(Warning, "webbrowser failed"):
+            result = export_to_pcbway(Box(1, 1, 1))
+
+        self.assertEqual(result, redirect_url)
+        self.assertEqual(len(uploaded_paths), 1)
+        self.assertFalse(uploaded_paths[0].exists())
 
 
 class TestExportGltf(DirectApiTestCase):


### PR DESCRIPTION
Adds an export helper for uploading a STEP file to PCBWay and opening the returned pricing URL.

The implementation:
- exports the provided Shape to a temporary STEP file
- uploads it to PCBWay's Build123dUpFile endpoint
- parses the JSON response
- opens and returns the redirect/pricing URL
