### PR TITLE
feat(drafting): accept a VectorLike offset for ExtensionLine

### DIFF
--- a/src/build123d/drafting.py
+++ b/src/build123d/drafting.py
@@ -28,7 +28,7 @@ license:
 
 from dataclasses import dataclass
 from datetime import date
-from math import copysign, floor, gcd, log2, pi
+from math import copysign, floor, gcd, log2, pi, radians, sin
 from typing import cast, ClassVar, TypeAlias
 
 from collections.abc import Iterable
@@ -47,7 +47,15 @@ from build123d.build_enums import (
 )
 from build123d.build_line import BuildLine
 from build123d.build_sketch import BuildSketch
-from build123d.geometry import Axis, Location, Plane, Pos, Vector, VectorLike
+from build123d.geometry import (
+    TOLERANCE,
+    Axis,
+    Location,
+    Plane,
+    Pos,
+    Vector,
+    VectorLike,
+)
 from build123d.objects_curve import Line, TangentArc
 from build123d.objects_sketch import BaseSketchObject, Polygon, Text
 from build123d.operations_generic import fillet, mirror, sweep
@@ -478,6 +486,16 @@ class DimensionLine(BaseSketchObject):
         super().__init__(obj=sorted_d_lines[-1][0], rotation=0, align=None, mode=mode)
 
 
+# Angular tolerance for a vector ``offset``: how close to perpendicular (to the
+# dimension line) and to in-plane (XY) it must be. build123d expresses angular
+# tolerances in degrees (e.g. ``Axis.is_normal``); only a rough direction is needed
+# here (per the PR #1326 discussion), so this is deliberately looser than the geometry
+# default. It is used below as the equivalent unit-vector dot-product threshold;
+# linear/length comparisons use the geometry-wide ``TOLERANCE`` instead.
+_OFFSET_ANGULAR_TOL_DEGREES = 1.0
+_OFFSET_ANGULAR_DOT_TOL = sin(radians(_OFFSET_ANGULAR_TOL_DEGREES))
+
+
 class ExtensionLine(BaseSketchObject):
     """Sketch Object: Extension Line
 
@@ -489,7 +507,15 @@ class ExtensionLine(BaseSketchObject):
         border (PathDescriptor): a very general type of input defining the object to
             be dimensioned. Typically this value would be extracted from the part but is
             not restricted to this use.
-        offset (float): a distance to displace the dimension line from the edge of the object
+        offset (float | VectorLike): displacement of the dimension line from the edge of
+            the object. A ``float`` is a signed perpendicular distance (the legacy
+            behaviour, where the sign selects the side). A ``VectorLike`` is an explicit
+            displacement in the drawing (XY) plane: its magnitude is the distance, its
+            direction selects the side, removing the sign-convention guesswork. The vector
+            must be perpendicular to the dimension line (a small tolerance is allowed); if
+            ``measurement_direction`` is also given the two must be perpendicular,
+            otherwise the dimension line direction is inferred perpendicular to the
+            offset.
         draft (Draft): instance of Draft dataclass
         label (str, optional): a text string which will replace the length (or arc length)
             that would otherwise be extracted from the provided path. Providing a label is
@@ -514,7 +540,7 @@ class ExtensionLine(BaseSketchObject):
     def __init__(
         self,
         border: PathDescriptor,
-        offset: float,
+        offset: float | VectorLike,
         draft: Draft,
         sketch: Sketch | None = None,
         label: str | None = None,
@@ -529,8 +555,21 @@ class ExtensionLine(BaseSketchObject):
         context = BuildSketch._get_context(self)
         if sketch is None and not (context is None or context.sketch is None):
             sketch = context.sketch
-        if offset == 0:
-            raise ValueError("A dimension line should be used if offset is 0")
+
+        # offset is either a signed scalar (legacy) or an explicit displacement vector.
+        # A vector removes the sign-convention guesswork: its direction selects the side
+        # and its magnitude is the distance. It is applied perpendicular to the
+        # dimension line, so it must be perpendicular to the measurement direction.
+        offset_vector: Vector | None = None
+        if isinstance(offset, (int, float)):
+            if offset == 0:
+                raise ValueError("A dimension line should be used if offset is 0")
+        else:
+            offset_vector = Vector(offset)
+            if offset_vector.length < TOLERANCE:
+                raise ValueError("offset vector must be non-zero")
+            if abs(offset_vector.Z) > offset_vector.length * _OFFSET_ANGULAR_DOT_TOL:
+                raise ValueError("offset vector must lie in the drawing (XY) plane")
 
         # Create a wire modelling the path of the dimension lines from a variety of input types
         object_to_measure = Draft._process_path(border)
@@ -538,14 +577,31 @@ class ExtensionLine(BaseSketchObject):
             raise ValueError("Start and end points of border must be different.")
 
         if measurement_direction is not None:
-            if isinstance(measurement_direction, Iterable):
-                measurement_direction = Vector(measurement_direction)
+            measurement_direction = Vector(measurement_direction)
+            if measurement_direction.length < TOLERANCE:
+                raise ValueError("measurement_direction must be non-zero")
+        elif offset_vector is not None:
+            # No explicit measurement direction: the dimension line runs perpendicular
+            # to the offset (offset is the perpendicular displacement of the line).
+            # The 90° rotation in the XY plane is offset × Z.
+            measurement_direction = offset_vector.cross(Vector(0, 0, 1))
+            if measurement_direction.length < TOLERANCE:
+                raise ValueError(
+                    "offset vector must have a non-zero component in the XY plane"
+                )
+
+        if measurement_direction is not None:
             measure_object_span = object_to_measure.position_at(
                 1
             ) - object_to_measure.position_at(0)
             extent_along_wire = measure_object_span.project_to_line(
                 measurement_direction
             )
+            if extent_along_wire.length < TOLERANCE:
+                raise ValueError(
+                    "border has no extent along the measurement direction; the "
+                    "dimension would be degenerate"
+                )
             object_to_dimension = Edge.make_line(
                 object_to_measure.position_at(0),
                 object_to_measure.position_at(0) + extent_along_wire,
@@ -555,8 +611,34 @@ class ExtensionLine(BaseSketchObject):
 
         side_lut = {1: Side.RIGHT, -1: Side.LEFT}
 
+        if offset_vector is None:
+            signed_offset = cast(float, offset)
+        else:
+            # Reduce the vector to the legacy signed-distance convention so the rest of
+            # the pipeline (offset_2d point ordering, extension-line flip heuristic)
+            # behaves identically. The offset must be perpendicular to the dimension
+            # line (equivalently, to measurement_direction when given); its sign against
+            # the in-plane right normal (path direction × Z) selects the side. The XY-
+            # plane check above guarantees this in-plane component is non-zero.
+            path_direction = (
+                object_to_dimension.position_at(1)
+                - object_to_dimension.position_at(0)
+            ).normalized()
+            along_line = offset_vector.normalized().dot(path_direction)
+            if abs(along_line) > _OFFSET_ANGULAR_DOT_TOL:
+                raise ValueError(
+                    "offset vector must be perpendicular to the dimension line "
+                    "(when measurement_direction is given, perpendicular to it)"
+                )
+            right_normal = path_direction.cross(Vector(0, 0, 1))
+            side_dot = offset_vector.dot(right_normal)
+            signed_offset = copysign(offset_vector.length, side_dot)
+
+        dimension_distance = signed_offset
+        dimension_side = side_lut[int(copysign(1, signed_offset))]
+
         dimension_path = object_to_dimension.offset_2d(
-            distance=offset, side=side_lut[int(copysign(1, offset))], closed=False
+            distance=dimension_distance, side=dimension_side, closed=False
         )
         dimension_label_str = (
             label
@@ -571,7 +653,7 @@ class ExtensionLine(BaseSketchObject):
             for e in [0, 1]
         ]
         # If the dimension path was created backwards, flip the extension lines
-        if abs(extension_lines[0].length - abs(offset)) > 1e-4:
+        if abs(extension_lines[0].length - abs(dimension_distance)) > 1e-4:
             extension_lines = [
                 Edge.make_line(
                     object_to_measure.position_at(e), dimension_path.position_at(1 - e)

--- a/src/build123d/drafting.py
+++ b/src/build123d/drafting.py
@@ -486,12 +486,11 @@ class DimensionLine(BaseSketchObject):
         super().__init__(obj=sorted_d_lines[-1][0], rotation=0, align=None, mode=mode)
 
 
-# Angular tolerance for a vector ``offset``: how close to perpendicular (to the
-# dimension line) and to in-plane (XY) it must be. build123d expresses angular
-# tolerances in degrees (e.g. ``Axis.is_normal``); only a rough direction is needed
-# here (per the PR #1326 discussion), so this is deliberately looser than the geometry
-# default. It is used below as the equivalent unit-vector dot-product threshold;
-# linear/length comparisons use the geometry-wide ``TOLERANCE`` instead.
+# Angular tolerance for how close a vector ``offset`` must be to perpendicular
+# to the dimension line. Only a rough direction is needed (per the PR #1326
+# discussion), so this is deliberately looser than the geometry default. It is
+# used below as the equivalent unit-vector dot-product threshold; linear/length
+# comparisons use the geometry-wide ``TOLERANCE`` instead.
 _OFFSET_ANGULAR_TOL_DEGREES = 1.0
 _OFFSET_ANGULAR_DOT_TOL = sin(radians(_OFFSET_ANGULAR_TOL_DEGREES))
 
@@ -568,8 +567,9 @@ class ExtensionLine(BaseSketchObject):
             offset_vector = Vector(offset)
             if offset_vector.length < TOLERANCE:
                 raise ValueError("offset vector must be non-zero")
-            if abs(offset_vector.Z) > offset_vector.length * _OFFSET_ANGULAR_DOT_TOL:
+            if abs(offset_vector.Z) > TOLERANCE:
                 raise ValueError("offset vector must lie in the drawing (XY) plane")
+            offset_vector = Vector(offset_vector.X, offset_vector.Y)
 
         # Create a wire modelling the path of the dimension lines from a variety of input types
         object_to_measure = Draft._process_path(border)
@@ -580,6 +580,13 @@ class ExtensionLine(BaseSketchObject):
             measurement_direction = Vector(measurement_direction)
             if measurement_direction.length < TOLERANCE:
                 raise ValueError("measurement_direction must be non-zero")
+            if abs(measurement_direction.Z) > TOLERANCE:
+                raise ValueError(
+                    "measurement_direction must lie in the drawing (XY) plane"
+                )
+            measurement_direction = Vector(
+                measurement_direction.X, measurement_direction.Y
+            )
         elif offset_vector is not None:
             # No explicit measurement direction: the dimension line runs perpendicular
             # to the offset (offset is the perpendicular displacement of the line).

--- a/tests/test_drafting.py
+++ b/tests/test_drafting.py
@@ -441,6 +441,95 @@ class ExtensionLineTestCase(unittest.TestCase):
                 measurement_direction=Vector(0, 1, 0),
             )
 
+    def test_vector_offset_above_horizontal_edge(self):
+        """A vector offset places the dimension on the side it points to."""
+        edge = Edge.make_line((0, 0), (40, 0))
+        above = ExtensionLine(border=edge, offset=(0, 10), draft=metric)
+        below = ExtensionLine(border=edge, offset=(0, -10), draft=metric)
+        self.assertGreater(above.center(CenterOf.BOUNDING_BOX).Y, 0)
+        self.assertLess(below.center(CenterOf.BOUNDING_BOX).Y, 0)
+
+    def test_vector_offset_left_right_of_vertical_edge(self):
+        """A vector offset on a vertical edge chooses left/right by direction."""
+        edge = Edge.make_line((0, 0), (0, 40))
+        right = ExtensionLine(border=edge, offset=(10, 0), draft=metric)
+        left = ExtensionLine(border=edge, offset=(-10, 0), draft=metric)
+        self.assertGreater(right.center(CenterOf.BOUNDING_BOX).X, 0)
+        self.assertLess(left.center(CenterOf.BOUNDING_BOX).X, 0)
+
+    def test_vector_offset_magnitude_matches_scalar(self):
+        """A vector offset matches the equivalent signed-scalar offset.
+
+        On a horizontal edge, offset=(0, 10) (up) is equivalent to scalar offset=-10.
+        """
+        edge = Edge.make_line((0, 0), (40, 0))
+        by_vector = ExtensionLine(border=edge, offset=(0, 10), draft=metric)
+        by_scalar = ExtensionLine(border=edge, offset=-10, draft=metric)
+        vbb, sbb = by_vector.bounding_box(), by_scalar.bounding_box()
+        self.assertAlmostEqual(vbb.min.Y, sbb.min.Y, places=4)
+        self.assertAlmostEqual(vbb.max.Y, sbb.max.Y, places=4)
+        self.assertAlmostEqual(by_vector.dimension, by_scalar.dimension, places=4)
+
+    def test_vector_offset_infers_measurement_direction(self):
+        """With no measurement_direction the dimension runs perpendicular to the offset:
+        a vertical offset on a diagonal border measures the horizontal extent."""
+        diagonal = Edge.make_line((0, 0), (10, 10))
+        ext = ExtensionLine(border=diagonal, offset=(0, 5), draft=metric)
+        self.assertAlmostEqual(ext.dimension, 10, places=4)
+        self.assertGreater(ext.center(CenterOf.BOUNDING_BOX).Y, 0)
+
+    def test_vector_offset_perpendicular_to_measurement_direction(self):
+        """A vector offset perpendicular to an explicit measurement_direction works."""
+        diagonal = Edge.make_line((0, 0), (10, 10))
+        ext = ExtensionLine(
+            border=diagonal,
+            offset=(0, 5),
+            draft=metric,
+            measurement_direction=Vector(1, 0, 0),
+        )
+        self.assertAlmostEqual(ext.dimension, 10, places=4)
+
+    def test_vector_offset_parallel_to_measurement_direction_raises(self):
+        """A vector offset parallel to measurement_direction is rejected."""
+        diagonal = Edge.make_line((0, 0), (10, 10))
+        with self.assertRaises(ValueError):
+            ExtensionLine(
+                border=diagonal,
+                offset=(5, 0),
+                draft=metric,
+                measurement_direction=Vector(1, 0, 0),
+            )
+
+    def test_zero_vector_offset_raises(self):
+        """A zero-length vector offset is rejected with a clear error."""
+        edge = Edge.make_line((0, 0), (40, 0))
+        with self.assertRaises(ValueError):
+            ExtensionLine(border=edge, offset=(0, 0, 0), draft=metric)
+
+    def test_out_of_plane_vector_offset_raises(self):
+        """A vector offset with no XY component (Z only) is rejected, not crashed."""
+        edge = Edge.make_line((0, 0), (40, 0))
+        with self.assertRaises(ValueError):
+            ExtensionLine(border=edge, offset=(0, 0, 5), draft=metric)
+
+    def test_zero_measurement_direction_raises(self):
+        """A zero-length measurement_direction is rejected with a clear error."""
+        edge = Edge.make_line((0, 0), (40, 0))
+        with self.assertRaises(ValueError):
+            ExtensionLine(
+                border=edge,
+                offset=(0, 10),
+                draft=metric,
+                measurement_direction=Vector(0, 0, 0),
+            )
+
+    def test_degenerate_projection_raises(self):
+        """An offset whose inferred measurement direction has no border extent
+        (e.g. a vertical offset on a vertical border) is rejected, not crashed."""
+        vertical = Edge.make_line((0, 0), (0, 40))
+        with self.assertRaises(ValueError):
+            ExtensionLine(border=vertical, offset=(0, 5), draft=metric)
+
 
 @pytest.mark.parametrize("design_date", [date(2023, 9, 17), None])
 def test_basic_drawing(design_date):

--- a/tests/test_drafting.py
+++ b/tests/test_drafting.py
@@ -507,10 +507,21 @@ class ExtensionLineTestCase(unittest.TestCase):
             ExtensionLine(border=edge, offset=(0, 0, 0), draft=metric)
 
     def test_out_of_plane_vector_offset_raises(self):
-        """A vector offset with no XY component (Z only) is rejected, not crashed."""
+        """A vector offset outside Plane.XY is rejected."""
         edge = Edge.make_line((0, 0), (40, 0))
         with self.assertRaises(ValueError):
-            ExtensionLine(border=edge, offset=(0, 0, 5), draft=metric)
+            ExtensionLine(border=edge, offset=(0, 10, 0.1), draft=metric)
+
+    def test_out_of_plane_measurement_direction_raises(self):
+        """A measurement direction outside Plane.XY is rejected."""
+        edge = Edge.make_line((0, 0), (40, 40))
+        with self.assertRaises(ValueError):
+            ExtensionLine(
+                border=edge,
+                offset=(0, 10),
+                draft=metric,
+                measurement_direction=(1, 0, 0.1),
+            )
 
     def test_zero_measurement_direction_raises(self):
         """A zero-length measurement_direction is rejected with a clear error."""


### PR DESCRIPTION
## Summary

Part 2 of 2 splitting #1326 (part 1, the `DimensionLine` crash fix, is #1336). Implements the `offset: float | VectorLike` design from the #1326 discussion ("option 8"), replacing the rejected `side="above"` literal.

`ExtensionLine`'s `offset` now accepts:
- **`float`** — unchanged: signed perpendicular distance, sign selects the side.
- **`VectorLike`** — explicit displacement in the XY plane; magnitude is the distance, direction selects the side (no sign-convention guesswork).

```python
l1 = Edge.make_line((0, 0), (10, 10))
ExtensionLine(l1, offset=(0, 5))    # 5 above
ExtensionLine(l1, offset=(0, -5))   # 5 below
```

## Semantics
- The vector must be perpendicular to the dimension line (rough ~1° tolerance). If `measurement_direction` is given, the two must be perpendicular; otherwise the dimension-line direction is inferred perpendicular to the offset (matching the `offset=(0,5)` example in the thread).
- Internally reduced to the existing signed-distance convention, so the scalar path is unchanged and fully backwards-compatible.
- Degenerate inputs (zero vector, out-of-plane offset, non-perpendicular/parallel, zero or zero-extent `measurement_direction`) raise a clear `ValueError` instead of a raw kernel error. Linear checks use the geometry-wide `TOLERANCE`; the angular tolerance is in degrees per `Axis.is_normal`.

## Test plan
Adds tests to `ExtensionLineTestCase` for vector placement (all four directions), scalar-equivalence, inferred vs explicit measurement direction, and the five error paths. `pytest tests/test_drafting.py` → 39 passed; mypy/pylint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
