### PR TITLE
Enhance diff-cover command in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,12 @@ jobs:
 
       - name: Enforce Patch Coverage
         run: |
-          diff-cover coverage.xml --compare-branch=origin/${{ github.base_ref || 'dev' }} --show-uncovered --html-report dc-report.html --markdown-report dc-report.md
+          diff-cover coverage.xml \
+            --config-file pyproject.toml \
+            --compare-branch=origin/${{ github.base_ref || 'dev' }} \
+            --show-uncovered \
+            --format html:dc-report.html \
+            --format markdown:dc-report.md
           cat dc-report.md >> $GITHUB_STEP_SUMMARY
 
       - name: Upload Interactive HTML Coverage Reports


### PR DESCRIPTION
- Updated diff-cover command to include pyproject.toml config file. This is not auto discovered like most python tools. This is important because it sets fail_under = 95 to flag poor coverage.
- Update format options to avoid deprecated diff-cover syntax and fix associated UserWarnings.