### PR TITLE
Fix import crash on uppercase .TTC font files

### DIFF
--- a/src/build123d/text.py
+++ b/src/build123d/text.py
@@ -135,7 +135,7 @@ class FontManager:
     ) -> list[str]:
         """Register all font faces in a font file and return font face names."""
         _, ext = os.path.splitext(path)
-        if ext.strip(".") == "ttc": # pragma: no cover
+        if ext.strip(".").lower() == "ttc": # pragma: no cover
             fonts = ttCollection.TTCollection(path)
         else:
             fonts = [TTFont(path)]


### PR DESCRIPTION
## Summary

Fixes #1333.

`FontManager.register_font` compared the font file extension case-sensitively, so font collections with an uppercase `.TTC` extension (common in `C:\Windows\Fonts` on CJK-locale Windows, e.g. `MSJH.TTC`, `MINGLIU.TTC`) fell through to the single-font `TTFont(path)` branch and raised `TTLibFileIsCollectionError` at `import build123d` time, making the dev branch unimportable on such systems.

One-line change: compare the extension case-insensitively so uppercase `.TTC` collections are loaded via `TTCollection` like their lowercase counterparts.

## Verification

On the affected machine (Windows 11 zh-TW, trigger file `C:\Windows\Fonts\HMFMMUEX.TTC`):

- before: `import build123d` raises `TTLibFileIsCollectionError` (traceback in #1333)
- after: import succeeds and `available_fonts` includes the faces from the `.TTC` collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)