### PR TITLE
one_d: arclength fraction

### DIFF
--- a/src/build123d/topology/one_d.py
+++ b/src/build123d/topology/one_d.py
@@ -3145,7 +3145,10 @@ class Edge(Mixin1D[TopoDS_Edge]):
             Vector(nearest_vertex) - pnt
         ).length <= TOLERANCE and nearest_vertex.wrapped is not None:
             param = BRep_Tool.Parameter_s(nearest_vertex.wrapped, self.wrapped)
-            return (param - param_min) / param_range
+            curve_adaptor = BRepAdaptor_Curve(self.wrapped)
+            u_value = GCPnts_AbscissaPoint.Length_s(curve_adaptor, param_min, param)
+            u_value /= GCPnts_AbscissaPoint.Length_s(curve_adaptor)
+            return u_value
 
         separation = self.distance_to(pnt)
         if not isclose_b(separation, 0, abs_tol=TOLERANCE):
@@ -3164,9 +3167,10 @@ class Edge(Mixin1D[TopoDS_Edge]):
         # be outside the given range
         curve_adaptor = BRepAdaptor_Curve(self.wrapped)
         if curve_adaptor.IsPeriodic():
-            u_value = ((param - param_min) % curve_adaptor.Period()) / param_range
-        else:
-            u_value = (param - param_min) / param_range
+            param = param_min + ((param - param_min) % curve_adaptor.Period())
+        u_value = GCPnts_AbscissaPoint.Length_s(curve_adaptor, param_min, param)
+        u_value /= GCPnts_AbscissaPoint.Length_s(curve_adaptor)
+
         # Validate that GeomAPI_ProjectPointOnCurve worked correctly
         if (self.position_at(u_value) - pnt).length < TOLERANCE:
             return u_value

--- a/tests/test_direct_api/test_edge.py
+++ b/tests/test_direct_api/test_edge.py
@@ -41,7 +41,7 @@ from build123d.build_enums import (
     Transition,
 )
 from build123d.geometry import Axis, Plane, Location, Vector
-from build123d.objects_curve import CenterArc, EllipticalCenterArc, Line
+from build123d.objects_curve import CenterArc, EllipticalCenterArc, Line, Spline
 from build123d.objects_sketch import Circle, Rectangle, RegularPolygon
 from build123d.objects_part import Box
 from build123d.operations_generic import sweep
@@ -224,6 +224,10 @@ class TestEdge(unittest.TestCase):
         l5 = l1.trim(0.5, Vertex(-1, 0))
         self.assertAlmostEqual(l5 @ 0, (0, 1, 0), 5)
         self.assertAlmostEqual(l5 @ 1, (-1, 0, 0), 5)
+
+        spline = Spline([(0, 0), (10, 8), (20, 0), (30, -4)]).edge()
+        l7 = spline.trim(0, (20, 0))
+        self.assertAlmostEqual(l7 @ 1, (20, 0, 0), 6)
 
         line.wrapped = None
         with self.assertRaises(ValueError):


### PR DESCRIPTION
I am not sure but I think that this extra division is correct so that we report the answer in the units of arclength fraction rather than parameter range fraction.  

I ran into this attempting to trim a spline to keep only the part above the X-axis, then add a mirrored copy of itself and make a face, but what was happening was that the fallback iterative branch was being taken and trim() was reporting a point at Y=1e-5 where it should be much closer to Y=0 as I intended to trim at the X-axis intersection. 

So, separately from this change, I am also suspicious of the rounding in the iterative approach - is it guaranteed that the answer reported there will always be within TOLERANCE ? Why bother with TOL_DIGITS at all?