### PR TITLE
switch from codecov to covdefaults, coverage.py, diff-cover

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -21,6 +21,6 @@ runs:
     - name: Install Requirements
       shell: bash
       run: |
-        uv pip install .["$OPTIONAL_DEPS"]
+        uv pip install -e .["$OPTIONAL_DEPS"]
       env:
         OPTIONAL_DEPS: ${{ inputs.optional-dependencies }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
           optional-dependencies: "development"
 
       - name: Run tests and collect coverage
-        run: pytest --cov --cov-report=xml
+        run: pytest --cov --cov-report=term-missing --cov-report=xml
 
       - name: Enforce Patch Coverage
         run: diff-cover coverage.xml --compare-branch=origin/${{ github.base_ref || 'dev' }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,12 +25,14 @@ jobs:
         run: pytest --cov --cov-report=term-missing --cov-report=xml --cov-report=html 
 
       - name: Enforce Patch Coverage
-        run: diff-cover coverage.xml --compare-branch=origin/${{ github.base_ref || 'dev' }} --show-uncovered --html-report diff-cover-report.html
-  
+        run: |
+          diff-cover coverage.xml --compare-branch=origin/${{ github.base_ref || 'dev' }} --show-uncovered --html-report dc-report.html --markdown-report dc-report.md
+          cat dc-report.md >> $GITHUB_STEP_SUMMARY
+
       - name: Upload Interactive HTML Coverage Reports
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
           name: coverage-reports
           path: |
             htmlcov/
-            diff-cover-report.html
+            dc-report.html

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,10 +1,9 @@
-name: Upload coverage reports to Codecov
+name: coverage
 
 on: [push, pull_request]
 
 permissions:
   contents: read
-  actions: write
 
 jobs:
   run:
@@ -14,12 +13,16 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           persist-credentials: false
+          fetch-depth: 0
+
       - name: Setup
         uses: ./.github/actions/setup/
         with:
           python-version: "3.10"
           optional-dependencies: "development"
+
       - name: Run tests and collect coverage
-        run: pytest --cov=build123d
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
+        run: pytest --cov --cov-report=xml
+
+      - name: Enforce Patch Coverage
+        run: diff-cover coverage.xml --compare-branch=origin/${{ github.base_ref || 'dev' }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,15 @@ jobs:
           optional-dependencies: "development"
 
       - name: Run tests and collect coverage
-        run: pytest --cov --cov-report=term-missing --cov-report=xml
+        run: pytest --cov --cov-report=term-missing --cov-report=xml --cov-report=html 
 
       - name: Enforce Patch Coverage
-        run: diff-cover coverage.xml --compare-branch=origin/${{ github.base_ref || 'dev' }}
+        run: diff-cover coverage.xml --compare-branch=origin/${{ github.base_ref || 'dev' }} --show-uncovered --html-report diff-cover-report.html
+  
+      - name: Upload Interactive HTML Coverage Reports
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
+        with:
+          name: coverage-reports
+          path: |
+            htmlcov/
+            diff-cover-report.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,8 @@ ocp_vscode = [
 # development dependencies
 development = [
     "black",
+    "covdefaults",
+    "diff-cover",
     "mypy",
     "pylint",
     "pytest >= 9.1.1",
@@ -114,3 +116,15 @@ write_to = "src/build123d/_version.py"
 [tool.black]
 target-version = ["py310", "py311", "py312", "py313", "py314"]
 line-length = 88
+
+[tool.coverage.run]
+plugins = ["covdefaults"]
+source = ["build123d"]
+
+[tool.coverage.report]
+fail_under = 95
+show_missing = true
+
+[tool.diff_cover]
+fail_under = 95
+show_uncovered = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ plugins = ["covdefaults"]
 source = ["build123d"]
 
 [tool.coverage.report]
-fail_under = 95
+fail_under = 94
 show_missing = true
 
 [tool.diff_cover]


### PR DESCRIPTION
1. This does not depend on an cloud provider like codecov did
2. covdefaults provides the default config as a plugin to coverage.py. This step is analogous to codecov/project.
3. diff-cover takes the report from step 2 and analyzes it in context of the patch. This step is analogous to codecov/patch.
4. lower project fail target to 94% which is slightly below current (94.21)
5. add html reports for coverage.py and diff-cover
6. switch to editable installs to ensure paths match correctly, this affects all workflows because it was changed in our setup workflow.

Motivation:
Eliminate constant flaky behavior in codecov resulting in failing CI especially for codecov/project being out of date.