### PR TITLE
feat: create planes from three points

### DIFF
--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -42,7 +42,6 @@ import logging
 import warnings
 from collections.abc import Callable, Iterable, Sequence
 from math import degrees, log10, pi, prod, radians
-from numbers import Real
 from typing import TYPE_CHECKING, Any, Type, TypeAlias, cast, overload
 
 import numpy as np
@@ -2839,13 +2838,9 @@ class Plane(metaclass=PlaneMeta):
                     if (
                         len(args) == 1
                         and not any((arg_x_dir, arg_y_dir, passed_y_dir, passed_z_dir))
-                        and not all(isinstance(point, Real) for point in arg0)
+                        and not all(isinstance(point, (int, float)) for point in arg0)
                     ):
-                        try:
-                            points = [Vector(point) for point in arg0]
-                        except TypeError:
-                            points = []
-
+                        points = [Vector(point) for point in arg0]
                         if len(points) == 3:
                             arg_origin = points[0]
                             arg_x_dir = points[1] - points[0]

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -42,6 +42,7 @@ import logging
 import warnings
 from collections.abc import Callable, Iterable, Sequence
 from math import degrees, log10, pi, prod, radians
+from numbers import Real
 from typing import TYPE_CHECKING, Any, Type, TypeAlias, cast, overload
 
 import numpy as np
@@ -2754,6 +2755,10 @@ class Plane(metaclass=PlaneMeta):
         """Return a plane from a OCCT gp_pln"""
 
     @overload
+    def __init__(self, points: Iterable[VectorLike]) -> None:
+        """Return a plane defined by three points"""
+
+    @overload
     def __init__(
         self,
         origin: VectorLike,
@@ -2789,7 +2794,9 @@ class Plane(metaclass=PlaneMeta):
         # pylint: disable=too-many-locals,too-many-branches,too-many-statements
         """Create a plane from either an OCCT gp_pln, Face, Location, or coordinates"""
 
-        type_error_message = "Expected gp_Pln, Face, Location, or VectorLike"
+        type_error_message = (
+            "Expected gp_Pln, Face, Location, Axis, VectorLike, or three points"
+        )
 
         passed_z_dir = "z_dir" in kwargs
         passed_y_dir = "y_dir" in kwargs
@@ -2829,7 +2836,25 @@ class Plane(metaclass=PlaneMeta):
                         raise TypeError(type_error_message) from exc
             elif arg_origin is None:
                 try:
-                    arg_origin = Vector(arg0)
+                    if (
+                        len(args) == 1
+                        and not any((arg_x_dir, arg_y_dir, passed_y_dir, passed_z_dir))
+                        and not all(isinstance(point, Real) for point in arg0)
+                    ):
+                        try:
+                            points = [Vector(point) for point in arg0]
+                        except TypeError:
+                            points = []
+
+                        if len(points) == 3:
+                            arg_origin = points[0]
+                            arg_x_dir = points[1] - points[0]
+                            arg_z_dir = arg_x_dir.cross(points[2] - points[0])
+                        else:
+                            arg_origin = Vector(arg0)
+                    else:
+                        arg_origin = Vector(arg0)
+
                     if arg_x_dir is None and len(args) > 1:
                         arg_x_dir = Vector(args[1]).normalized()
                     if len(args) > 2:

--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -2835,18 +2835,25 @@ class Plane(metaclass=PlaneMeta):
                         raise TypeError(type_error_message) from exc
             elif arg_origin is None:
                 try:
-                    if (
-                        len(args) == 1
-                        and not any((arg_x_dir, arg_y_dir, passed_y_dir, passed_z_dir))
-                        and not all(isinstance(point, (int, float)) for point in arg0)
+                    if len(args) == 1 and not any(
+                        (arg_x_dir, arg_y_dir, passed_y_dir, passed_z_dir)
                     ):
-                        points = [Vector(point) for point in arg0]
-                        if len(points) == 3:
+                        arg0_sequence = list(arg0)
+                        if all(
+                            isinstance(coordinate, (int, float))
+                            for coordinate in arg0_sequence
+                        ):
+                            arg_origin = Vector(arg0_sequence)
+                        else:
+                            if len(arg0_sequence) != 3:
+                                raise TypeError("Expected three VectorLike points")
+                            try:
+                                points = [Vector(point) for point in arg0_sequence]
+                            except Exception as exc:
+                                raise TypeError("Expected three VectorLike points") from exc
                             arg_origin = points[0]
                             arg_x_dir = points[1] - points[0]
                             arg_z_dir = arg_x_dir.cross(points[2] - points[0])
-                        else:
-                            arg_origin = Vector(arg0)
                     else:
                         arg_origin = Vector(arg0)
 
@@ -2854,6 +2861,8 @@ class Plane(metaclass=PlaneMeta):
                         arg_x_dir = Vector(args[1]).normalized()
                     if len(args) > 2:
                         arg_z_dir = Vector(args[2]).normalized()
+                except TypeError:
+                    raise
                 except Exception as exc:
                     raise TypeError(type_error_message) from exc
 

--- a/tests/test_direct_api/test_plane.py
+++ b/tests/test_direct_api/test_plane.py
@@ -181,6 +181,20 @@ class TestPlane(unittest.TestCase):
         with self.assertRaises(TypeError):
             Plane(Edge.make_line((0, 0), (0, 1)))
 
+        # from three points, with the first two points defining x_dir and all
+        # three points defining the normal
+        point_plane = Plane([(0, 1, 2), (-3, 4, 5), (6, 7, -8)])
+        self.assertAlmostEqual(point_plane.origin, (0, 1, 2), 6)
+        self.assertAlmostEqual(point_plane.x_dir, Vector((-3, 3, 3)).normalized(), 6)
+        self.assertAlmostEqual(
+            point_plane.z_dir,
+            Vector((-3, 3, 3)).cross(Vector((6, 6, -10))).normalized(),
+            6,
+        )
+
+        with self.assertRaises(ValueError):
+            Plane([(0, 0, 0), (1, 1, 1), (2, 2, 2)])
+
         # can be instantiated from planar faces of surface types other than Geom_Plane
         # this loft creates the trapezoid faces of type Geom_BSplineSurface
         lofted_solid = Solid.make_loft(

--- a/tests/test_direct_api/test_plane.py
+++ b/tests/test_direct_api/test_plane.py
@@ -195,6 +195,12 @@ class TestPlane(unittest.TestCase):
         with self.assertRaises(ValueError):
             Plane([(0, 0, 0), (1, 1, 1), (2, 2, 2)])
 
+        with self.assertRaises(TypeError):
+            Plane([(0, 0, 0), (1, 0, 0)])
+
+        with self.assertRaises(TypeError):
+            Plane([object(), object(), object()])
+
         # can be instantiated from planar faces of surface types other than Geom_Plane
         # this loft creates the trapezoid faces of type Geom_BSplineSurface
         lofted_solid = Solid.make_loft(


### PR DESCRIPTION
## Summary

Adds `Plane(points)` support for an iterable of three points.

The constructor now derives:

- `origin` from the first point
- `x_dir` from point 1 to point 2
- `z_dir` from the cross product of point 1->2 and point 1->3

It also keeps the existing `Plane(origin)`, `Plane(origin, x_dir)`, and `Plane(origin, x_dir, z_dir)` forms unchanged.

Closes #1078.

## Tests

- `.venv/bin/python -m pytest tests/test_direct_api/test_plane.py -q`
- `.venv/bin/python -m black --check src/build123d/geometry.py tests/test_direct_api/test_plane.py`
- `.venv/bin/python -m mypy src/build123d/geometry.py`
- `git diff --check`

I also ran `pylint src/build123d/geometry.py tests/test_direct_api/test_plane.py`; it currently reports existing module/test-suite warnings unrelated to this change.
