### PR TITLE
Test Docs Examples

### DIFF
--- a/docs/constraint_examples.py
+++ b/docs/constraint_examples.py
@@ -79,7 +79,7 @@ svg.write("assets/perpendicular_ex.svg")
 # Intersection
 #
 with BuildLine() as intersect_ex:
-    c_l1 = EllipticalCenterArc((0, 0), 1.2, 1.8, 0, 90, mode=Mode.PRIVATE)
+    c_l1 = EllipticalCenterArc((0, 0), 1.2, 1.8, 0, arc_size=90, mode=Mode.PRIVATE)
     l1 = IntersectingLine(
         start=(0, 0), direction=Vector(1, 0).rotate(Axis.Z, 10), other=c_l1
     )

--- a/docs/objects_1d.py
+++ b/docs/objects_1d.py
@@ -118,7 +118,7 @@ svg.add_shape(dot.moved(Location(Vector((0, 0)))))
 svg.write("assets/center_arc_example.svg")
 
 with BuildLine() as elliptical_center_arc:
-    EllipticalCenterArc((0, 0), 2, 3, 0, 90)
+    EllipticalCenterArc((0, 0), 2, 3, 0, arc_size=90)
 s = 100 / max(*elliptical_center_arc.line.bounding_box().size)
 svg = ExportSVG(scale=s)
 svg.add_shape(elliptical_center_arc.line)

--- a/docs/objects_1d_ellipticalstartarc.py
+++ b/docs/objects_1d_ellipticalstartarc.py
@@ -7,7 +7,7 @@ dot = Circle(0.05)
 
 e_dir = Vector(0.2, 1)
 with BuildLine() as arcs:
-    a = EllipticalStartArc((1, 1), (0, 1), 3, 1, e_dir, 160)
+    a = EllipticalStartArc((1, 1), (0, 1), 3, 1, 160, major_axis_dir=e_dir)
     d = PolarLine(a.arc_center, 0.5, direction=e_dir)
 
 

--- a/docs/objects_1d_parabolic_hyperbolic.py
+++ b/docs/objects_1d_parabolic_hyperbolic.py
@@ -6,7 +6,7 @@ from build123d import *
 dot = Circle(0.05)
 
 with BuildLine() as parabolic_center_arc:
-    ParabolicCenterArc((0, 0), 0.25, -60, 60)
+    ParabolicCenterArc((0, 0), 0.25, -60, arc_size=120)
 s = 100 / max(*parabolic_center_arc.line.bounding_box().size)
 svg = ExportSVG(scale=s)
 svg.add_shape(parabolic_center_arc.line)
@@ -14,7 +14,7 @@ svg.add_shape(dot.moved(Location(Vector((0, 0)))))
 svg.write("assets/parabolic_center_arc_example.svg")
 
 with BuildLine() as hyperbolic_center_arc:
-    HyperbolicCenterArc((0, 0), 0.5, 1, 0, 180)
+    HyperbolicCenterArc((0, 0), 0.5, 1, 0, arc_size=180)
 s = 100 / max(*hyperbolic_center_arc.line.bounding_box().size)
 svg = ExportSVG(scale=s)
 svg.add_shape(hyperbolic_center_arc.line)

--- a/docs/spitfire_wing_gordon.py
+++ b/docs/spitfire_wing_gordon.py
@@ -2,6 +2,8 @@
 Supermarine Spitfire Wing
 """
 
+import pytest
+
 # [Code]
 
 from build123d import *
@@ -15,10 +17,18 @@ wing_tip_section = wing_span / 2 - 1 * IN  # distance from root to last section
 
 # Create leading and trailing edges
 leading_edge = EllipticalCenterArc(
-    (0, 0), wing_span / 2, wing_leading, start_angle=270, end_angle=360
+    (0, 0),
+    wing_span / 2,
+    wing_leading,
+    start_angle=270,
+    arc_size=90,
 )
 trailing_edge = EllipticalCenterArc(
-    (0, 0), wing_span / 2, wing_trailing, start_angle=0, end_angle=90
+    (0, 0),
+    wing_span / 2,
+    wing_trailing,
+    start_angle=0,
+    arc_size=90,
 )
 
 # [AirfoilSizes]
@@ -33,12 +43,18 @@ for i in [0, 1]:
 # [Airfoils]
 # Create the root and tip airfoils - note that they are different NACA profiles
 airfoil_root = Plane.YZ * scale(
-    Airfoil("2213").translate((-wing_leading_fraction, 0, 0)), airfoil_sizes[0]
+    Airfoil("2213").move(Pos(-wing_leading_fraction, 0, 0)),
+    airfoil_sizes[0],
+    about=(0, 0, 0),
 )
 airfoil_tip = (
     Plane.YZ
     * Pos(Z=wing_tip_section)
-    * scale(Airfoil("2205").translate((-wing_leading_fraction, 0, 0)), airfoil_sizes[1])
+    * scale(
+        Airfoil("2205").move(Pos(-wing_leading_fraction, 0, 0)),
+        airfoil_sizes[1],
+        about=(0, 0, 0),
+    )
 )
 
 # [Profiles]
@@ -46,6 +62,7 @@ airfoil_tip = (
 profiles = airfoil_root.edges() + airfoil_tip.edges()
 profiles.append(leading_edge @ 1)  # wing tip
 guides = [leading_edge, trailing_edge]
+
 # Create the wing surface as a Gordon Surface
 wing_surface = -Face.make_gordon_surface(profiles, guides)
 # Create the root of the wing
@@ -58,6 +75,9 @@ wing.color = 0x99A3B9  # Azure Blue
 
 show(wing)
 # [End]
+
+assert wing.volume / 1e9 == pytest.approx(1.9879945989)
+
 # Documentation artifact generation
 # wing_control_edges = Curve(
 #     [airfoil_root, airfoil_tip, Vertex(leading_edge @ 1), leading_edge, trailing_edge]

--- a/docs/topology_selection/examples/group_hole_area.py
+++ b/docs/topology_selection/examples/group_hole_area.py
@@ -25,7 +25,7 @@ with BuildPart() as part:
 
 show(
     before,
-    [f.translate(f.normal_at() * 0.01) for f in faces],
+    [f.translate(f.normal_at() * 0.01) for group in faces for f in group],
     part.part.translate((40, 40)),
 )
 save_screenshot(os.path.join(filedir, "group_hole_area.png"))

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -1,0 +1,133 @@
+"""
+build123d docs example tests
+
+name: test_docs_examples.py
+by:   jdegenstein
+date: July 16 2026
+
+desc: Unit tests for the build123d examples in the docs subfolder.
+"""
+
+from pathlib import Path
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+_docs_dir = Path(os.path.abspath(os.path.dirname(__file__))).parent / "docs"
+
+_MOCK_OCP_VSCODE_CONTENTS = """
+import sys
+from unittest.mock import MagicMock
+
+mock_ocp = MagicMock()
+# Explicitly add properties so `from ocp_vscode import *` pulls them in
+for attr in [
+    "show", "show_object", "show_all", "save_screenshot", 
+    "set_port", "set_defaults", "Camera", "ColorMap", "reset_show"
+]:
+    setattr(mock_ocp, attr, MagicMock())
+
+sys.modules["ocp_vscode"] = mock_ocp
+
+# Mock heavy optional dependencies so they don't crash the CI runner
+mock_bd = MagicMock()
+sys.modules["tcv_screenshots"] = mock_bd
+"""
+
+# fmt: off
+IGNORE_FILES = {
+    "conf.py",
+    "build123d_lexer.py",
+    "rigid_joints_pipe.py",  # ignored due to bd_warehouse dependency
+    "technical_drawing.py",  # ^
+    "rod_end.py",            # ^
+}  # fmt: on
+
+# skip "ttt" as that is covered by test_examples.py
+IGNORE_DIRS = {"ttt", "_build", ".venv", "_static"}
+
+
+def generate_docs_example_test(path: Path):
+    name = path.stem
+
+    def assert_example_does_not_raise(self):
+        with tempfile.TemporaryDirectory(
+            prefix=f"build123d_test_docs_{name}"
+        ) as tmpdir:
+
+            # copy assets subfolder to the temp directory
+            # this ensures 1. files are present to be imported
+            # 2. directory structure allows for temporary exports
+            if (_docs_dir / "assets").exists():
+                shutil.copytree(
+                    _docs_dir / "assets", Path(tmpdir) / "assets", dirs_exist_ok=True
+                )
+
+            for file_obj in _docs_dir.glob("*.*"):
+                if file_obj.is_file() and file_obj.suffix not in [".py", ".rst", ".md"]:
+                    shutil.copy(file_obj, Path(tmpdir) / file_obj.name)
+            # ------------------------------------------------------------------------
+
+            mock_ocp_vscode = Path(tmpdir) / "_mock_ocp_vscode.py"
+            with open(mock_ocp_vscode, "w", encoding="utf-8") as f:
+                f.write(_MOCK_OCP_VSCODE_CONTENTS)
+
+            cmd = (
+                f"exec(open(r'{mock_ocp_vscode}', encoding='utf-8').read()); "
+                f"__file__ = r'{path}'; "
+                f"exec(open(r'{path}', encoding='utf-8').read())"
+            )
+
+            env = os.environ.copy()
+            env["PYTHONIOENCODING"] = "utf-8"
+
+            got = subprocess.run(
+                [sys.executable, "-c", cmd],
+                capture_output=True,
+                cwd=tmpdir,
+                check=False,
+                text=True,
+                encoding="utf-8",
+                env=env,
+            )
+
+            self.assertEqual(
+                0,
+                got.returncode,
+                f"Example {path.name} failed!\nSTDOUT:\n{got.stdout}\nSTDERR:\n{got.stderr}",
+            )
+
+    return assert_example_does_not_raise
+
+
+class TestDocsExamples(unittest.TestCase):
+    """Tests build123d docs examples."""
+
+
+# Recursively find all python files in the docs directory
+for example in _docs_dir.rglob("*.py"):
+    # Filter against ignore sets and underscore prefixes
+    if example.name in IGNORE_FILES or example.name.startswith("_"):
+        continue
+
+    if any(part in IGNORE_DIRS for part in example.relative_to(_docs_dir).parts):
+        continue
+
+    # Create a safe test method name (e.g., test_topology_selection_examples_filter_geomtype)
+    rel_path = example.relative_to(_docs_dir)
+    test_name = (
+        f"test_{str(rel_path.with_suffix('')).replace(os.sep, '_').replace('.', '_')}"
+    )
+
+    setattr(
+        TestDocsExamples,
+        test_name,
+        generate_docs_example_test(example),
+    )
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- create new test file for testing examples from docs subfolder
  - skip ttt as they are tested in existing `test_examples.py`
  - skip those that depend on `bd_warehouse`
  - does not test python code embedded in .rst files (non-goal of this PR)
  - for the most part this is testing that examples can run, not for correctness
  - correctness can be tested by simply adding assert statements as I did below with spitfire_gordon.py
- fix failing tests
  - spitfire_gordon.py had two problems:
    - affected by bug in EllipticalCenterArc arc_size handling
    - affected by change to .translate where it does not reconstruct anymore, decided to switch to .move and scale about global origin. This resulted in incorrect curve placement, causing gordon surface construction to fail.
    - also added an assert statement with expected volume
  - work around bug in EllipticalCenterArc, HyperbolicCenterArc, and ParabolicCenterArc by manually setting arc_size
  
Motivation:
  
Add another guardrail to prevent the docs from not being updated when the API is. Even if this is an incomplete solution, I feel like it will help catch issues in the future.

related to this issue https://github.com/gumyr/build123d/issues/1269 but does not fix the underlying problem