### PR TITLE
Fix issue 1296 2tanrad

### DIFF
--- a/src/build123d/topology/constrained_lines.py
+++ b/src/build123d/topology/constrained_lines.py
@@ -38,7 +38,7 @@ from OCP.BRepAdaptor import BRepAdaptor_Curve
 from OCP.BRepBuilderAPI import BRepBuilderAPI_MakeEdge, BRepBuilderAPI_MakeVertex
 from OCP.BRepLib import BRepLib
 from OCP.GCPnts import GCPnts_AbscissaPoint
-from OCP.Geom import Geom_Curve, Geom_Plane
+from OCP.Geom import Geom_Plane
 from OCP.Geom2d import (
     Geom2d_CartesianPoint,
     Geom2d_Circle,
@@ -71,10 +71,11 @@ from OCP.gp import (
     gp_Pln,
     gp_Pnt,
     gp_Pnt2d,
+    gp_Vec2d,
 )
 from OCP.IntAna2d import IntAna2d_AnaIntersection
 from OCP.Standard import Standard_ConstructionError, Standard_Failure
-from OCP.TopoDS import TopoDS_Edge, TopoDS_Vertex
+from OCP.TopoDS import TopoDS_Edge
 
 from build123d.build_enums import Sagitta, Tangency
 from build123d.geometry import Axis, TOLERANCE, Vector, VectorLike
@@ -368,28 +369,81 @@ def _make_2tan_rad_arcs(
     solutions: list[TopoDS_Edge] = []
     for i in range(1, gcc.NbSolutions() + 1):
         circ: gp_Circ2d = gcc.ThisSolution(i)
+        center = circ.Location()
+        sol_radius = circ.Radius()
 
-        # Tangency on curve 1
-        p1 = gp_Pnt2d()
-        u_circ1, u_arg1 = gcc.Tangency1(i, p1)
-        if not _ok(0, u_arg1):
+        # To handle stability issues with Gcc solver parameters
+        # on transformed curves (specifically ellipses), we use a
+        # "Verify then Correct" strategy.
+        corrected_params = []
+        valid_solution = True
+
+        # Get solver's candidate parameters
+        p_tmp = gp_Pnt2d()
+        u_circ1_s, u_arg1_s = gcc.Tangency1(i, p_tmp)
+        u_circ2_s, u_arg2_s = gcc.Tangency2(i, p_tmp)
+        solver_candidates = [(u_circ1_s, u_arg1_s), (u_circ2_s, u_arg2_s)]
+
+        for j in range(2):
+            u_circ_s, u_arg_s = solver_candidates[j]
+
+            if not is_edge[j]:
+                # Point input: the tangency point is the point itself.
+                p_s = q_o[j]
+                assert isinstance(p_s, Geom2d_CartesianPoint)
+
+                # Geom2d_CartesianPoint provides X() and Y()
+                p_s_pnt = gp_Pnt2d(p_s.X(), p_s.Y())
+                dist = p_s_pnt.Distance(center)
+
+                if abs(dist - sol_radius) < TOLERANCE:
+                    # The point is at the correct radius; calculate u_circ from the point.
+                    vec = gp_Vec2d(p_s_pnt.X() - center.X(), p_s_pnt.Y() - center.Y())
+                    u_circ_act = atan2(vec.Y(), vec.X())
+                    corrected_params.append((u_circ_act, u_arg_s))
+                else:
+                    valid_solution = False
+                    break
+                continue
+
+            # Curve input: use the "Verify then Correct" strategy.
+            p_s = h_e[j].Value(u_arg_s)
+            dist = p_s.Distance(center)
+
+            # 1. Verify: If solver's point is correct and within trimmed range, use it.
+            if abs(dist - sol_radius) < TOLERANCE and _ok(j, u_arg_s):
+                corrected_params.append((u_circ_s, u_arg_s))
+            else:
+                # 2. Correct: Project center onto curve to find the actual tangency point.
+                proj = Geom2dAPI_ProjectPointOnCurve(
+                    gp_Pnt2d(center.X(), center.Y()), h_e[j]
+                )
+                if proj.NbPoints() == 0:
+                    valid_solution = False
+                    break
+
+                u_arg_act = proj.LowerDistanceParameter()
+                p_act = h_e[j].Value(u_arg_act)
+
+                # Verify that the projected point is actually at the correct radius.
+                if abs(p_act.Distance(center) - sol_radius) > TOLERANCE:
+                    valid_solution = False
+                    break
+
+                if not _ok(j, u_arg_act):
+                    valid_solution = False
+                    break
+
+                # Calculate corresponding circle parameter (u_circ) from tangency point.
+                vec = gp_Vec2d(p_act.X() - center.X(), p_act.Y() - center.Y())
+                u_circ_act = atan2(vec.Y(), vec.X())
+                corrected_params.append((u_circ_act, u_arg_act))
+
+        if not valid_solution:
             continue
 
-        # Tangency on curve 2
-        p2 = gp_Pnt2d()
-        u_circ2, u_arg2 = gcc.Tangency2(i, p2)
-        if not _ok(1, u_arg2):
-            continue
-
-        # qual1 = GccEnt_Position(int())
-        # qual2 = GccEnt_Position(int())
-        # gcc.WhichQualifier(i, qual1, qual2)  # returns two GccEnt_Position values
-        # print(
-        #     f"Solution {i}: "
-        #     f"arg1={_qstr(qual1)}, arg2={_qstr(qual2)} | "
-        #     f"u_circ=({u_circ1:.6g}, {u_circ2:.6g}) "
-        #     f"u_arg=({u_arg1:.6g}, {u_arg2:.6g})"
-        # )
+        u_circ1, _ = corrected_params[0]
+        u_circ2, _ = corrected_params[1]
 
         # Build BOTH sagitta arcs and select by LengthConstraint
         if sagitta == Sagitta.BOTH:

--- a/src/build123d/topology/constrained_lines.py
+++ b/src/build123d/topology/constrained_lines.py
@@ -97,6 +97,8 @@ _surf_xy = Geom_Plane(_pln_xy)
 # ---------------------------
 def _norm_on_period(u: float, first: float, period: float) -> float:
     """Map parameter u into [first, first+per)."""
+    if abs(u - first) < TOLERANCE:
+        return first
     return (u - first) % period + first
 
 

--- a/src/build123d/topology/one_d.py
+++ b/src/build123d/topology/one_d.py
@@ -266,7 +266,7 @@ class _WireFilletCorner:
 class _WireFilletSolution:
     """Replacement edges for a filleted wire corner."""
 
-    trimmed_topods_edges: list[TopoDS_Edge]
+    trimmed_topods_edges: list[TopoDS_Edge | None]
     fillet_topods_edge: TopoDS_Edge
 
 
@@ -294,36 +294,6 @@ def _analyze_wire_fillet_corner(wire: Wire, vertex: Vertex) -> _WireFilletCorner
         all_edges=all_edges,
         connected_edges=connected_edges,
         connected_edge_indices=connected_edge_indices,
-    )
-
-
-def _solve_wire_fillet_corner_chfi2d(
-    corner: _WireFilletCorner, radius: float
-) -> _WireFilletSolution | None:
-    """Try to fillet a planar wire corner with ``ChFi2d_FilletAlgo``."""
-
-    fillet_builder = ChFi2d_FilletAlgo()
-    fillet_builder.Init(
-        corner.connected_edges[0].wrapped,
-        corner.connected_edges[1].wrapped,
-        Plane.XY.wrapped,
-    )
-
-    vertex_point = BRep_Tool.Pnt_s(corner.vertex.wrapped)
-    if (
-        not fillet_builder.Perform(radius)
-        or fillet_builder.NbResults(vertex_point) == 0
-    ):
-        return None
-
-    trimmed_topods_edge0, trimmed_topods_edge1 = TopoDS_Edge(), TopoDS_Edge()
-    fillet_topods_edge = fillet_builder.Result(
-        vertex_point, trimmed_topods_edge0, trimmed_topods_edge1
-    )
-
-    return _WireFilletSolution(
-        trimmed_topods_edges=[trimmed_topods_edge0, trimmed_topods_edge1],
-        fillet_topods_edge=fillet_topods_edge,
     )
 
 
@@ -413,13 +383,16 @@ def _solve_wire_fillet_corner_geom2dgcc_circ2d2tanrad(
             BRepBuilderAPI_MakeVertex(Vector(fillet_vertex).to_pnt()).Vertex()
         )
         split_edges = _split_edge_at_vertex(copy.deepcopy(connected_edge), split_vertex)
-        trimmed_topods_edges.append(
-            next(
+        edge_result = next(
+            (
                 edge
                 for edge in split_edges
                 if _topods_edge_contains_vertex(edge, other_vertex.wrapped)
-            )
+                and not _topods_edge_contains_vertex(edge, corner.vertex.wrapped)
+            ),
+            None,
         )
+        trimmed_topods_edges.append(edge_result)
 
     return _WireFilletSolution(
         trimmed_topods_edges=trimmed_topods_edges,
@@ -435,23 +408,29 @@ def _splice_wire_fillet_corner(
     all_topods_edges = [edge.wrapped for edge in corner.all_edges]
 
     # Flip any edges that were reversed during trimming
-    for i in range(2):
-        if (
-            solution.trimmed_topods_edges[i].Orientation()
-            != corner.connected_edges[i].wrapped.Orientation()
-        ):
-            solution.trimmed_topods_edges[i].Reverse()
+    indices_to_remove = set()
+    for i, trimmed in enumerate(solution.trimmed_topods_edges):
+        edge_idx = corner.connected_edge_indices[i]
+        if trimmed is None:
+            indices_to_remove.add(edge_idx)
+            continue
 
-    for i in range(2):
-        all_topods_edges[corner.connected_edge_indices[i]] = (
-            solution.trimmed_topods_edges[i]
-        )
+        if trimmed.Orientation() != corner.connected_edges[i].wrapped.Orientation():
+            trimmed.Reverse()
+        all_topods_edges[edge_idx] = trimmed
 
+    # Calculate insert index before removal (in original index space)
     n = len(all_topods_edges)
     if corner.connected_edge_indices[1] == (corner.connected_edge_indices[0] + 1) % n:
         insert_index = corner.connected_edge_indices[0] + 1
     else:
         insert_index = corner.connected_edge_indices[1] + 1
+
+    # Remove consumed edges in reverse order to preserve indices during deletion
+    for idx in sorted(indices_to_remove, reverse=True):
+        all_topods_edges.pop(idx)
+        if idx < insert_index:
+            insert_index -= 1
 
     all_topods_edges.insert(insert_index, solution.fillet_topods_edge)
 
@@ -461,7 +440,6 @@ def _splice_wire_fillet_corner(
     wire_builder = BRepBuilderAPI_MakeWire()
     wire_builder.Add(combined_edges)
     wire_builder.Build()
-
     return Wire(wire_builder.Wire())
 
 
@@ -471,15 +449,23 @@ def _fillet_wire_corner(wire: Wire, vertex: Vertex, radius: float) -> Wire:
     corner = _analyze_wire_fillet_corner(wire, vertex)
     if _wire_fillet_corner_is_tangent_continuous(corner):
         return wire
+
     vertex_label = str(vertex)
-    solution = _solve_wire_fillet_corner_chfi2d(corner, radius)
-    if solution is None:
-        solution = _solve_wire_fillet_corner_geom2dgcc_circ2d2tanrad(corner, radius)
+    solution = _solve_wire_fillet_corner_geom2dgcc_circ2d2tanrad(corner, radius)
+
+    if solution is not None:
+        new_wire = _splice_wire_fillet_corner(corner, solution)
+        if not wire.is_closed or new_wire.is_closed:
+            return new_wire
+
     if solution is None:
         raise ValueError(
             f"Fillet algorithm failed for {vertex_label} with radius {radius}"
         )
-    return _splice_wire_fillet_corner(corner, solution)
+
+    raise ValueError(
+        "Filleting failed to create a closed wire."
+    )
 
 
 class Mixin1D(Shape[TOPODS]):

--- a/src/build123d/topology/one_d.py
+++ b/src/build123d/topology/one_d.py
@@ -91,7 +91,6 @@ from OCP.BRepOffset import BRepOffset_MakeOffset
 from OCP.BRepOffsetAPI import BRepOffsetAPI_MakeOffset
 from OCP.BRepProj import BRepProj_Projection
 from OCP.BRepTools import BRepTools, BRepTools_WireExplorer
-from OCP.ChFi2d import ChFi2d_FilletAlgo
 from OCP.Extrema import Extrema_ExtPC
 from OCP.GC import (
     GC_MakeArcOfCircle,
@@ -463,9 +462,7 @@ def _fillet_wire_corner(wire: Wire, vertex: Vertex, radius: float) -> Wire:
             f"Fillet algorithm failed for {vertex_label} with radius {radius}"
         )
 
-    raise ValueError(
-        "Filleting failed to create a closed wire."
-    )
+    raise ValueError("Filleting failed to create a closed wire.")
 
 
 class Mixin1D(Shape[TOPODS]):

--- a/tests/test_build_generic.py
+++ b/tests/test_build_generic.py
@@ -595,7 +595,7 @@ class OffsetTests(unittest.TestCase):
         line = FilletPolyline(*pts, radius=3.177)
         self.assertEqual(len(line.edges()), 11)
         o_line = offset(line, amount=2)
-        self.assertEqual(len(o_line.edges()), 26)
+        self.assertEqual(len(o_line.edges()), 24)
 
     def test_offset_face_with_inner_wire(self):
         # offset amount causes the inner wire to have zero length

--- a/tests/test_direct_api/test_wire.py
+++ b/tests/test_direct_api/test_wire.py
@@ -381,7 +381,9 @@ class TestWireFilletHelpers(unittest.TestCase):
 
     def test_wire_fillet_corner_is_not_tangent_continuous_on_rounded_cut_tips(self):
         sketch = RectangleRounded(20, 10, 2)
-        sketch -= [Location(e.arc_center) for e in sketch.edges().filter_by(GeomType.CIRCLE)] * Circle(2)
+        sketch -= [
+            Location(e.arc_center) for e in sketch.edges().filter_by(GeomType.CIRCLE)
+        ] * Circle(2)
         wire = sketch.wire()
 
         skipped_vertices = [(-10, -3, 0), (-10, 3, 0), (-8, 5, 0)]
@@ -416,7 +418,7 @@ class TestWireFilletHelpers(unittest.TestCase):
         with (
             patch(
                 "build123d.topology.one_d._solve_wire_fillet_corner_geom2dgcc_circ2d2tanrad",
-                return_value=MagicMock(), # Return a dummy solution
+                return_value=MagicMock(),  # Return a dummy solution
             ),
             patch(
                 "build123d.topology.one_d._splice_wire_fillet_corner",

--- a/tests/test_direct_api/test_wire.py
+++ b/tests/test_direct_api/test_wire.py
@@ -394,24 +394,39 @@ class TestWireFilletHelpers(unittest.TestCase):
                     one_d._wire_fillet_corner_is_tangent_continuous(corner)
                 )
 
-    def test_fillet_wire_corner_failure_when_all_solvers_fail(self):
+    def test_fillet_wire_corner_failure_when_solver_fails(self):
         wire = Wire.make_rect(1, 1)
         vertex = wire.vertices()[0]
 
-        with (
-            patch(
-                "build123d.topology.one_d._solve_wire_fillet_corner_chfi2d",
-                return_value=None,
-            ),
-            patch(
-                "build123d.topology.one_d._solve_wire_fillet_corner_geom2dgcc_circ2d2tanrad",
-                return_value=None,
-            ),
+        with patch(
+            "build123d.topology.one_d._solve_wire_fillet_corner_geom2dgcc_circ2d2tanrad",
+            return_value=None,
         ):
             with self.assertRaises(ValueError) as ctx:
                 one_d._fillet_wire_corner(wire, vertex, 0.1)
 
         self.assertIn("Fillet algorithm failed", str(ctx.exception))
+
+    def test_fillet_wire_corner_failure_when_closed_wire_becomes_open(self):
+        wire = Wire.make_rect(1, 1)
+        vertex = wire.vertices()[0]
+        # Create an open wire to simulate a failed splice
+        open_wire = Wire(wire.edges().sort_by(Axis.X)[:-1])
+
+        with (
+            patch(
+                "build123d.topology.one_d._solve_wire_fillet_corner_geom2dgcc_circ2d2tanrad",
+                return_value=MagicMock(), # Return a dummy solution
+            ),
+            patch(
+                "build123d.topology.one_d._splice_wire_fillet_corner",
+                return_value=open_wire,
+            ),
+        ):
+            with self.assertRaises(ValueError) as ctx:
+                one_d._fillet_wire_corner(wire, vertex, 0.1)
+
+        self.assertIn("Filleting failed to create a closed wire", str(ctx.exception))
 
 
 class TestWireToBSpline(unittest.TestCase):

--- a/tests/test_fillet_2d_regressions.py
+++ b/tests/test_fillet_2d_regressions.py
@@ -1,0 +1,146 @@
+# tests/test_fillet_2d_regressions.py
+
+import pytest
+from build123d import *
+from ocp_vscode import show_object
+
+r = 5  # fillet radius
+tr = 5.0001  # arc/spline/ellipse 'radius'
+# TOLERANCE = 1e-6
+
+
+def _assert_valid_fillet(sk, number_of_edges:int = 4):
+    assert len(sk.edges()) == number_of_edges
+    # assert sk.area > 0
+    # assert all(e.length > TOLERANCE for e in sk.edges())
+
+
+def test_fillet_line_full_edge_consumed():
+    """Fillet consuming an entire Line edge between two circle arcs.
+    Regresses ChFi2d_FilletAlgo failure producing open wire.
+    """
+    for all_verts in (False, True):
+        with BuildSketch() as sk:
+            with BuildLine():
+                ln1 = JernArc((0, 0), (1, 0), 20, 90)
+                ln2 = JernArc((0, 10), (1, 0), 10, 90)
+                Line(ln1 @ 1, ln2 @ 1)
+                Line(ln1 @ 0, ln2 @ 0)
+            make_face()
+            vrts = sk.vertices() if all_verts else sk.vertices().sort_by(Axis.Y)[-2:]
+            fillet(vrts, r)
+
+        _assert_valid_fillet(sk)
+
+def test_fillet_line_full_edge_consumed_all_verts():
+    """Fillet consuming an entire Line edge between two circle arcs.
+    Regresses ChFi2d_FilletAlgo failure producing `ValueError: Could not
+    find shared vertex on wire`.
+    """
+    # all_verts=False: only top two vertices
+    with BuildSketch() as sk:
+        with BuildLine():
+            ln1 = JernArc((0, 0), (1, 0), 20, 90)
+            ln2 = JernArc((0, 10), (1, 0), 10, 90)
+            Line(ln1 @ 1, ln2 @ 1)
+            Line(ln1 @ 0, ln2 @ 0)
+        make_face()
+        vrts = sk.vertices()
+        fillet(vrts, r)
+
+    _assert_valid_fillet(sk)
+
+def test_fillet_line_all_edges_consumed():
+    """Fillet where all edges of the sketch are consumed.
+    Regresses 'Face can only be created with closed wires'.
+    """
+    with BuildSketch() as sk:
+        with BuildLine():
+            ln1 = JernArc((0, 0), (1, 0), 20, 90)
+            ln2 = JernArc((0, 10), (1, 0), 10, 90)
+            Line(ln1 @ 1, ln2 @ 1)
+            Line(ln1 @ 0, ln2 @ 0)
+        make_face()
+        with BuildLine():
+            cr1 = CenterArc(
+                (14.142135623730951, 14.999999999999996, 0.0),
+                r, 0, 360, mode=Mode.PRIVATE,
+            )
+            cn1 = ConstrainedLines(
+                cr1.edge(), (0, 20), mode=Mode.PRIVATE,
+                selector=lambda lines: lines[1],
+            ).edge()
+        with Locations(Plane(origin=cn1 @ 0, x_dir=cn1 % 1)):
+            Rectangle(20, 20, align=(Align.CENTER, Align.MIN), mode=Mode.SUBTRACT)
+        vrts = sk.vertices()
+        fillet(vrts, r)
+
+    _assert_valid_fillet(sk, 1)
+
+def test_fillet_arc_cutout_all_edges_consumed():
+    """all_verts=False fixed by main solver switch;
+    all_verts=True required the additional precision fix in _norm_on_period.
+    """
+    for all_verts in (False, True):
+        with BuildSketch() as sk:
+            with BuildLine():
+                ln1 = JernArc((0, 0), (1, 0), 20, 90)
+                ln2 = JernArc((0, 10), (1, 0), 10, 90)
+                ln3 = RadiusArc(ln1 @ 1, ln2 @ 1, tr)
+                Line(ln1 @ 0, ln2 @ 0)
+            make_face()
+            with BuildLine():
+                arc3tan = ConstrainedArcs(
+                    ln1, ln2, ln3,
+                    sagitta=Sagitta.BOTH,
+                    selector=lambda arcs: arcs.sort_by(Axis.Y)[0],
+                    mode=Mode.PRIVATE,
+                )
+                arctancen = ConstrainedArcs(
+                    tangency_one=arc3tan.edge(),
+                    center=ln1 @ 0,
+                    mode=Mode.PRIVATE,
+                )
+            make_face(arctancen.edge(), mode=Mode.SUBTRACT)
+            vrts = sk.vertices() if all_verts else sk.vertices().sort_by(Axis.Y)[-2:]
+            fillet(vrts, r)
+
+        egds = 1 if all_verts else 4
+        _assert_valid_fillet(sk, egds)
+
+def test_fillet_spline_full_edge_consumed():
+    """Fillet consuming an entire Spline edge between two circle arcs.
+    Regresses ChFi2d_FilletAlgo failure producing open wire for certain splines.
+    """
+    # all_verts=False: only top two vertices
+    with BuildSketch() as sk:
+        with BuildLine():
+            ln1 = JernArc((0, 0), (1, 0), 20, 90)
+            ln2 = JernArc((0, 10), (1, 0), 10, 90)
+            cln3 = RadiusArc(ln1 @ 1, ln2 @ 1, 5.001, mode=Mode.PRIVATE)
+            ln3 = Spline(cln3 @ 0, cln3 @ 0.5, cln3 @ 1)
+            Line(ln1 @ 0, ln2 @ 0)
+        make_face()
+        vrts = sk.vertices()
+        fillet(vrts, r)
+
+    _assert_valid_fillet(sk)
+
+def test_fillet_ellipse_cutout():
+    """Fillet on a sketch with an ellipse cutout — previously produced
+    open wire due to small length dangling edge. To solve this example with
+    _solve_wire_fillet_corner_geom2dgcc_circ2d2tanrad the changes in _make_2tan_rad_arcs are needed.
+    """
+    with BuildSketch() as sk:
+        with BuildLine():
+            ln1 = JernArc((0, 0), (1, 0), 20, 90)
+            ln2 = JernArc((0, 10), (1, 0), 10, 90)
+            Line(ln1 @ 1, ln2 @ 1)
+            Line(ln1 @ 0, ln2 @ 0)
+        make_face()
+        with Locations((15, 20)):
+            Ellipse(10, 5, mode=Mode.SUBTRACT)
+        vrts = sk.vertices().sort_by(Axis.Y)[-2:]
+        fillet(vrts, r)
+
+    _assert_valid_fillet(sk)

--- a/tests/test_fillet_2d_regressions.py
+++ b/tests/test_fillet_2d_regressions.py
@@ -1,18 +1,59 @@
-# tests/test_fillet_2d_regressions.py
+"""
+build123d imports
 
-import pytest
-from build123d import *
-from ocp_vscode import show_object
+name: test_fillet_2d_regressions.py
+by:   Gumyr
+date: June 29, 2026
 
-r = 5  # fillet radius
-tr = 5.0001  # arc/spline/ellipse 'radius'
-# TOLERANCE = 1e-6
+desc:
+    This python module contains tests for the build123d project related to issue #1296.
+
+license:
+
+    Copyright 2025 Gumyr
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+"""
+
+from build123d import (
+    Align,
+    Axis,
+    BuildLine,
+    BuildSketch,
+    CenterArc,
+    ConstrainedArcs,
+    ConstrainedLines,
+    Ellipse,
+    JernArc,
+    Line,
+    Locations,
+    Mode,
+    Plane,
+    RadiusArc,
+    Rectangle,
+    Sagitta,
+    Spline,
+    fillet,
+    make_face,
+)
+
+RADIUS = 5  # fillet radius
+EDGE_RADIUS = 5.0001  # arc/spline/ellipse 'radius'
 
 
-def _assert_valid_fillet(sk, number_of_edges:int = 4):
+def _assert_valid_fillet(sk, number_of_edges: int = 4):
     assert len(sk.edges()) == number_of_edges
-    # assert sk.area > 0
-    # assert all(e.length > TOLERANCE for e in sk.edges())
 
 
 def test_fillet_line_full_edge_consumed():
@@ -28,9 +69,10 @@ def test_fillet_line_full_edge_consumed():
                 Line(ln1 @ 0, ln2 @ 0)
             make_face()
             vrts = sk.vertices() if all_verts else sk.vertices().sort_by(Axis.Y)[-2:]
-            fillet(vrts, r)
+            fillet(vrts, RADIUS)
 
         _assert_valid_fillet(sk)
+
 
 def test_fillet_line_full_edge_consumed_all_verts():
     """Fillet consuming an entire Line edge between two circle arcs.
@@ -46,9 +88,10 @@ def test_fillet_line_full_edge_consumed_all_verts():
             Line(ln1 @ 0, ln2 @ 0)
         make_face()
         vrts = sk.vertices()
-        fillet(vrts, r)
+        fillet(vrts, RADIUS)
 
     _assert_valid_fillet(sk)
+
 
 def test_fillet_line_all_edges_consumed():
     """Fillet where all edges of the sketch are consumed.
@@ -64,18 +107,24 @@ def test_fillet_line_all_edges_consumed():
         with BuildLine():
             cr1 = CenterArc(
                 (14.142135623730951, 14.999999999999996, 0.0),
-                r, 0, 360, mode=Mode.PRIVATE,
+                RADIUS,
+                0,
+                360,
+                mode=Mode.PRIVATE,
             )
             cn1 = ConstrainedLines(
-                cr1.edge(), (0, 20), mode=Mode.PRIVATE,
+                cr1.edge(),
+                (0, 20),
+                mode=Mode.PRIVATE,
                 selector=lambda lines: lines[1],
             ).edge()
         with Locations(Plane(origin=cn1 @ 0, x_dir=cn1 % 1)):
             Rectangle(20, 20, align=(Align.CENTER, Align.MIN), mode=Mode.SUBTRACT)
         vrts = sk.vertices()
-        fillet(vrts, r)
+        fillet(vrts, RADIUS)
 
     _assert_valid_fillet(sk, 1)
+
 
 def test_fillet_arc_cutout_all_edges_consumed():
     """all_verts=False fixed by main solver switch;
@@ -86,12 +135,14 @@ def test_fillet_arc_cutout_all_edges_consumed():
             with BuildLine():
                 ln1 = JernArc((0, 0), (1, 0), 20, 90)
                 ln2 = JernArc((0, 10), (1, 0), 10, 90)
-                ln3 = RadiusArc(ln1 @ 1, ln2 @ 1, tr)
+                ln3 = RadiusArc(ln1 @ 1, ln2 @ 1, EDGE_RADIUS)
                 Line(ln1 @ 0, ln2 @ 0)
             make_face()
             with BuildLine():
                 arc3tan = ConstrainedArcs(
-                    ln1, ln2, ln3,
+                    ln1,
+                    ln2,
+                    ln3,
                     sagitta=Sagitta.BOTH,
                     selector=lambda arcs: arcs.sort_by(Axis.Y)[0],
                     mode=Mode.PRIVATE,
@@ -103,10 +154,11 @@ def test_fillet_arc_cutout_all_edges_consumed():
                 )
             make_face(arctancen.edge(), mode=Mode.SUBTRACT)
             vrts = sk.vertices() if all_verts else sk.vertices().sort_by(Axis.Y)[-2:]
-            fillet(vrts, r)
+            fillet(vrts, RADIUS)
 
         egds = 1 if all_verts else 4
         _assert_valid_fillet(sk, egds)
+
 
 def test_fillet_spline_full_edge_consumed():
     """Fillet consuming an entire Spline edge between two circle arcs.
@@ -117,14 +169,15 @@ def test_fillet_spline_full_edge_consumed():
         with BuildLine():
             ln1 = JernArc((0, 0), (1, 0), 20, 90)
             ln2 = JernArc((0, 10), (1, 0), 10, 90)
-            cln3 = RadiusArc(ln1 @ 1, ln2 @ 1, 5.001, mode=Mode.PRIVATE)
-            ln3 = Spline(cln3 @ 0, cln3 @ 0.5, cln3 @ 1)
+            cln3 = RadiusArc(ln1 @ 1, ln2 @ 1, EDGE_RADIUS, mode=Mode.PRIVATE)
+            Spline(cln3 @ 0, cln3 @ 0.5, cln3 @ 1)
             Line(ln1 @ 0, ln2 @ 0)
         make_face()
         vrts = sk.vertices()
-        fillet(vrts, r)
+        fillet(vrts, RADIUS)
 
     _assert_valid_fillet(sk)
+
 
 def test_fillet_ellipse_cutout():
     """Fillet on a sketch with an ellipse cutout — previously produced
@@ -139,8 +192,8 @@ def test_fillet_ellipse_cutout():
             Line(ln1 @ 0, ln2 @ 0)
         make_face()
         with Locations((15, 20)):
-            Ellipse(10, 5, mode=Mode.SUBTRACT)
+            Ellipse(10, EDGE_RADIUS, mode=Mode.SUBTRACT)
         vrts = sk.vertices().sort_by(Axis.Y)[-2:]
-        fillet(vrts, r)
+        fillet(vrts, RADIUS)
 
     _assert_valid_fillet(sk)

--- a/tests/test_fillet_2d_regressions.py
+++ b/tests/test_fillet_2d_regressions.py
@@ -49,7 +49,7 @@ from build123d import (
 )
 
 RADIUS = 5  # fillet radius
-EDGE_RADIUS = 5.0001  # arc/spline/ellipse 'radius'
+EDGE_RADIUS = 5.001  # arc/spline/ellipse 'radius'
 
 
 def _assert_valid_fillet(sk, number_of_edges: int = 4):
@@ -192,7 +192,7 @@ def test_fillet_ellipse_cutout():
             Line(ln1 @ 0, ln2 @ 0)
         make_face()
         with Locations((15, 20)):
-            Ellipse(10, EDGE_RADIUS, mode=Mode.SUBTRACT)
+            Ellipse(10, 5, mode=Mode.SUBTRACT)
         vrts = sk.vertices().sort_by(Axis.Y)[-2:]
         fillet(vrts, RADIUS)
 


### PR DESCRIPTION
This PR addresses three primary issues and substitutes #1303:

1. **Issue #1296: `fillet_2d()` failures when edges are fully consumed.**
   Previously, the fillet logic failed to remove unnecessary edges when a fillet (or fillets) completely consumed the adjacent edges. This resulted in "dangling" edges that left the wire open, leading to `ValueError: Face can only be created with closed wires`. The fix adds logic to detect and remove these consumed edges to ensure the resulting wire remains closed.
   
   While resolving this, two additional issues were identified and fixed (detailed below) that allow the replacement of `ChFi2d_FilletAlgo` with the `circ2d2tanrad` approach. The latter is analytical in most cases, more robust, and less prone to crashes, whereas `ChFi2d` required significant manual handling of edge cases and was entirely numerical.

2. **`_norm_on_period` boundary condition.**
   Fixed a bug where `_norm_on_period` could return parameters outside the expected period when the input was very close to the start of the period. A tolerance check was added to ensure consistent behavior at the boundary.

3. **`_make_2tan_rad_arcs` stability with transformed ellipses.**
   Fixed a failure where `_make_2tan_rad_arcs` could not find valid arcs when using ellipse edges transformed via `to_local_coords`. The solver often returned correctly positioned circles but incorrect tangent point parameters on the non-ellipse edge, causing valid solutions to be filtered out or resulting in incorrect arcs. The fix implements a "Verify then Correct" strategy: it validates the distance from the tangent point to the circle center and, if it exceeds `TOLERANCE`, projects the center back onto the curve to derive the correct tangent point.

Code coverage returns lines *407-408*, *424-425* and *432-433* in `constrained_lines.py` related to the changes on this PR as uncovered. Those lines were added by an LLM as safety guards, I failed to find cases for them, but the LLM recommends keeping them so, I'm unsure about how to proceed.

If you are ok with the changes in this PR (namely, the removing of `_solve_wire_fillet_corner_chfi2d` and modifications in `_make_2tan_rad_arcs`) #1303 can be closed.