### PR TITLE
Invert bulge value calculation in import_dxf.py

### DIFF
--- a/src/build123d/import_dxf.py
+++ b/src/build123d/import_dxf.py
@@ -209,7 +209,7 @@ def _convert_bulge_polyline(
         end_data = points[(i + 1) % len(points)]
         start_point = (start_data[0], start_data[1], z_value)
         end_point = (end_data[0], end_data[1], z_value)
-        bulge = start_data[2] if len(start_data) > 2 else 0
+        bulge = -1 * start_data[2] if len(start_data) > 2 else 0
 
         if math.dist(start_point, end_point) < TOLERANCE:
             continue

--- a/tests/test_import_dxf.py
+++ b/tests/test_import_dxf.py
@@ -250,11 +250,21 @@ def test_convert_bulge_polyline_single_edge(import_dxf_module):
     assert isinstance(edge, Line)
 
 
-def test_convert_bulge_polyline_sagitta_arc(import_dxf_module):
+@pytest.mark.parametrize(
+    ("bulge", "expected_midpoint"),
+    [
+        (1.0, (1.0, -1.0, 0.0)),
+        (-1.0, (1.0, 1.0, 0.0)),
+    ],
+)
+def test_convert_bulge_polyline_sagitta_arc(
+    import_dxf_module, bulge, expected_midpoint
+):
     edge = import_dxf_module._convert_bulge_polyline(
-        [(0.0, 0.0, 1.0), (2.0, 0.0, 0.0)], False, 0.0, "TEST"
+        [(0.0, 0.0, bulge), (2.0, 0.0, 0.0)], False, 0.0, "TEST"
     )
     assert isinstance(edge, SagittaArc)
+    assert tuple(edge.position_at(0.5)) == pytest.approx(expected_midpoint)
 
 
 def test_convert_bulge_polyline_degenerate(import_dxf_module):


### PR DESCRIPTION
Invert the bulge value for the start point in the import_dxf function. Fixes #1368