### PR TITLE
Add build123d-vtk package variant to publish.yml workflow, add a variant test to testing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,15 @@ jobs:
       - name: Build sdist and wheel (build123d-vtk)
         shell: bash
         run: |
+          WHEEL_FILE=$(ls wheelhouse/build123d-*.whl | head -n 1)
+
+          # Use unzip to stream the METADATA file, then grep the Version line
+          CLEAN_VERSION=$(unzip -p "$WHEEL_FILE" "*.dist-info/METADATA" | grep "^Version: " | cut -d' ' -f2)
+
+          # Force setuptools_scm to use this exact version
+          export SETUPTOOLS_SCM_PRETEND_VERSION="$CLEAN_VERSION"
+          echo "Pretending version for VTK build: $CLEAN_VERSION"
+
           # Patch pyproject.toml for the VTK variant
           sed -i 's/name = "build123d"/name = "build123d-vtk"/' pyproject.toml
           sed -i 's/cadquery-ocp-novtk/cadquery-ocp/' pyproject.toml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0 # get all history for setuptools_scm
         
-      - name: Build sdist and wheel
+      - name: Build sdist and wheel (main build123d)
         shell: bash
         run: |
           pwd
@@ -33,9 +33,21 @@ jobs:
           python3 -m pip freeze
           ls -lR
 
+      - name: Build sdist and wheel (build123d-vtk)
+        shell: bash
+        run: |
+          # Patch pyproject.toml for the VTK variant
+          sed -i 's/name = "build123d"/name = "build123d-vtk"/' pyproject.toml
+          sed -i 's/cadquery-ocp-novtk/cadquery-ocp/' pyproject.toml
+
+          # Build the new variant into the existing wheelhouse dir
+          python3 -m build --outdir wheelhouse
+
+          ls -lR wheelhouse
+
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
-          path: ./wheelhouse/build123d*.* # store the build123d wheel and sdist
+          path: ./wheelhouse/*.* # store the build123d wheel and sdist and build123d-vtk variant
       
   upload_pypi:
     needs: [build_wheel]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,19 +18,33 @@ jobs:
           windows-latest, 
           ubuntu-24.04-arm
         ]
+        vtk: [false]
         include:
           - python-version: "3.10"
             os: ubuntu-latest
+            vtk: false
+
+          - python-version: "3.13"
+            os: ubuntu-latest
+            vtk: true
 
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           persist-credentials: false
+
+      - name: Patch pyproject.toml for build123d-vtk variant
+        if: matrix.vtk == true
+        run: |
+          sed -i 's/name = "build123d"/name = "build123d-vtk"/' pyproject.toml
+          sed -i 's/cadquery-ocp-novtk/cadquery-ocp/' pyproject.toml
+
       - uses: ./.github/actions/setup/
         with:
           python-version: ${{ matrix.python-version }}
           optional-dependencies: "development"
+
       - name: test
         run: |
           python -m pytest -n auto --benchmark-disable


### PR DESCRIPTION
- Patch pyproject.toml during runtime of publish.yml and test.yml workflows
  - Changes to cadquery-ocp as dep, change package name to build123d-vtk
- Considered the approach of creating a `build123d-vtk/` subfolder with separate `pyproject.toml` but using `../src` is not recommended and not compatible with windows
- Manually sets setuptools_scm version of build123d-vtk variant to match build123d to override dirty git history caused by sed changes to pyproject.toml
- Both packages are built then published simultaneously on tag creation
- Will need to separately create a build123d-vtk package on PyPI

Motivation:

1. Makes it easier to install build123d alongside cadquery again because of shared `cadquery-ocp` dependency instead of clash caused by `cadquery-ocp-novtk`
2. Makes it easier to use build123d's `vtk_tools.py`