### PR TITLE
Fix location_at to respect face orientation

### DIFF
--- a/src/build123d/topology/two_d.py
+++ b/src/build123d/topology/two_d.py
@@ -2218,6 +2218,10 @@ class Face(Mixin2D[TopoDS_Face]):
 
         origin = Vector(pnt)
         z_dir = Vector(du).cross(Vector(dv)).normalized()
+        # The surface normal ignores the face orientation flag, so flip it to
+        # match the face's actual normal direction (see normal_at).
+        if self.wrapped.Orientation() == TopAbs_Orientation.TopAbs_REVERSED:
+            z_dir = -z_dir
         x_dir = (
             Vector(user_x_dir).normalized()
             if user_x_dir is not None

--- a/tests/test_direct_api/test_face.py
+++ b/tests/test_direct_api/test_face.py
@@ -943,6 +943,14 @@ class TestFace(unittest.TestCase):
         self.assertAlmostEqual(loc4.position, (-1, 0, 0), 5)
         self.assertAlmostEqual(loc4.z_axis.direction, (-1, 0, 0), 5)
 
+        # Reversed face: z-direction must follow the orientation flag (#1007)
+        rect = Face.make_rect(34, 10)
+        rect_flipped = -rect
+        self.assertAlmostEqual(rect.location_at().z_axis.direction, (0, 0, 1), 5)
+        self.assertAlmostEqual(
+            rect_flipped.location_at().z_axis.direction, (0, 0, -1), 5
+        )
+
     def test_without_holes(self):
         # Planar test
         frame = (Rectangle(1, 1) - Rectangle(0.5, 0.5)).face()

--- a/tests/test_direct_api/test_projection.py
+++ b/tests/test_direct_api/test_projection.py
@@ -105,7 +105,7 @@ class TestProjection(unittest.TestCase):
         center_surface = -Face.extrude(center_arc, (0, 0, 2 * width)).moved(
             Location((0, 0, -width), (0, 0, 180))
         )
-        tip_center_loc = -center_surface.location_at(center_arc @ 1, x_dir=(1, 0, 0))
+        tip_center_loc = center_surface.location_at(center_arc @ 1, x_dir=(1, 0, 0))
         normal_at_tip_center = tip_center_loc.z_axis.direction
 
         planar_tip_arc = Edge.make_circle(


### PR DESCRIPTION
Fixes #1007.

`Face.location_at` built `z_dir` straight from the surface normal (`du.cross(dv)`), which ignores the face's orientation flag. So a reversed face returned a location whose z-axis pointed opposite to the face's actual normal. `normal_at` already accounts for this, so I mirror it here: flip `z_dir` when the face orientation is `TopAbs_REVERSED`.

This also let me drop a `-` in `test_projection` that was only there to undo the old wrong direction.

Tests:
- `python -m pytest tests/test_direct_api/test_face.py::TestFace::test_location_at tests/test_direct_api/test_projection.py::TestProjection::test_project_clean_wire` pass.