### PR TITLE
import_step: detach single free shape from its temporary wrapper

### DIFF
--- a/src/build123d/importers.py
+++ b/src/build123d/importers.py
@@ -258,9 +258,12 @@ def import_step(filename: PathLike | str | bytes) -> Compound:
 
     root = Compound()
     root.children = build_assembly()
-    # Remove empty Compound wrapper if single free object
+    # Remove empty Compound wrapper if single free object. Detach it from
+    # the wrapper too — a shape returned with a stale anytree parent makes
+    # export_step build an empty document (its label lookup walks .parent).
     if len(root.children) == 1:
         root = root.children[0]
+        root.parent = None
 
     return root
 

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -302,6 +302,35 @@ class ImportSTEP(unittest.TestCase):
         self.assertAlmostEqual(p.Y, -2.0, 6)
         self.assertAlmostEqual(p.Z, -3.0, 6)
 
+    def test_reexport_imported_assembly(self):
+        """import_step's result must be exportable again: the single-free-
+        shape unwrap has to detach the root from its temporary wrapper
+        (a stale parent made export_step build an empty document)."""
+        leaf = Solid.make_box(1, 1, 1)
+        leaf.label = "leaf"
+        leaf.color = Color(0, 0, 1)
+        sub = Compound(children=[leaf])
+        sub.label = "sub"
+        root = Compound(children=[Pos(10, 0, 0) * sub])
+        root.label = "root"
+        export_step(root, "test.step")
+        imported = import_step("test.step")
+        os.remove("test.step")
+
+        self.assertIsNone(imported.parent)
+
+        export_step(imported, "test.step")  # raised RuntimeError before
+        reimported = import_step("test.step")
+        os.remove("test.step")
+
+        # geometry round-trips at the correct world position
+        bb = reimported.bounding_box()
+        self.assertAlmostEqual(bb.min.X, 10.0, 6)
+        self.assertAlmostEqual(bb.max.X, 11.0, 6)
+        leaf2 = reimported.children[0].children[0]
+        self.assertEqual(leaf2.label, "leaf")
+        self.assertEqual(tuple(leaf2.color), (0, 0, 1, 1))
+
 
 @pytest.mark.parametrize(
     "format", (Path, fsencode, fsdecode), ids=["path", "bytes", "str"]


### PR DESCRIPTION
## Problem

With exactly one free shape in the document, `import_step` returns
`root.children[0]` while it is still parented to the discarded wrapper
`Compound`. `export_step` walks `.parent`, finds no label for the wrapper,
and silently builds an empty XCAF document — so
`export_step(import_step(f), out)` always fails with
`RuntimeError: Failed to write STEP file`.

## Fix

Detach the unwrapped shape from the temporary wrapper before returning it.

## Testing

`test_reexport_imported_assembly` (added) — `import_step`'s result has
`parent is None` and survives an export/import round-trip with label,
colour and placement intact. Fails before this change.
