### PR TITLE
Fix segfault in Edge.radius on non-circular curves

### DIFF
--- a/src/build123d/topology/one_d.py
+++ b/src/build123d/topology/one_d.py
@@ -125,6 +125,7 @@ from OCP.GeomAbs import (
     GeomAbs_C1,
     GeomAbs_C2,
     GeomAbs_C3,
+    GeomAbs_Circle,
     GeomAbs_CN,
     GeomAbs_G1,
     GeomAbs_G2,
@@ -557,11 +558,12 @@ class Mixin1D(Shape[TOPODS]):
 
         """
         geom = self.geom_adaptor()
-        try:
-            circ = geom.Circle()
-        except (Standard_NoSuchObject, Standard_Failure) as err:
-            raise ValueError("Shape could not be reduced to a circle") from err
-        return circ.Radius()
+        if isinstance(geom, BRepAdaptor_CompCurve):
+            # Wire: delegate to the first edge (CompCurve reports OtherCurve)
+            return self.edges()[0].radius
+        if geom.GetType() != GeomAbs_Circle:
+            raise ValueError("Shape could not be reduced to a circle")
+        return geom.Circle().Radius()
 
     @property
     def volume(self) -> float:


### PR DESCRIPTION
## Summary

- `BRepAdaptor_Curve.Circle()` is undefined behavior in OCCT when the curve is not a circle — it accesses invalid memory instead of raising an exception
- Replace the try/except in `Mixin1D.radius` with a `GetType()` check before calling `Circle()`
- For `Wire`, delegate to the first edge since `BRepAdaptor_CompCurve` always reports `GeomAbs_OtherCurve`

Reproducer (segfaults on FreeBSD without this fix):
```python
from build123d import Edge
e = Edge.make_ellipse(10, 20)
e.radius  # segfault instead of ValueError
```

## Test plan

- [x] `test_edge_wrapper_radius` passes (previously segfaulted)
- [x] Circle edges still return correct radius
- [x] Wire radius still delegates to first edge correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)