### PR TITLE
import_step: compose cumulative locations so children are world-placed

### DIFF
--- a/src/build123d/importers.py
+++ b/src/build123d/importers.py
@@ -203,7 +203,10 @@ def import_step(filename: PathLike | str | bytes) -> Compound:
             return col
         return None
 
-    def build_assembly(parent_tdf_label: TDF_Label | None = None) -> list[Shape]:
+    def build_assembly(
+        parent_tdf_label: TDF_Label | None = None,
+        parent_location: Location | None = None,
+    ) -> list[Shape]:
         """Recursively extract object into an assembly"""
         sub_tdf_labels = TDF_LabelSequence()
         if parent_tdf_label is None:
@@ -220,12 +223,28 @@ def import_step(filename: PathLike | str | bytes) -> Compound:
             else:
                 ref_tdf_label = sub_tdf_label
 
+            # Compose this instance's location onto the ancestors' so every
+            # node's wrapped shape is world-placed. XCAF stores component
+            # geometry in the referred product's local frame; applying only
+            # the local instance location (as before) left the children of
+            # nested assemblies inconsistent with their parent's topological
+            # content — visible as mislocated children after re-parenting,
+            # and as STEPCAFControl_Writer transfer failures on re-export.
+            instance_location = Location(shape_tool.GetLocation_s(sub_tdf_label))
+            if parent_location is None:
+                world_location = instance_location
+            else:
+                world_location = parent_location * instance_location
+
             sub_topo_shape = downcast(shape_tool.GetShape_s(ref_tdf_label))
             if shape_tool.IsAssembly_s(ref_tdf_label):
                 sub_shape = Compound()
-                sub_shape.children = build_assembly(ref_tdf_label)
+                # children are world-placed; the children setter rebuilds
+                # this Compound's wrapped shape from them, so no move here
+                sub_shape.children = build_assembly(ref_tdf_label, world_location)
             else:
                 sub_shape = topods_lut[type(sub_topo_shape)](sub_topo_shape)
+                sub_shape.move(world_location)
 
             # Priority: instance/component label -> referred shape label -> geometric fallback
             instance_color = get_label_color(sub_tdf_label)
@@ -234,7 +253,6 @@ def import_step(filename: PathLike | str | bytes) -> Compound:
             sub_shape.color = instance_color or referred_color or shape_fallback_color
 
             sub_shape.label = get_name(ref_tdf_label)
-            sub_shape.move(Location(shape_tool.GetLocation_s(sub_tdf_label)))
 
             sub_shapes.append(sub_shape)
         return sub_shapes

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -302,6 +302,37 @@ class ImportSTEP(unittest.TestCase):
         self.assertAlmostEqual(p.Y, -2.0, 6)
         self.assertAlmostEqual(p.Z, -3.0, 6)
 
+    def test_import_children_world_placed(self):
+        """Children of a located nested assembly must come back world-placed,
+        consistent with the parent's topological content — not in the
+        referred product's local frame."""
+        leaf = Solid.make_box(1, 1, 1)
+        leaf.label = "leaf"
+        leaf.color = Color(1, 0, 0)
+        sub = Compound(children=[leaf])
+        sub.label = "sub"
+        root = Compound(children=[Pos(10, 0, 0) * sub])
+        root.label = "root"
+        export_step(root, "test.step")
+        imported = import_step("test.step")
+        os.remove("test.step")
+
+        self.assertEqual(imported.label, "root")
+        imported_sub = imported.children[0]
+        self.assertEqual(imported_sub.label, "sub")
+        imported_leaf = imported_sub.children[0]
+        self.assertEqual(imported_leaf.label, "leaf")
+        self.assertEqual(tuple(imported_leaf.color), (1, 0, 0, 1))
+
+        # the leaf node's own geometry is world-placed ...
+        leaf_bb = imported_leaf.bounding_box()
+        self.assertAlmostEqual(leaf_bb.min.X, 10.0, 6)
+        self.assertAlmostEqual(leaf_bb.max.X, 11.0, 6)
+        # ... and agrees with its parent's topological content
+        sub_bb = imported_sub.bounding_box()
+        self.assertAlmostEqual(sub_bb.min.X, leaf_bb.min.X, 6)
+        self.assertAlmostEqual(sub_bb.max.X, leaf_bb.max.X, 6)
+
 
 @pytest.mark.parametrize(
     "format", (Path, fsencode, fsdecode), ids=["path", "bytes", "str"]


### PR DESCRIPTION
## Problem

`build_assembly` applies only each node's own instance location, so the
children of a located sub-assembly stay in the referred product's local
frame — the anytree children disagree with the parent's topological content.
Anything that walks `.children` (e.g. re-parenting them into a new
`Compound`) sees mislocated geometry.

## Fix

Thread the cumulative (parent ∘ instance) location through `build_assembly`
and move leaf shapes by it; assembly nodes need no explicit move because
assigning `.children` rebuilds their wrapped shape from the (now
world-placed) children.

## Testing

`test_import_children_world_placed` (added) — the grandchild of a located
nested assembly comes back world-placed and agrees with its parent's
topology. Fails before this change; `tests/test_importers.py` and
`tests/test_exporters3d.py` pass with it.
