### PR TITLE
enable pylint fail on E and F, unpin pytest on resolution of pytest subtest issue, fix remaining pylint error

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,4 +20,4 @@ jobs:
           python-version: ${{ matrix.python-version }}
           optional-dependencies: "development"
       - name: lint
-        run: pylint --rcfile=.pylintrc --fail-under=9.5 src/build123d
+        run: pylint --rcfile=.pylintrc --fail-under=9.5 --fail-on=E,F src/build123d

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ development = [
     "black",
     "mypy",
     "pylint",
-    "pytest==8.4.2", # TODO: unpin on resolution of pytest-dev/pytest-xdist/issues/1273
+    "pytest >= 9.1.1",
     "pytest-benchmark",
     "pytest-cov",
     "pytest-xdist",

--- a/src/build123d/topology/shape_core.py
+++ b/src/build123d/topology/shape_core.py
@@ -2806,7 +2806,9 @@ def topo_distance_to(
     if not all(isinstance(shape, Shape) for shape in sources):
         raise ValueError("Topological distance requires Shape objects")
 
+    # pylint: disable=no-member
     peer_type = sources[0].shape_type
+
     if any(shape.shape_type != peer_type for shape in sources):
         raise ValueError("Topological distance requires shapes of the same type")
 


### PR DESCRIPTION
- Enabled pylint failure on E,F
- Unpinned pytest because of resolution of pytest-xdist/issues/1273
- Fix remaining pylint error with `# pylint: disable=no-member`