### PR TITLE
Add persistent Onshape-style mates and AP242 kinematics

### DIFF
--- a/docs/assemblies.rst
+++ b/docs/assemblies.rst
@@ -8,6 +8,9 @@ Most CAD designs consist of more than one part which are naturally arranged in
 some type of assembly. Once parts have been assembled in a :class:`~topology.Compound` object
 they can be treated as a unit - i.e. :meth:`~topology.Shape.moved` or exported.
 
+For assemblies that must preserve and re-solve their mechanical constraints,
+see :ref:`assembly_mates`.
+
 To create an assembly in build123d, one needs to
 create a tree of parts by simply assigning either a :class:`~topology.Compound` object's ``parent`` or
 ``children`` attributes. To illustrate the process, we'll extend the

--- a/docs/assembly_mates.rst
+++ b/docs/assembly_mates.rst
@@ -1,0 +1,253 @@
+.. _assembly_mates:
+
+#########################
+Persistent Assembly Mates
+#########################
+
+Build123d joints position two parts when ``connect_to`` is called.  An
+:class:`~assembly.Assembly` instead retains its mates and mate relations as
+design intent.  Calling :meth:`~assembly.Assembly.solve` recalculates every
+active constraint simultaneously, so moving a fixed component, changing a
+mate value, or suppressing a feature updates the complete assembly.
+
+Mate connectors use the Onshape coordinate convention: Z is the primary axis
+and X is the secondary axis.  :class:`~assembly.MateConnector` derives from
+:class:`~joints.RigidJoint`, so existing rigid joints can be used directly as
+mate connectors and retain the usual part-local storage and copy behavior.
+
+Quick Start
+***********
+
+.. code-block:: python
+
+    from build123d import *
+
+    frame = Box(40, 20, 4)
+    frame.label = "frame"
+    arm = Pos(0, 0, 20) * Box(4, 4, 30)
+    arm.label = "arm"
+
+    frame_axis = MateConnector("frame axis", frame, Location((0, 0, 4)))
+    arm_axis = MateConnector("arm axis", arm, arm.location)
+
+    mechanism = Assembly((frame, arm), label="mechanism").ground(frame)
+    hinge = mechanism.revolute(
+        "hinge",
+        frame_axis,
+        arm_axis,
+        limits={"rz": (-90, 90)},
+    )
+
+    hinge.set_value("rz", 35)
+    mechanism.solve()
+
+The assembly itself is a :class:`~topology.Compound`, so it can be displayed,
+moved, and exported like other build123d shapes.  Mate definitions are Python
+object state; neutral CAD formats such as STEP contain the solved geometry and
+assembly hierarchy, but do not contain build123d's mate objects.
+
+Mate Features
+*************
+
+Connector-based mates accept ``flip_primary`` to reverse Z and
+``reorient_secondary`` to rotate the XY orientation in 90-degree increments.
+They may also be created suppressed.  The complete supported motion and option
+set is:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 20 20 24
+
+   * - Mate
+     - Free motion
+     - Limits
+     - Offset
+   * - :class:`~assembly.FastenedMate`
+     - None
+     - None
+     - X, Y, Z and rotation
+   * - :class:`~assembly.RevoluteMate`
+     - Rz
+     - Rz
+     - Z and rotation
+   * - :class:`~assembly.SliderMate`
+     - Tz
+     - Tz
+     - X, Y and rotation
+   * - :class:`~assembly.PlanarMate`
+     - Tx, Ty, Rz
+     - Tx, Ty, Rz
+     - Z and rotation
+   * - :class:`~assembly.CylindricalMate`
+     - Tz, Rz
+     - Tz, Rz
+     - None
+   * - :class:`~assembly.PinSlotMate`
+     - Tx, Rz
+     - Tx, Rz
+     - Z and rotation
+   * - :class:`~assembly.BallMate`
+     - Rx, Ry, Rz
+     - Conical swing
+     - None
+   * - :class:`~assembly.ParallelMate`
+     - Tx, Ty, Tz, Rz
+     - Tx, Ty, Tz, Rz
+     - None
+   * - :class:`~assembly.TangentMate`
+     - Determined by selected geometry
+     - None
+     - None
+   * - :class:`~assembly.WidthMate`
+     - Translation and rotation in the center plane
+     - None
+     - None
+   * - :class:`~assembly.GroupMate`
+     - Six for the group as a whole
+     - None
+     - Captured component origins
+
+Tx, Ty, and Tz are translations in the first mate connector's frame.  Rx, Ry,
+and Rz are rotations in degrees.  All mate types except Ball, Fastened,
+Tangent, Width, and Group expose their free coordinates through
+:meth:`~assembly.Mate.set_value`. Commanded angles retain their full turn count
+for Gear, Rack and Pinion, and Screw relations even though the resulting rigid
+transform is periodic.
+
+Offsets, Limits, and Suppression
+================================
+
+:class:`~assembly.MateOffset` stores a fixed translation and Euler-angle
+rotation.  Each mate validates that only its supported translation directions
+are used.  :class:`~assembly.MateLimit` stores inclusive minimum and maximum
+values.  Limits apply only to a mate's free coordinates:
+
+.. code-block:: python
+
+    slide = SliderMate(
+        "piston",
+        cylinder_connector,
+        piston_connector,
+        offset=MateOffset((2, -1, 0), (0, 0, 5)),
+        limits={"tz": MateLimit(0, 80)},
+    )
+    assembly.add_mate(slide)
+    slide.set_value("tz", 25)
+
+    slide.suppress()
+    assembly.solve()
+    slide.suppress(False)
+    assembly.solve()
+
+For Ball mates, use ``limits={"swing": (0, maximum_angle)}``; the swing angle
+is measured between the two connector Z axes.
+
+Tangent
+========
+
+:class:`~assembly.TangentMate` accepts a component and selected face, edge, or
+vertex on each side.  Analytic and swept faces are supported; offset and
+generic Bezier/B-spline faces are rejected.  Adjacent tangent-continuous faces
+or edges are included by default, or this can be disabled with
+``propagate=False``. Propagation has no effect on vertices. ``flip_primary``
+selects the opposite face-to-face normal relationship and is ignored for other
+selection pairs.
+
+.. code-block:: python
+
+    tangent = TangentMate(
+        "cam contact",
+        cam,
+        cam.faces()[0],
+        follower,
+        follower.faces()[0],
+        propagate=True,
+    )
+    assembly.add_mate(tangent)
+
+Width
+=====
+
+:class:`~assembly.WidthMate` accepts one or two tab connectors and exactly two
+width connectors.  A one-tab mate centers that connector on the width center
+plane.  A two-tab mate keeps the tabs mirror-symmetric about the plane.  Tab
+and width connectors cannot belong to the same component, while either side
+may use two connectors from one component.
+
+Group
+=====
+
+:class:`~assembly.GroupMate` captures the current relative component origins
+without depending on geometry.  The selected components subsequently move as
+a rigid cluster.  The group itself remains free until a member is fixed or
+constrained by another mate.
+
+Mate Relations
+**************
+
+Relations couple coordinates already exposed by mates.  Their initial phase is
+captured on the first solve, preserving the current assembly position.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 35 40
+
+   * - Relation
+     - Coupled motion
+     - Parameter
+   * - :class:`~assembly.GearRelation`
+     - Two revolute Rz coordinates
+     - Ratio and reverse direction
+   * - :class:`~assembly.RackAndPinionRelation`
+     - Revolute Rz and linear coordinate
+     - Travel per revolution and reverse direction
+   * - :class:`~assembly.ScrewRelation`
+     - Tz and Rz of one cylindrical mate
+     - Travel per revolution and reverse direction
+   * - :class:`~assembly.LinearRelation`
+     - Two translational mate coordinates
+     - Ratio and reverse direction
+
+Solving and Diagnostics
+***********************
+
+Use :meth:`~assembly.Assembly.ground` to ground one or more direct components.
+If none is fixed, the solver temporarily grounds the first component to remove
+the six global rigid-body degrees of freedom.  The solve result reports cost,
+maximum normalized residual, iteration count, and remaining physical degrees
+of freedom.  Inconsistent or nonconvergent constraints raise
+:class:`~assembly.MateSolveError` by default; pass ``strict=False`` to inspect
+the unsuccessful result without raising.
+
+Mates and relations survive ordinary Python deep copies.  The copied assembly
+has independent mate values, relations, grounding, and geometry.
+
+API
+***
+
+.. py:module:: assembly
+
+.. autoclass:: Assembly
+   :members:
+.. autoclass:: MateConnector
+.. autoclass:: Mate
+   :members:
+.. autoclass:: MateLimit
+.. autoclass:: MateOffset
+.. autoclass:: FastenedMate
+.. autoclass:: RevoluteMate
+.. autoclass:: SliderMate
+.. autoclass:: PlanarMate
+.. autoclass:: CylindricalMate
+.. autoclass:: PinSlotMate
+.. autoclass:: BallMate
+.. autoclass:: ParallelMate
+.. autoclass:: TangentMate
+.. autoclass:: WidthMate
+.. autoclass:: GroupMate
+.. autoclass:: GearRelation
+.. autoclass:: RackAndPinionRelation
+.. autoclass:: ScrewRelation
+.. autoclass:: LinearRelation
+.. autoclass:: MateSolveResult
+.. autoclass:: MateSolveError

--- a/docs/assembly_mates.rst
+++ b/docs/assembly_mates.rst
@@ -42,9 +42,15 @@ Quick Start
     mechanism.solve()
 
 The assembly itself is a :class:`~topology.Compound`, so it can be displayed,
-moved, and exported like other build123d shapes.  Mate definitions are Python
-object state; neutral CAD formats such as STEP contain the solved geometry and
-assembly hierarchy, but do not contain build123d's mate objects.
+moved, and exported like other build123d shapes.  :func:`~exporters3d.export_step`
+exports assemblies with mates as AP242.  Common connector mates, ranges, current
+values, links, joints, and rigid groups are standard AP242 kinematics.  Because
+AP242 cannot faithfully express every Onshape feature detail (including Ball's
+single conical swing limit, Tangent/Width selections, and general mate
+relations), the same file also contains a versioned build123d payload preserving
+all mate fields and raw Onshape API parameters.  Use
+:func:`~importers.import_step_assembly` for a lossless build123d round trip, or
+``write_kinematics=False`` to export geometry without kinematics.
 
 Mate Features
 *************

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -101,6 +101,7 @@ Table Of Contents
     builders.rst
     joints.rst
     assemblies.rst
+    assembly_mates.rst
     tips.rst
     import_export.rst
     advanced.rst

--- a/src/build123d/__init__.py
+++ b/src/build123d/__init__.py
@@ -11,6 +11,7 @@ from build123d.geometry import *
 from build123d.importers import *
 from build123d.import_dxf import import_dxf
 from build123d.joints import *
+from build123d.assembly import *
 from build123d.mesher import *
 from build123d.objects_curve import *
 from build123d.objects_part import *
@@ -194,6 +195,31 @@ __all__ = [
     "LinearJoint",
     "CylindricalJoint",
     "BallJoint",
+    # Persistent assemblies and Onshape-style mates
+    "Assembly",
+    "Mate",
+    "MateConnector",
+    "MateDOF",
+    "MateLimit",
+    "MateOffset",
+    "MateRelation",
+    "MateSolveError",
+    "MateSolveResult",
+    "FastenedMate",
+    "RevoluteMate",
+    "SliderMate",
+    "PlanarMate",
+    "CylindricalMate",
+    "PinSlotMate",
+    "BallMate",
+    "ParallelMate",
+    "TangentMate",
+    "WidthMate",
+    "GroupMate",
+    "GearRelation",
+    "RackAndPinionRelation",
+    "ScrewRelation",
+    "LinearRelation",
     "DraftAngleError",
     "FontManager",
     # Exporter classes

--- a/src/build123d/__init__.py
+++ b/src/build123d/__init__.py
@@ -24,6 +24,7 @@ from build123d.topology import *
 from build123d.drafting import *
 from build123d.persistence import modify_copyreg
 from build123d.exporters3d import *
+from build123d.step_kinematics import *
 from build123d.text import available_fonts, FontManager
 from build123d.brep_from_stl import detect_primitives
 from build123d.build_constants import (
@@ -234,6 +235,7 @@ __all__ = [
     "import_brep",
     "import_dxf",
     "import_step",
+    "import_step_assembly",
     "import_stl",
     "import_svg",
     "import_svg_as_buildline_code",
@@ -288,4 +290,11 @@ __all__ = [
     "export_stl",
     "export_brep",
     "export_to_pcbway",
+    # STEP assembly kinematics
+    "assembly_from_kinematics",
+    "assembly_to_kinematics",
+    "decode_kinematics_payload",
+    "encode_kinematics_payload",
+    "inject_step_kinematics",
+    "read_step_kinematics",
 ]

--- a/src/build123d/assembly.py
+++ b/src/build123d/assembly.py
@@ -490,7 +490,8 @@ def _shared_tangent_edge(face1: Face, face2: Face) -> bool:
             point = edge1.position_at(0.5)
             normal1 = _normalized(_vector_tuple(face1.normal_at(point)))
             normal2 = _normalized(_vector_tuple(face2.normal_at(point)))
-            return abs(float(np.dot(normal1, normal2))) >= 1 - 1e-7
+            if abs(float(np.dot(normal1, normal2))) >= 1 - 1e-7:
+                return True
     return False
 
 
@@ -524,21 +525,16 @@ def _propagated_faces(component: Shape, selected: Face) -> list[Face]:
 def _edges_tangent_at_shared_vertex(edge1: Edge, edge2: Edge) -> bool:
     """Return whether two edges meet with tangent-continuous directions."""
 
-    shared = next(
-        (
-            vertex1
-            for vertex1 in edge1.vertices()
-            for vertex2 in edge2.vertices()
-            if vertex1.is_same(vertex2)
-        ),
-        None,
-    )
-    if shared is None:
-        return False
-    point = shared.center()
-    tangent1 = _normalized(_vector_tuple(edge1.tangent_at(point)))
-    tangent2 = _normalized(_vector_tuple(edge2.tangent_at(point)))
-    return abs(float(np.dot(tangent1, tangent2))) >= 1 - 1e-7
+    for vertex1 in edge1.vertices():
+        for vertex2 in edge2.vertices():
+            if not vertex1.is_same(vertex2):
+                continue
+            point = vertex1.center()
+            tangent1 = _normalized(_vector_tuple(edge1.tangent_at(point)))
+            tangent2 = _normalized(_vector_tuple(edge2.tangent_at(point)))
+            if abs(float(np.dot(tangent1, tangent2))) >= 1 - 1e-7:
+                return True
+    return False
 
 
 def _propagated_edges(component: Shape, selected: Edge) -> list[Edge]:
@@ -742,17 +738,6 @@ class TangentMate(Mate):
         located2 = [
             (reference, reference.located(poses)) for reference in self.entities2
         ]
-        pairs = [
-            (
-                entity1.distance_to(entity2),
-                reference1,
-                entity1,
-                reference2,
-                entity2,
-            )
-            for reference1, entity1 in located1
-            for reference2, entity2 in located2
-        ]
         best: (
             tuple[
                 float,
@@ -763,43 +748,44 @@ class TangentMate(Mate):
             ]
             | None
         ) = None
-        for _, reference1, entity1, reference2, entity2 in pairs:
-            _, point1, point2 = entity1.distance_to_with_closest_points(entity2)
-            scale = max(
-                entity1.bounding_box(optimal=False).diagonal,
-                entity2.bounding_box(optimal=False).diagonal,
-                1.0,
-            )
-            candidates1 = _parameter_candidates(entity1, point1)
-            candidates2 = _parameter_candidates(entity2, point2)
-            evaluated1 = [
-                (parameters, *_entity_point_direction(entity1, parameters))
-                for parameters in candidates1
-            ]
-            evaluated2 = [
-                (parameters, *_entity_point_direction(entity2, parameters))
-                for parameters in candidates2
-            ]
-            for parameters1, sample1, direction1 in evaluated1:
-                for parameters2, sample2, direction2 in evaluated2:
-                    score = np.linalg.norm(sample2 - sample1) / scale + 4 * (
-                        _tangent_alignment_error(
-                            entity1,
-                            direction1,
-                            entity2,
-                            direction2,
-                            self.flip_primary,
+        for reference1, entity1 in located1:
+            for reference2, entity2 in located2:
+                _, point1, point2 = entity1.distance_to_with_closest_points(entity2)
+                scale = max(
+                    entity1.bounding_box(optimal=False).diagonal,
+                    entity2.bounding_box(optimal=False).diagonal,
+                    1.0,
+                )
+                candidates1 = _parameter_candidates(entity1, point1)
+                candidates2 = _parameter_candidates(entity2, point2)
+                evaluated1 = [
+                    (parameters, *_entity_point_direction(entity1, parameters))
+                    for parameters in candidates1
+                ]
+                evaluated2 = [
+                    (parameters, *_entity_point_direction(entity2, parameters))
+                    for parameters in candidates2
+                ]
+                for parameters1, sample1, direction1 in evaluated1:
+                    for parameters2, sample2, direction2 in evaluated2:
+                        score = np.linalg.norm(sample2 - sample1) / scale + 4 * (
+                            _tangent_alignment_error(
+                                entity1,
+                                direction1,
+                                entity2,
+                                direction2,
+                                self.flip_primary,
+                            )
                         )
-                    )
-                    candidate = (
-                        float(score),
-                        reference1,
-                        reference2,
-                        parameters1,
-                        parameters2,
-                    )
-                    if best is None or candidate[0] < best[0]:
-                        best = candidate
+                        candidate = (
+                            float(score),
+                            reference1,
+                            reference2,
+                            parameters1,
+                            parameters2,
+                        )
+                        if best is None or candidate[0] < best[0]:
+                            best = candidate
         assert best is not None
         _, reference1, reference2, parameters1, parameters2 = best
         self._active_pair = (reference1, reference2)

--- a/src/build123d/assembly.py
+++ b/src/build123d/assembly.py
@@ -12,6 +12,7 @@ angular values use degrees.
 
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass, field
 from enum import Enum
 from math import acos, degrees, inf, pi
@@ -196,6 +197,7 @@ class Mate:
         flip_primary: bool = False,
         reorient_secondary: int = 0,
         suppressed: bool = False,
+        onshape_parameters: Sequence[Mapping[str, object]] | None = None,
     ):
         if not isinstance(connector1, RigidJoint) or not isinstance(
             connector2, RigidJoint
@@ -211,6 +213,7 @@ class Mate:
         self.flip_primary = bool(flip_primary)
         self.reorient_secondary = int(reorient_secondary) % 4
         self.suppressed = bool(suppressed)
+        self.onshape_parameters = deepcopy(list(onshape_parameters or ()))
         self.limits = _coerce_limits(limits)
         self.values: dict[MateDOF, float] = {}
         self._validate_options()
@@ -676,6 +679,7 @@ class TangentMate(Mate):
         propagate: bool = True,
         flip_primary: bool = False,
         suppressed: bool = False,
+        onshape_parameters: Sequence[Mapping[str, object]] | None = None,
     ):
         if component1 is component2:
             raise ValueError("A tangent mate must connect different components")
@@ -685,6 +689,7 @@ class TangentMate(Mate):
         self.propagate = bool(propagate)
         self.flip_primary = bool(flip_primary)
         self.suppressed = bool(suppressed)
+        self.onshape_parameters = deepcopy(list(onshape_parameters or ()))
         self.values = {}
         self.limits = {}
 
@@ -862,6 +867,7 @@ class WidthMate(Mate):
         widths: Sequence[RigidJoint],
         *,
         suppressed: bool = False,
+        onshape_parameters: Sequence[Mapping[str, object]] | None = None,
     ):
         tab_connectors = (tabs,) if isinstance(tabs, RigidJoint) else tuple(tabs)
         width_connectors = tuple(widths)
@@ -885,6 +891,7 @@ class WidthMate(Mate):
         self.tabs = tab_connectors
         self.widths = width_connectors
         self.suppressed = bool(suppressed)
+        self.onshape_parameters = deepcopy(list(onshape_parameters or ()))
         self.values = {}
         self.limits = {}
 
@@ -953,6 +960,7 @@ class GroupMate(Mate):
         components: Iterable[Shape],
         *,
         suppressed: bool = False,
+        onshape_parameters: Sequence[Mapping[str, object]] | None = None,
     ):
         component_tuple = tuple(components)
         if len(component_tuple) < 2:
@@ -967,6 +975,7 @@ class GroupMate(Mate):
         self.label = label
         self._components = component_tuple
         self.suppressed = bool(suppressed)
+        self.onshape_parameters = deepcopy(list(onshape_parameters or ()))
         self.values = {}
         self.limits = {}
         reference = _location_matrix(component_tuple[0].location)
@@ -1007,9 +1016,16 @@ class GroupMate(Mate):
 class MateRelation:
     """Base class for persistent relationships between mate DOFs."""
 
-    def __init__(self, label: str, *, suppressed: bool = False):
+    def __init__(
+        self,
+        label: str,
+        *,
+        suppressed: bool = False,
+        onshape_parameters: Sequence[Mapping[str, object]] | None = None,
+    ):
         self.label = label
         self.suppressed = bool(suppressed)
+        self.onshape_parameters = deepcopy(list(onshape_parameters or ()))
         self._phase: float | None = None
 
     @property
@@ -1053,8 +1069,13 @@ class GearRelation(MateRelation):
         dof2: MateDOF | str = MateDOF.RZ,
         reverse: bool = False,
         suppressed: bool = False,
+        onshape_parameters: Sequence[Mapping[str, object]] | None = None,
     ):
-        super().__init__(label, suppressed=suppressed)
+        super().__init__(
+            label,
+            suppressed=suppressed,
+            onshape_parameters=onshape_parameters,
+        )
         self.mate1, self.mate2 = mate1, mate2
         self.dof1, self.dof2 = MateDOF.coerce(dof1), MateDOF.coerce(dof2)
         self._require_dof(mate1, self.dof1)
@@ -1100,8 +1121,13 @@ class RackAndPinionRelation(MateRelation):
         linear_dof: MateDOF | str = MateDOF.TZ,
         reverse: bool = False,
         suppressed: bool = False,
+        onshape_parameters: Sequence[Mapping[str, object]] | None = None,
     ):
-        super().__init__(label, suppressed=suppressed)
+        super().__init__(
+            label,
+            suppressed=suppressed,
+            onshape_parameters=onshape_parameters,
+        )
         self.rotational_mate, self.linear_mate = rotational_mate, linear_mate
         self.rotational_dof = MateDOF.coerce(rotational_dof)
         self.linear_dof = MateDOF.coerce(linear_dof)
@@ -1149,8 +1175,13 @@ class ScrewRelation(MateRelation):
         linear_dof: MateDOF | str = MateDOF.TZ,
         reverse: bool = False,
         suppressed: bool = False,
+        onshape_parameters: Sequence[Mapping[str, object]] | None = None,
     ):
-        super().__init__(label, suppressed=suppressed)
+        super().__init__(
+            label,
+            suppressed=suppressed,
+            onshape_parameters=onshape_parameters,
+        )
         self.mate = mate
         self.rotational_dof = MateDOF.coerce(rotational_dof)
         self.linear_dof = MateDOF.coerce(linear_dof)
@@ -1191,8 +1222,13 @@ class LinearRelation(MateRelation):
         dof2: MateDOF | str = MateDOF.TZ,
         reverse: bool = False,
         suppressed: bool = False,
+        onshape_parameters: Sequence[Mapping[str, object]] | None = None,
     ):
-        super().__init__(label, suppressed=suppressed)
+        super().__init__(
+            label,
+            suppressed=suppressed,
+            onshape_parameters=onshape_parameters,
+        )
         self.mate1, self.mate2 = mate1, mate2
         self.dof1, self.dof2 = MateDOF.coerce(dof1), MateDOF.coerce(dof2)
         self._require_dof(mate1, self.dof1)

--- a/src/build123d/assembly.py
+++ b/src/build123d/assembly.py
@@ -1,0 +1,1746 @@
+"""
+Persistent assembly mates and mate relations.
+
+This module models assembly intent independently from the one-shot positioning
+performed by :mod:`build123d.joints`.  Mates remain attached to an ``Assembly``
+and are solved simultaneously whenever ``Assembly.solve`` is called.
+
+The mate coordinate system follows Onshape's convention: Z is the primary axis
+and X is the secondary axis.  Linear values use build123d model units and
+angular values use degrees.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from math import acos, degrees, inf, pi
+from typing import ClassVar, Iterable, Mapping, Sequence
+
+import numpy as np
+from OCP.BRep import BRep_Tool
+from OCP.GeomAPI import GeomAPI_ProjectPointOnSurf
+from OCP.gp import gp_Quaternion, gp_Trsf, gp_Vec
+from scipy.optimize import least_squares
+from scipy.spatial.transform import Rotation as SciPyRotation
+from typing_extensions import Self
+
+from build123d.build_enums import GeomType
+from build123d.geometry import Location, Vector
+from build123d.joints import RigidJoint
+from build123d.topology import Compound, Edge, Face, Shape, Vertex
+from build123d.topology.shape_core import _make_topods_compound_from_shapes
+
+
+class MateSolveError(RuntimeError):
+    """Raised when an assembly's active mate system cannot be satisfied."""
+
+
+class MateDOF(str, Enum):
+    """Degrees of freedom expressed in a mate connector coordinate system."""
+
+    TX = "tx"
+    TY = "ty"
+    TZ = "tz"
+    RX = "rx"
+    RY = "ry"
+    RZ = "rz"
+    SWING = "swing"
+
+    @classmethod
+    def coerce(cls, value: MateDOF | str) -> MateDOF:
+        """Convert a string or enum member into a ``MateDOF``."""
+
+        return value if isinstance(value, cls) else cls(value.lower())
+
+
+@dataclass(frozen=True)
+class MateLimit:
+    """Optional minimum and maximum values for one mate degree of freedom."""
+
+    minimum: float = -inf
+    maximum: float = inf
+
+    def __post_init__(self):
+        if self.minimum > self.maximum:
+            raise ValueError("Mate limit minimum must not exceed maximum")
+
+    def contains(self, value: float) -> bool:
+        """Return whether ``value`` lies inside this limit."""
+
+        return self.minimum <= value <= self.maximum
+
+
+@dataclass(frozen=True)
+class MateOffset:
+    """Fixed transform applied from the first mate connector to the second."""
+
+    translation: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    rotation: tuple[float, float, float] = (0.0, 0.0, 0.0)
+
+
+class MateConnector(RigidJoint):
+    """An oriented local coordinate system used to define assembly mates.
+
+    ``MateConnector`` intentionally derives from ``RigidJoint`` so existing
+    joint storage, copying, builder transfer, and parent rebinding continue to
+    work.  Existing ``RigidJoint`` instances may also be supplied to mates.
+    """
+
+
+class _PoseMap(dict[object, np.ndarray]):
+    """Identity-keyed component pose lookup accepting Shape instances."""
+
+    def __getitem__(self, key):
+        return super().__getitem__(id(key) if isinstance(key, Shape) else key)
+
+
+def _location_matrix(location: Location) -> np.ndarray:
+    """Convert a build123d ``Location`` to a homogeneous matrix."""
+
+    transform = location.wrapped.Transformation()
+    result = np.eye(4)
+    for row in range(1, 4):
+        for column in range(1, 4):
+            result[row - 1, column - 1] = transform.Value(row, column)
+        result[row - 1, 3] = transform.Value(row, 4)
+    return result
+
+
+def _matrix_location(matrix: np.ndarray) -> Location:
+    """Convert a homogeneous matrix to a build123d ``Location``."""
+
+    transform = gp_Trsf()
+    rotation = SciPyRotation.from_matrix(matrix[:3, :3]).as_quat()
+    transform.SetRotation(
+        gp_Quaternion(
+            float(rotation[0]),
+            float(rotation[1]),
+            float(rotation[2]),
+            float(rotation[3]),
+        )
+    )
+    transform.SetTranslationPart(
+        gp_Vec(
+            float(matrix[0, 3]),
+            float(matrix[1, 3]),
+            float(matrix[2, 3]),
+        )
+    )
+    return Location(transform)
+
+
+def _matrix_pose(matrix: np.ndarray) -> np.ndarray:
+    """Convert a homogeneous matrix to translation plus rotation-vector pose."""
+
+    return np.concatenate(
+        (matrix[:3, 3], SciPyRotation.from_matrix(matrix[:3, :3]).as_rotvec())
+    )
+
+
+def _pose_matrix(pose: Sequence[float] | np.ndarray) -> np.ndarray:
+    """Convert translation plus rotation-vector pose to a homogeneous matrix."""
+
+    result = np.eye(4)
+    result[:3, 3] = pose[:3]
+    result[:3, :3] = SciPyRotation.from_rotvec(pose[3:]).as_matrix()
+    return result
+
+
+def _wrap_radians(value: float) -> float:
+    """Wrap an angle to the interval [-pi, pi)."""
+
+    return (value + pi) % (2 * pi) - pi
+
+
+def _vector_tuple(vector: Vector) -> np.ndarray:
+    """Convert a build123d vector into a NumPy vector."""
+
+    return np.array((vector.X, vector.Y, vector.Z), dtype=float)
+
+
+def _normalized(vector: np.ndarray) -> np.ndarray:
+    norm = np.linalg.norm(vector)
+    if norm <= 1e-15:
+        raise ValueError("Cannot normalize a zero-length vector")
+    return vector / norm
+
+
+def _coerce_limits(
+    limits: Mapping[MateDOF | str, MateLimit | tuple[float, float]] | None,
+) -> dict[MateDOF, MateLimit]:
+    result: dict[MateDOF, MateLimit] = {}
+    for dof, value in (limits or {}).items():
+        key = MateDOF.coerce(dof)
+        result[key] = value if isinstance(value, MateLimit) else MateLimit(*value)
+    return result
+
+
+class Mate:
+    """Base class for persistent connector-based mates."""
+
+    free_dofs: ClassVar[frozenset[MateDOF]] = frozenset()
+    offset_translation_dofs: ClassVar[frozenset[MateDOF]] = frozenset()
+    supports_rotation_offset: ClassVar[bool] = False
+    limit_dofs: ClassVar[frozenset[MateDOF]] = frozenset()
+    supports_values: ClassVar[bool] = True
+
+    def __init__(
+        self,
+        label: str,
+        connector1: RigidJoint,
+        connector2: RigidJoint,
+        *,
+        offset: MateOffset | None = None,
+        limits: Mapping[MateDOF | str, MateLimit | tuple[float, float]] | None = None,
+        flip_primary: bool = False,
+        reorient_secondary: int = 0,
+        suppressed: bool = False,
+    ):
+        if not isinstance(connector1, RigidJoint) or not isinstance(
+            connector2, RigidJoint
+        ):
+            raise TypeError("Connector mates require two RigidJoint-like connectors")
+        if connector1.parent is connector2.parent:
+            raise ValueError("A mate must connect different components")
+
+        self.label = label
+        self.connector1 = connector1
+        self.connector2 = connector2
+        self.offset = offset or MateOffset()
+        self.flip_primary = bool(flip_primary)
+        self.reorient_secondary = int(reorient_secondary) % 4
+        self.suppressed = bool(suppressed)
+        self.limits = _coerce_limits(limits)
+        self.values: dict[MateDOF, float] = {}
+        self._validate_options()
+
+    @property
+    def components(self) -> tuple[Shape, ...]:
+        """The two components constrained by this mate."""
+
+        return self.connector1.parent, self.connector2.parent  # type: ignore[return-value]
+
+    def _validate_options(self):
+        translation = self.offset.translation
+        translation_dofs = (MateDOF.TX, MateDOF.TY, MateDOF.TZ)
+        for dof, value in zip(translation_dofs, translation):
+            if value and dof not in self.offset_translation_dofs:
+                raise ValueError(
+                    f"{type(self).__name__} does not support an offset along {dof.value}"
+                )
+        if any(self.offset.rotation) and not self.supports_rotation_offset:
+            raise ValueError(
+                f"{type(self).__name__} does not support a rotation offset"
+            )
+        invalid_limits = set(self.limits) - self.limit_dofs
+        if invalid_limits:
+            names = ", ".join(sorted(dof.value for dof in invalid_limits))
+            raise ValueError(
+                f"{type(self).__name__} does not support limits for {names}"
+            )
+
+    def set_value(self, dof: MateDOF | str, value: float | None) -> Mate:
+        """Drive or release one of the mate's degrees of freedom."""
+
+        key = MateDOF.coerce(dof)
+        if not self.supports_values or key not in self.free_dofs:
+            raise ValueError(
+                f"{type(self).__name__} does not expose a {key.value} mate value"
+            )
+        if value is None:
+            self.values.pop(key, None)
+            return self
+        if key in self.limits and not self.limits[key].contains(value):
+            raise ValueError(f"{key.value} value {value} is outside {self.limits[key]}")
+        self.values[key] = float(value)
+        return self
+
+    def suppress(self, suppressed: bool = True) -> Mate:
+        """Suppress or unsuppress this mate without deleting it."""
+
+        self.suppressed = suppressed
+        return self
+
+    def _alignment_matrix(self) -> np.ndarray:
+        result = np.eye(4)
+        result[:3, 3] = self.offset.translation
+
+        orientation = SciPyRotation.from_euler(
+            "xyz", self.offset.rotation, degrees=True
+        )
+        if self.flip_primary:
+            orientation = SciPyRotation.from_euler("x", 180, degrees=True) * orientation
+        if self.reorient_secondary:
+            orientation = (
+                SciPyRotation.from_euler(
+                    "z", 90 * self.reorient_secondary, degrees=True
+                )
+                * orientation
+            )
+        result[:3, :3] = orientation.as_matrix()
+        return result
+
+    def _relative_matrix(self, poses: Mapping[object, np.ndarray]) -> np.ndarray:
+        frame1 = poses[self.connector1.parent] @ _location_matrix(
+            self.connector1.relative_location
+        )
+        frame2 = poses[self.connector2.parent] @ _location_matrix(
+            self.connector2.relative_location
+        )
+        return np.linalg.inv(frame1) @ frame2 @ np.linalg.inv(self._alignment_matrix())
+
+    def coordinate(
+        self, poses: Mapping[object, np.ndarray], dof: MateDOF | str
+    ) -> float:
+        """Return the current value of a mate degree of freedom."""
+
+        key = MateDOF.coerce(dof)
+        if key in self.values:
+            return self.values[key]
+        relative = self._relative_matrix(poses)
+        return self.coordinate_from_relative(relative, key)
+
+    def residual(
+        self, poses: Mapping[object, np.ndarray], length_scale: float
+    ) -> np.ndarray:
+        """Return normalized residuals for the locked and driven mate DOFs."""
+
+        relative = self._relative_matrix(poses)
+        residuals: list[float] = []
+
+        translation = relative[:3, 3]
+        for index, dof in enumerate((MateDOF.TX, MateDOF.TY, MateDOF.TZ)):
+            if dof not in self.free_dofs:
+                residuals.append(float(translation[index]) / length_scale)
+            elif dof in self.values:
+                residuals.append(
+                    (float(translation[index]) - self.values[dof]) / length_scale
+                )
+
+        rotation = relative[:3, :3]
+        rotational_free = self.free_dofs.intersection(
+            (MateDOF.RX, MateDOF.RY, MateDOF.RZ)
+        )
+        if not rotational_free:
+            residuals.extend(SciPyRotation.from_matrix(rotation).as_rotvec().tolist())
+        elif rotational_free == {MateDOF.RZ}:
+            residuals.extend((rotation[:, 2] - np.array((0.0, 0.0, 1.0))).tolist())
+            if MateDOF.RZ in self.values:
+                angle = np.arctan2(rotation[1, 0], rotation[0, 0])
+                residuals.append(
+                    _wrap_radians(angle - np.deg2rad(self.values[MateDOF.RZ]))
+                )
+
+        residuals.extend(self._limit_residuals(relative, length_scale))
+        return np.asarray(residuals, dtype=float)
+
+    def _limit_residuals(
+        self, relative: np.ndarray, length_scale: float
+    ) -> list[float]:
+        result: list[float] = []
+        for dof, limit in self.limits.items():
+            value = self.coordinate_from_relative(relative, dof)
+            angular = dof in (
+                MateDOF.RX,
+                MateDOF.RY,
+                MateDOF.RZ,
+                MateDOF.SWING,
+            )
+            scale = 180 / pi if angular else length_scale
+            if value < limit.minimum:
+                result.append((value - limit.minimum) / scale)
+            elif value > limit.maximum:
+                result.append((value - limit.maximum) / scale)
+            else:
+                result.append(0.0)
+        return result
+
+    @staticmethod
+    # A direct branch for each enum member keeps the coordinate definitions clear.
+    # pylint: disable=too-many-return-statements
+    def coordinate_from_relative(relative: np.ndarray, dof: MateDOF) -> float:
+        """Extract a DOF value from an already computed relative transform."""
+
+        if dof == MateDOF.TX:
+            return float(relative[0, 3])
+        if dof == MateDOF.TY:
+            return float(relative[1, 3])
+        if dof == MateDOF.TZ:
+            return float(relative[2, 3])
+        if dof == MateDOF.RZ:
+            return degrees(float(np.arctan2(relative[1, 0], relative[0, 0])))
+        euler = SciPyRotation.from_matrix(relative[:3, :3]).as_euler(
+            "xyz", degrees=True
+        )
+        if dof == MateDOF.RX:
+            return float(euler[0])
+        if dof == MateDOF.RY:
+            return float(euler[1])
+        if dof == MateDOF.SWING:
+            return degrees(acos(float(np.clip(relative[2, 2], -1.0, 1.0))))
+        raise ValueError(f"Unknown mate degree of freedom {dof}")
+
+
+class FastenedMate(Mate):
+    """Remove all six relative degrees of freedom."""
+
+    offset_translation_dofs = frozenset((MateDOF.TX, MateDOF.TY, MateDOF.TZ))
+    supports_rotation_offset = True
+    supports_values = False
+
+
+class RevoluteMate(Mate):
+    """Allow rotation about the mate connector Z axis."""
+
+    free_dofs = frozenset((MateDOF.RZ,))
+    offset_translation_dofs = frozenset((MateDOF.TZ,))
+    supports_rotation_offset = True
+    limit_dofs = free_dofs
+
+
+class SliderMate(Mate):
+    """Allow translation along the mate connector Z axis."""
+
+    free_dofs = frozenset((MateDOF.TZ,))
+    offset_translation_dofs = frozenset((MateDOF.TX, MateDOF.TY))
+    supports_rotation_offset = True
+    limit_dofs = free_dofs
+
+
+class PlanarMate(Mate):
+    """Allow X/Y translation and Z rotation in the connector plane."""
+
+    free_dofs = frozenset((MateDOF.TX, MateDOF.TY, MateDOF.RZ))
+    offset_translation_dofs = frozenset((MateDOF.TZ,))
+    supports_rotation_offset = True
+    limit_dofs = free_dofs
+
+
+class CylindricalMate(Mate):
+    """Allow translation along and rotation about the connector Z axis."""
+
+    free_dofs = frozenset((MateDOF.TZ, MateDOF.RZ))
+    limit_dofs = free_dofs
+
+
+class PinSlotMate(Mate):
+    """Allow translation along X and rotation about connector Z."""
+
+    free_dofs = frozenset((MateDOF.TX, MateDOF.RZ))
+    offset_translation_dofs = frozenset((MateDOF.TZ,))
+    supports_rotation_offset = True
+    limit_dofs = free_dofs
+
+
+class BallMate(Mate):
+    """Allow rotation about all three axes with an optional conical swing limit."""
+
+    free_dofs = frozenset((MateDOF.RX, MateDOF.RY, MateDOF.RZ))
+    limit_dofs = frozenset((MateDOF.SWING,))
+    supports_values = False
+
+
+class ParallelMate(Mate):
+    """Keep connector Z axes parallel while leaving four degrees of freedom."""
+
+    free_dofs = frozenset((MateDOF.TX, MateDOF.TY, MateDOF.TZ, MateDOF.RZ))
+    limit_dofs = free_dofs
+
+
+@dataclass(frozen=True)
+class _EntityReference:
+    """A selected topological entity stored relative to an owning component."""
+
+    component: Shape
+    entity: Shape
+    relative_location: Location = field(init=False)
+    local_entity: Shape = field(init=False)
+
+    def __post_init__(self):
+        if not isinstance(self.entity, (Face, Edge, Vertex)):
+            raise TypeError("Tangent mates accept only faces, edges, or vertices")
+        object.__setattr__(
+            self,
+            "relative_location",
+            _matrix_location(
+                np.linalg.inv(_location_matrix(self.component.location))
+                @ _location_matrix(self.entity.location)
+            ),
+        )
+        object.__setattr__(self, "local_entity", self.entity.located(Location()))
+
+    def located(self, poses: Mapping[object, np.ndarray]) -> Shape:
+        """Return this entity positioned by its component's candidate pose."""
+
+        location = poses[self.component] @ _location_matrix(self.relative_location)
+        return self.local_entity.located(_matrix_location(location))
+
+
+def _shared_tangent_edge(face1: Face, face2: Face) -> bool:
+    """Return whether two faces share a tangent-continuous edge."""
+
+    for edge1 in face1.edges():
+        for edge2 in face2.edges():
+            if not edge1.is_same(edge2):
+                continue
+            point = edge1.position_at(0.5)
+            normal1 = _normalized(_vector_tuple(face1.normal_at(point)))
+            normal2 = _normalized(_vector_tuple(face2.normal_at(point)))
+            return abs(float(np.dot(normal1, normal2))) >= 1 - 1e-7
+    return False
+
+
+def _propagated_faces(component: Shape, selected: Face) -> list[Face]:
+    """Collect tangent-connected analytic faces for Tangent propagation."""
+
+    faces = list(component.faces())
+    selected_index = next(
+        (index for index, face in enumerate(faces) if face.is_same(selected)), None
+    )
+    if selected_index is None:
+        return [selected]
+
+    result = [faces[selected_index]]
+    pending = [faces[selected_index]]
+    remaining = [face for index, face in enumerate(faces) if index != selected_index]
+    while pending:
+        current = pending.pop()
+        attached = [
+            candidate
+            for candidate in remaining
+            if _shared_tangent_edge(current, candidate)
+        ]
+        for candidate in attached:
+            remaining.remove(candidate)
+            result.append(candidate)
+            pending.append(candidate)
+    return result
+
+
+def _edges_tangent_at_shared_vertex(edge1: Edge, edge2: Edge) -> bool:
+    """Return whether two edges meet with tangent-continuous directions."""
+
+    shared = next(
+        (
+            vertex1
+            for vertex1 in edge1.vertices()
+            for vertex2 in edge2.vertices()
+            if vertex1.is_same(vertex2)
+        ),
+        None,
+    )
+    if shared is None:
+        return False
+    point = shared.center()
+    tangent1 = _normalized(_vector_tuple(edge1.tangent_at(point)))
+    tangent2 = _normalized(_vector_tuple(edge2.tangent_at(point)))
+    return abs(float(np.dot(tangent1, tangent2))) >= 1 - 1e-7
+
+
+def _propagated_edges(component: Shape, selected: Edge) -> list[Edge]:
+    """Collect tangent-connected edges for Tangent propagation."""
+
+    edges = list(component.edges())
+    selected_index = next(
+        (index for index, edge in enumerate(edges) if edge.is_same(selected)), None
+    )
+    if selected_index is None:
+        return [selected]
+
+    result = [edges[selected_index]]
+    pending = [edges[selected_index]]
+    remaining = [edge for index, edge in enumerate(edges) if index != selected_index]
+    while pending:
+        current = pending.pop()
+        attached = [
+            candidate
+            for candidate in remaining
+            if _edges_tangent_at_shared_vertex(current, candidate)
+        ]
+        for candidate in attached:
+            remaining.remove(candidate)
+            result.append(candidate)
+            pending.append(candidate)
+    return result
+
+
+def _propagated_entities(component: Shape, selected: Shape) -> list[Shape]:
+    """Apply Onshape-style Tangent propagation for the selected entity kind."""
+
+    if isinstance(selected, Face):
+        return _propagated_faces(component, selected)
+    if isinstance(selected, Edge):
+        return _propagated_edges(component, selected)
+    return [selected]
+
+
+def _entity_parameters(entity: Shape, point: Vector) -> list[float]:
+    """Find normalized surface/curve parameters nearest to ``point``."""
+
+    if isinstance(entity, Face):
+        surface = BRep_Tool.Surface_s(entity.wrapped)
+        projector = GeomAPI_ProjectPointOnSurf(point.to_pnt(), surface)
+        if projector.NbPoints() == 0:
+            return [0.5, 0.5]
+        u_value, v_value = projector.LowerDistanceParameters()
+        u_min, u_max, v_min, v_max = entity._uv_bounds()
+        u = (u_value - u_min) / (u_max - u_min) if u_max != u_min else 0.5
+        v = (v_value - v_min) / (v_max - v_min) if v_max != v_min else 0.5
+        return [float(np.clip(u, 0, 1)), float(np.clip(v, 0, 1))]
+    if isinstance(entity, Edge):
+        return [float(np.clip(entity.param_at_point(point), 0, 1))]
+    return []
+
+
+def _entity_point_direction(
+    entity: Shape, parameters: Sequence[float] | np.ndarray
+) -> tuple[np.ndarray, np.ndarray | None]:
+    """Evaluate an entity contact point and its normal/tangent direction."""
+
+    if isinstance(entity, Face):
+        point = entity.position_at(parameters[0], parameters[1])
+        direction = entity.normal_at(parameters[0], parameters[1])
+    elif isinstance(entity, Edge):
+        point = entity.position_at(parameters[0])
+        direction = entity.tangent_at(parameters[0])
+    elif isinstance(entity, Vertex):
+        point = entity.center()
+        direction = None
+    else:  # pragma: no cover - validated by TangentMate
+        raise TypeError(type(entity))
+    return _vector_tuple(point), (
+        None if direction is None else _normalized(_vector_tuple(direction))
+    )
+
+
+def _parameter_candidates(
+    entity: Shape, nearest_point: Vector | None = None
+) -> list[tuple[float, ...]]:
+    """Generate stable contact-parameter starting candidates for an entity."""
+
+    candidates: list[tuple[float, ...]] = []
+    if nearest_point is not None:
+        candidates.append(tuple(_entity_parameters(entity, nearest_point)))
+    samples = np.linspace(0.0, 1.0, 5)
+    if isinstance(entity, Face):
+        candidates.extend((float(u), float(v)) for u in samples for v in samples)
+    elif isinstance(entity, Edge):
+        candidates.extend((float(value),) for value in np.linspace(0.0, 1.0, 9))
+    else:
+        candidates.append(())
+    return list(dict.fromkeys(candidates))
+
+
+def _tangent_alignment_error(
+    entity1: Shape,
+    direction1: np.ndarray | None,
+    entity2: Shape,
+    direction2: np.ndarray | None,
+    flip_primary: bool,
+) -> float:
+    """Score how closely two sampled entity directions satisfy tangency."""
+
+    if direction1 is None or direction2 is None:
+        return 0.0
+    dot = float(np.clip(np.dot(direction1, direction2), -1, 1))
+    if isinstance(entity1, Face) and isinstance(entity2, Face):
+        target = 1.0 if flip_primary else -1.0
+        return 1.0 - target * dot
+    if isinstance(entity1, Face) or isinstance(entity2, Face):
+        return abs(dot)
+    return 1.0 - abs(dot)
+
+
+class TangentMate(Mate):
+    """Keep two selected analytic entities tangent.
+
+    Faces, edges, and vertices are supported.  Face selections reject generic
+    Bezier/B-spline surfaces, matching Onshape's swept/analytic-face rule.
+    ``propagate=True`` expands a selected face across tangent-continuous
+    neighboring faces.
+    """
+
+    supports_values = False
+
+    # This geometric mate has no pair of connector objects for Mate.__init__.
+    # pylint: disable=super-init-not-called
+    def __init__(
+        self,
+        label: str,
+        component1: Shape,
+        entity1: Shape,
+        component2: Shape,
+        entity2: Shape,
+        *,
+        propagate: bool = True,
+        flip_primary: bool = False,
+        suppressed: bool = False,
+    ):
+        if component1 is component2:
+            raise ValueError("A tangent mate must connect different components")
+        self.label = label
+        self.component1 = component1
+        self.component2 = component2
+        self.propagate = bool(propagate)
+        self.flip_primary = bool(flip_primary)
+        self.suppressed = bool(suppressed)
+        self.values = {}
+        self.limits = {}
+
+        for entity in (entity1, entity2):
+            if isinstance(entity, Face) and entity.geom_type in (
+                GeomType.BEZIER,
+                GeomType.BSPLINE,
+                GeomType.OFFSET,
+                GeomType.OTHER,
+            ):
+                raise ValueError(
+                    "TangentMate supports analytic or swept faces, not generic surfaces"
+                )
+            if not isinstance(entity, (Face, Edge, Vertex)):
+                raise TypeError(
+                    "TangentMate selections must be faces, edges, or vertices"
+                )
+
+        entities1 = (
+            _propagated_entities(component1, entity1) if propagate else [entity1]
+        )
+        entities2 = (
+            _propagated_entities(component2, entity2) if propagate else [entity2]
+        )
+        self.entities1 = tuple(
+            _EntityReference(component1, entity) for entity in entities1
+        )
+        self.entities2 = tuple(
+            _EntityReference(component2, entity) for entity in entities2
+        )
+        self._active_pair: tuple[_EntityReference, _EntityReference] | None = None
+        self._parameter_counts: tuple[int, int] = (0, 0)
+
+    @property
+    def components(self) -> tuple[Shape, Shape]:
+        return self.component1, self.component2
+
+    def suppress(self, suppressed: bool = True) -> TangentMate:
+        self.suppressed = suppressed
+        return self
+
+    def prepare_parameters(
+        self, poses: Mapping[object, np.ndarray]
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Select a propagated entity pair and initialize its contact parameters."""
+
+        located1 = [
+            (reference, reference.located(poses)) for reference in self.entities1
+        ]
+        located2 = [
+            (reference, reference.located(poses)) for reference in self.entities2
+        ]
+        pairs = [
+            (
+                entity1.distance_to(entity2),
+                reference1,
+                entity1,
+                reference2,
+                entity2,
+            )
+            for reference1, entity1 in located1
+            for reference2, entity2 in located2
+        ]
+        best: (
+            tuple[
+                float,
+                _EntityReference,
+                _EntityReference,
+                tuple[float, ...],
+                tuple[float, ...],
+            ]
+            | None
+        ) = None
+        for _, reference1, entity1, reference2, entity2 in pairs:
+            _, point1, point2 = entity1.distance_to_with_closest_points(entity2)
+            scale = max(
+                entity1.bounding_box(optimal=False).diagonal,
+                entity2.bounding_box(optimal=False).diagonal,
+                1.0,
+            )
+            candidates1 = _parameter_candidates(entity1, point1)
+            candidates2 = _parameter_candidates(entity2, point2)
+            evaluated1 = [
+                (parameters, *_entity_point_direction(entity1, parameters))
+                for parameters in candidates1
+            ]
+            evaluated2 = [
+                (parameters, *_entity_point_direction(entity2, parameters))
+                for parameters in candidates2
+            ]
+            for parameters1, sample1, direction1 in evaluated1:
+                for parameters2, sample2, direction2 in evaluated2:
+                    score = np.linalg.norm(sample2 - sample1) / scale + 4 * (
+                        _tangent_alignment_error(
+                            entity1,
+                            direction1,
+                            entity2,
+                            direction2,
+                            self.flip_primary,
+                        )
+                    )
+                    candidate = (
+                        float(score),
+                        reference1,
+                        reference2,
+                        parameters1,
+                        parameters2,
+                    )
+                    if best is None or candidate[0] < best[0]:
+                        best = candidate
+        assert best is not None
+        _, reference1, reference2, parameters1, parameters2 = best
+        self._active_pair = (reference1, reference2)
+        self._parameter_counts = (len(parameters1), len(parameters2))
+        values = np.asarray((*parameters1, *parameters2), dtype=float)
+        return values, np.zeros(len(values)), np.ones(len(values))
+
+    def residual(
+        self,
+        poses: Mapping[object, np.ndarray],
+        length_scale: float,
+        parameters: Sequence[float] | np.ndarray | None = None,
+    ) -> np.ndarray:
+        active_parameters: Sequence[float] | np.ndarray
+        if self._active_pair is None or parameters is None:
+            active_parameters, _, _ = self.prepare_parameters(poses)
+        else:
+            active_parameters = parameters
+        reference1, reference2 = self._active_pair  # type: ignore[misc]
+        count1, count2 = self._parameter_counts
+        entity1 = reference1.located(poses)
+        entity2 = reference2.located(poses)
+        point1, direction1 = _entity_point_direction(
+            entity1, active_parameters[:count1]
+        )
+        point2, direction2 = _entity_point_direction(
+            entity2, active_parameters[count1 : count1 + count2]
+        )
+        residuals = ((point2 - point1) / length_scale).tolist()
+
+        if isinstance(entity1, Face) and isinstance(entity2, Face):
+            assert direction1 is not None and direction2 is not None
+            target = 1.0 if self.flip_primary else -1.0
+            residuals.extend(np.cross(direction1, direction2).tolist())
+            residuals.append(float(np.dot(direction1, direction2) - target))
+        elif isinstance(entity1, Face) and isinstance(entity2, Edge):
+            assert direction1 is not None and direction2 is not None
+            residuals.append(float(np.dot(direction1, direction2)))
+        elif isinstance(entity1, Edge) and isinstance(entity2, Face):
+            assert direction1 is not None and direction2 is not None
+            residuals.append(float(np.dot(direction1, direction2)))
+        elif isinstance(entity1, Edge) and isinstance(entity2, Edge):
+            assert direction1 is not None and direction2 is not None
+            residuals.extend(np.cross(direction1, direction2).tolist())
+
+        return np.asarray(residuals, dtype=float)
+
+
+class WidthMate(Mate):
+    """Center one or two tab connectors between two width connectors.
+
+    With one tab connector, the tab may translate in and rotate normally to
+    the slot center plane.  With two tab connectors, their locations and XY
+    planes remain mirror-symmetric across the slot center plane.
+    """
+
+    supports_values = False
+
+    # Width has three or four connectors, so Mate.__init__ does not apply.
+    # pylint: disable=super-init-not-called
+    def __init__(
+        self,
+        label: str,
+        tabs: RigidJoint | Sequence[RigidJoint],
+        widths: Sequence[RigidJoint],
+        *,
+        suppressed: bool = False,
+    ):
+        tab_connectors = (tabs,) if isinstance(tabs, RigidJoint) else tuple(tabs)
+        width_connectors = tuple(widths)
+        if len(tab_connectors) not in (1, 2):
+            raise ValueError("WidthMate requires one or two tab connectors")
+        if len(width_connectors) != 2:
+            raise ValueError("WidthMate requires exactly two width connectors")
+        if not all(
+            isinstance(connector, RigidJoint)
+            for connector in (*tab_connectors, *width_connectors)
+        ):
+            raise TypeError("WidthMate requires RigidJoint-like connectors")
+        tab_components = {id(connector.parent) for connector in tab_connectors}
+        width_components = {id(connector.parent) for connector in width_connectors}
+        if tab_components.intersection(width_components):
+            raise ValueError(
+                "Tab and width mate connectors cannot belong to the same component"
+            )
+
+        self.label = label
+        self.tabs = tab_connectors
+        self.widths = width_connectors
+        self.suppressed = bool(suppressed)
+        self.values = {}
+        self.limits = {}
+
+    @property
+    def components(self) -> tuple[Shape, ...]:
+        result: list[Shape] = []
+        for connector in (*self.tabs, *self.widths):
+            if not any(connector.parent is component for component in result):
+                result.append(connector.parent)  # type: ignore[arg-type]
+        return tuple(result)
+
+    def suppress(self, suppressed: bool = True) -> WidthMate:
+        self.suppressed = suppressed
+        return self
+
+    @staticmethod
+    def _frame(connector: RigidJoint, poses: Mapping[object, np.ndarray]) -> np.ndarray:
+        return poses[connector.parent] @ _location_matrix(connector.relative_location)
+
+    def residual(
+        self, poses: Mapping[object, np.ndarray], length_scale: float
+    ) -> np.ndarray:
+        width1, width2 = (self._frame(connector, poses) for connector in self.widths)
+        center = (width1[:3, 3] + width2[:3, 3]) / 2
+        normal = _normalized(width2[:3, 3] - width1[:3, 3])
+
+        if len(self.tabs) == 1:
+            tab = self._frame(self.tabs[0], poses)
+            tab_normal = tab[:3, 2]
+            return np.asarray(
+                [
+                    float(np.dot(tab[:3, 3] - center, normal)) / length_scale,
+                    *(tab_normal - normal).tolist(),
+                ]
+            )
+
+        tab1, tab2 = (self._frame(connector, poses) for connector in self.tabs)
+
+        def reflect_point(point: np.ndarray) -> np.ndarray:
+            return point - 2 * np.dot(point - center, normal) * normal
+
+        def reflect_vector(vector: np.ndarray) -> np.ndarray:
+            return vector - 2 * np.dot(vector, normal) * normal
+
+        position_error = (tab2[:3, 3] - reflect_point(tab1[:3, 3])) / length_scale
+        normal_error = tab2[:3, 2] - reflect_vector(tab1[:3, 2])
+        return np.concatenate((position_error, normal_error))
+
+
+class GroupMate(Mate):
+    """Keep two or more components fixed relative to their initial origins.
+
+    Like Onshape's Group feature, this ignores selected geometry and records
+    only the relative component-origin transforms present at construction.
+    The resulting group retains six rigid-body degrees of freedom until one
+    member is otherwise constrained or fixed.
+    """
+
+    supports_values = False
+
+    # Group records component origins rather than connector pairs.
+    # pylint: disable=super-init-not-called
+    def __init__(
+        self,
+        label: str,
+        components: Iterable[Shape],
+        *,
+        suppressed: bool = False,
+    ):
+        component_tuple = tuple(components)
+        if len(component_tuple) < 2:
+            raise ValueError("GroupMate requires at least two components")
+        if not all(isinstance(component, Shape) for component in component_tuple):
+            raise TypeError("GroupMate components must be build123d Shapes")
+        if len({id(component) for component in component_tuple}) != len(
+            component_tuple
+        ):
+            raise ValueError("GroupMate components must be unique")
+
+        self.label = label
+        self._components = component_tuple
+        self.suppressed = bool(suppressed)
+        self.values = {}
+        self.limits = {}
+        reference = _location_matrix(component_tuple[0].location)
+        self._relative_poses = tuple(
+            np.linalg.inv(reference) @ _location_matrix(component.location)
+            for component in component_tuple[1:]
+        )
+
+    @property
+    def components(self) -> tuple[Shape, ...]:
+        """Components whose origin transforms are held relative."""
+
+        return self._components
+
+    def suppress(self, suppressed: bool = True) -> GroupMate:
+        """Suppress or unsuppress this group without deleting it."""
+
+        self.suppressed = suppressed
+        return self
+
+    def residual(
+        self, poses: Mapping[object, np.ndarray], length_scale: float
+    ) -> np.ndarray:
+        """Return errors from the captured component-origin transforms."""
+
+        reference = poses[self._components[0]]
+        residuals: list[float] = []
+        for component, expected in zip(self._components[1:], self._relative_poses):
+            relative = np.linalg.inv(reference) @ poses[component]
+            error = relative @ np.linalg.inv(expected)
+            residuals.extend((error[:3, 3] / length_scale).tolist())
+            residuals.extend(
+                SciPyRotation.from_matrix(error[:3, :3]).as_rotvec().tolist()
+            )
+        return np.asarray(residuals, dtype=float)
+
+
+class MateRelation:
+    """Base class for persistent relationships between mate DOFs."""
+
+    def __init__(self, label: str, *, suppressed: bool = False):
+        self.label = label
+        self.suppressed = bool(suppressed)
+        self._phase: float | None = None
+
+    @property
+    def mates(self) -> tuple[Mate, ...]:
+        """Mates referenced by this relation."""
+
+        raise NotImplementedError
+
+    def suppress(self, suppressed: bool = True) -> MateRelation:
+        """Suppress or unsuppress this relation without deleting it."""
+
+        self.suppressed = suppressed
+        return self
+
+    def residual(
+        self, poses: Mapping[object, np.ndarray], length_scale: float
+    ) -> np.ndarray:
+        """Return the normalized coupling error for candidate component poses."""
+
+        raise NotImplementedError
+
+    @staticmethod
+    def _require_dof(mate: Mate, dof: MateDOF):
+        if dof not in mate.free_dofs:
+            raise ValueError(
+                f"{type(mate).__name__} does not provide {dof.value} for a relation"
+            )
+
+
+class GearRelation(MateRelation):
+    """Relate two rotational mate DOFs by a constant ratio."""
+
+    def __init__(
+        self,
+        label: str,
+        mate1: Mate,
+        mate2: Mate,
+        ratio: float = 1.0,
+        *,
+        dof1: MateDOF | str = MateDOF.RZ,
+        dof2: MateDOF | str = MateDOF.RZ,
+        reverse: bool = False,
+        suppressed: bool = False,
+    ):
+        super().__init__(label, suppressed=suppressed)
+        self.mate1, self.mate2 = mate1, mate2
+        self.dof1, self.dof2 = MateDOF.coerce(dof1), MateDOF.coerce(dof2)
+        self._require_dof(mate1, self.dof1)
+        self._require_dof(mate2, self.dof2)
+        if self.dof1 not in (MateDOF.RX, MateDOF.RY, MateDOF.RZ) or self.dof2 not in (
+            MateDOF.RX,
+            MateDOF.RY,
+            MateDOF.RZ,
+        ):
+            raise ValueError("GearRelation requires rotational mate DOFs")
+        if ratio <= 0:
+            raise ValueError("Gear ratio must be positive")
+        self.ratio = float(ratio)
+        self.reverse = bool(reverse)
+
+    @property
+    def mates(self) -> tuple[Mate, Mate]:
+        return self.mate1, self.mate2
+
+    def residual(
+        self, poses: Mapping[object, np.ndarray], length_scale: float
+    ) -> np.ndarray:
+        value1 = self.mate1.coordinate(poses, self.dof1)
+        value2 = self.mate2.coordinate(poses, self.dof2)
+        sign = 1.0 if self.reverse else -1.0
+        expression = value2 - sign * self.ratio * value1
+        if self._phase is None:
+            self._phase = expression
+        return np.asarray([_wrap_radians((expression - self._phase) * pi / 180)])
+
+
+class RackAndPinionRelation(MateRelation):
+    """Relate a rotational mate DOF to linear travel per revolution."""
+
+    def __init__(
+        self,
+        label: str,
+        rotational_mate: Mate,
+        linear_mate: Mate,
+        travel_per_revolution: float,
+        *,
+        rotational_dof: MateDOF | str = MateDOF.RZ,
+        linear_dof: MateDOF | str = MateDOF.TZ,
+        reverse: bool = False,
+        suppressed: bool = False,
+    ):
+        super().__init__(label, suppressed=suppressed)
+        self.rotational_mate, self.linear_mate = rotational_mate, linear_mate
+        self.rotational_dof = MateDOF.coerce(rotational_dof)
+        self.linear_dof = MateDOF.coerce(linear_dof)
+        self._require_dof(rotational_mate, self.rotational_dof)
+        self._require_dof(linear_mate, self.linear_dof)
+        if self.rotational_dof not in (
+            MateDOF.RX,
+            MateDOF.RY,
+            MateDOF.RZ,
+        ):
+            raise ValueError("RackAndPinionRelation requires a rotational DOF")
+        if self.linear_dof not in (MateDOF.TX, MateDOF.TY, MateDOF.TZ):
+            raise ValueError("RackAndPinionRelation requires a linear DOF")
+        if travel_per_revolution <= 0:
+            raise ValueError("Travel per revolution must be positive")
+        self.travel_per_revolution = float(travel_per_revolution)
+        self.reverse = bool(reverse)
+
+    @property
+    def mates(self) -> tuple[Mate, Mate]:
+        return self.rotational_mate, self.linear_mate
+
+    def residual(
+        self, poses: Mapping[object, np.ndarray], length_scale: float
+    ) -> np.ndarray:
+        angle = self.rotational_mate.coordinate(poses, self.rotational_dof)
+        travel = self.linear_mate.coordinate(poses, self.linear_dof)
+        sign = -1.0 if self.reverse else 1.0
+        expression = travel - sign * self.travel_per_revolution * angle / 360
+        if self._phase is None:
+            self._phase = expression
+        return np.asarray([(expression - self._phase) / length_scale])
+
+
+class ScrewRelation(MateRelation):
+    """Couple rotation and translation in one cylindrical-style mate."""
+
+    def __init__(
+        self,
+        label: str,
+        mate: Mate,
+        travel_per_revolution: float,
+        *,
+        rotational_dof: MateDOF | str = MateDOF.RZ,
+        linear_dof: MateDOF | str = MateDOF.TZ,
+        reverse: bool = False,
+        suppressed: bool = False,
+    ):
+        super().__init__(label, suppressed=suppressed)
+        self.mate = mate
+        self.rotational_dof = MateDOF.coerce(rotational_dof)
+        self.linear_dof = MateDOF.coerce(linear_dof)
+        self._require_dof(mate, self.rotational_dof)
+        self._require_dof(mate, self.linear_dof)
+        if travel_per_revolution <= 0:
+            raise ValueError("Travel per revolution must be positive")
+        self.travel_per_revolution = float(travel_per_revolution)
+        self.reverse = bool(reverse)
+
+    @property
+    def mates(self) -> tuple[Mate]:
+        return (self.mate,)
+
+    def residual(
+        self, poses: Mapping[object, np.ndarray], length_scale: float
+    ) -> np.ndarray:
+        angle = self.mate.coordinate(poses, self.rotational_dof)
+        travel = self.mate.coordinate(poses, self.linear_dof)
+        sign = -1.0 if self.reverse else 1.0
+        expression = travel - sign * self.travel_per_revolution * angle / 360
+        if self._phase is None:
+            self._phase = expression
+        return np.asarray([(expression - self._phase) / length_scale])
+
+
+class LinearRelation(MateRelation):
+    """Relate two linear mate DOFs by a constant ratio."""
+
+    def __init__(
+        self,
+        label: str,
+        mate1: Mate,
+        mate2: Mate,
+        ratio: float = 1.0,
+        *,
+        dof1: MateDOF | str = MateDOF.TZ,
+        dof2: MateDOF | str = MateDOF.TZ,
+        reverse: bool = False,
+        suppressed: bool = False,
+    ):
+        super().__init__(label, suppressed=suppressed)
+        self.mate1, self.mate2 = mate1, mate2
+        self.dof1, self.dof2 = MateDOF.coerce(dof1), MateDOF.coerce(dof2)
+        self._require_dof(mate1, self.dof1)
+        self._require_dof(mate2, self.dof2)
+        if self.dof1 not in (MateDOF.TX, MateDOF.TY, MateDOF.TZ) or self.dof2 not in (
+            MateDOF.TX,
+            MateDOF.TY,
+            MateDOF.TZ,
+        ):
+            raise ValueError("LinearRelation requires linear mate DOFs")
+        if ratio <= 0:
+            raise ValueError("Linear ratio must be positive")
+        self.ratio = float(ratio)
+        self.reverse = bool(reverse)
+
+    @property
+    def mates(self) -> tuple[Mate, Mate]:
+        return self.mate1, self.mate2
+
+    def residual(
+        self, poses: Mapping[object, np.ndarray], length_scale: float
+    ) -> np.ndarray:
+        value1 = self.mate1.coordinate(poses, self.dof1)
+        value2 = self.mate2.coordinate(poses, self.dof2)
+        sign = 1.0 if self.reverse else -1.0
+        expression = value2 - sign * self.ratio * value1
+        if self._phase is None:
+            self._phase = expression
+        return np.asarray([(expression - self._phase) / length_scale])
+
+
+@dataclass(frozen=True)
+class MateSolveResult:
+    """Summary of an assembly mate solve."""
+
+    success: bool
+    cost: float
+    max_residual: float
+    iterations: int
+    degrees_of_freedom: int
+    message: str
+
+
+class Assembly(Compound):
+    """A compound whose component positions are governed by persistent mates."""
+
+    def __init__(
+        self,
+        components: Iterable[Shape] | None = None,
+        *,
+        label: str = "",
+    ):
+        component_list = list(components or ())
+        labels = [component.label for component in component_list if component.label]
+        if len(labels) != len(set(labels)):
+            raise ValueError("Assembly component labels must be unique")
+        super().__init__(
+            obj=component_list,
+            label=label,
+            children=component_list,
+        )
+        self.mates: list[Mate] = []
+        self.relations: list[MateRelation] = []
+        self._fixed_component_ids: set[int] = set()
+        self.last_solve: MateSolveResult | None = None
+
+    def __deepcopy__(self, memo) -> Self:
+        """Copy geometry, components, mate connections, relations, and grounding."""
+
+        original_components = list(self.children)
+        result = super().__deepcopy__(memo)
+        copied_components = list(result.children)
+        copied_by_original_id = {
+            id(original): copied
+            for original, copied in zip(original_components, copied_components)
+        }
+        result._fixed_component_ids = {
+            id(copied_by_original_id[original_id])
+            for original_id in self._fixed_component_ids
+            if original_id in copied_by_original_id
+        }
+        return result
+
+    @property
+    def components(self) -> tuple[Shape, ...]:
+        """Direct component instances in this assembly."""
+
+        return tuple(self.children)
+
+    def add(
+        self,
+        component: Shape,
+        *,
+        name: str | None = None,
+        fixed: bool = False,
+    ) -> Shape:
+        """Add a component instance to the assembly."""
+
+        if not isinstance(component, Shape):
+            raise TypeError("Assembly components must be build123d Shapes")
+        if any(component is child for child in self.children):
+            raise ValueError("Component is already in this assembly")
+        if name is not None:
+            component.label = name
+        if component.label and any(
+            child.label == component.label for child in self.children
+        ):
+            raise ValueError(f"Duplicate assembly component label {component.label!r}")
+        component.parent = self
+        if fixed:
+            self.ground(component)
+        return component
+
+    def component(self, name: str) -> Shape:
+        """Find a direct component by label."""
+
+        matches = [component for component in self.children if component.label == name]
+        if not matches:
+            raise KeyError(name)
+        if len(matches) > 1:  # pragma: no cover - protected by add/constructor
+            raise KeyError(f"Component label {name!r} is ambiguous")
+        return matches[0]
+
+    def ground(self, component: Shape, fixed: bool = True) -> Assembly:
+        """Ground or unground a component."""
+
+        self._require_component(component)
+        if fixed:
+            self._fixed_component_ids.add(id(component))
+        else:
+            self._fixed_component_ids.discard(id(component))
+        return self
+
+    def is_fixed(self, component: Shape) -> bool:
+        """Return whether a component is explicitly grounded."""
+
+        return id(component) in self._fixed_component_ids
+
+    def add_mate(self, mate: Mate, *, solve: bool = True) -> Mate:
+        """Persist a mate and optionally solve the assembly immediately."""
+
+        if not isinstance(mate, Mate):
+            raise TypeError("add_mate expects a Mate")
+        if any(existing.label == mate.label for existing in self.mates):
+            raise ValueError(f"Duplicate mate label {mate.label!r}")
+        for component in mate.components:
+            self._require_component(component)
+        self.mates.append(mate)
+        if solve:
+            try:
+                self.solve()
+            except Exception:
+                self.mates.remove(mate)
+                raise
+        return mate
+
+    def add_relation(
+        self, relation: MateRelation, *, solve: bool = True
+    ) -> MateRelation:
+        """Persist a mate relation and optionally solve immediately."""
+
+        if not isinstance(relation, MateRelation):
+            raise TypeError("add_relation expects a MateRelation")
+        if any(existing.label == relation.label for existing in self.relations):
+            raise ValueError(f"Duplicate relation label {relation.label!r}")
+        for mate in relation.mates:
+            if mate not in self.mates:
+                raise ValueError("Mate relations may reference only assembly mates")
+        self.relations.append(relation)
+        if solve:
+            try:
+                self.solve()
+            except Exception:
+                self.relations.remove(relation)
+                raise
+        return relation
+
+    def mate(self, label: str) -> Mate:
+        """Find a mate by label."""
+
+        return next((mate for mate in self.mates if mate.label == label), None) or (
+            _raise_key_error(label)
+        )
+
+    def relation(self, label: str) -> MateRelation:
+        """Find a mate relation by label."""
+
+        return next(
+            (relation for relation in self.relations if relation.label == label), None
+        ) or _raise_key_error(label)
+
+    def fastened(
+        self,
+        label: str,
+        connector1: RigidJoint,
+        connector2: RigidJoint,
+        **kwargs,
+    ) -> FastenedMate:
+        """Add a persistent Fastened mate."""
+
+        return self.add_mate(  # type: ignore[return-value]
+            FastenedMate(label, connector1, connector2, **_mate_kwargs(kwargs)),
+            solve=kwargs.pop("solve", True),
+        )
+
+    def revolute(
+        self,
+        label: str,
+        connector1: RigidJoint,
+        connector2: RigidJoint,
+        **kwargs,
+    ) -> RevoluteMate:
+        """Add a persistent Revolute mate."""
+
+        return self.add_mate(  # type: ignore[return-value]
+            RevoluteMate(label, connector1, connector2, **_mate_kwargs(kwargs)),
+            solve=kwargs.pop("solve", True),
+        )
+
+    def slider(
+        self,
+        label: str,
+        connector1: RigidJoint,
+        connector2: RigidJoint,
+        **kwargs,
+    ) -> SliderMate:
+        """Add a persistent Slider mate."""
+
+        return self.add_mate(  # type: ignore[return-value]
+            SliderMate(label, connector1, connector2, **_mate_kwargs(kwargs)),
+            solve=kwargs.pop("solve", True),
+        )
+
+    def planar(
+        self,
+        label: str,
+        connector1: RigidJoint,
+        connector2: RigidJoint,
+        **kwargs,
+    ) -> PlanarMate:
+        """Add a persistent Planar mate."""
+
+        return self.add_mate(  # type: ignore[return-value]
+            PlanarMate(label, connector1, connector2, **_mate_kwargs(kwargs)),
+            solve=kwargs.pop("solve", True),
+        )
+
+    def cylindrical(
+        self,
+        label: str,
+        connector1: RigidJoint,
+        connector2: RigidJoint,
+        **kwargs,
+    ) -> CylindricalMate:
+        """Add a persistent Cylindrical mate."""
+
+        return self.add_mate(  # type: ignore[return-value]
+            CylindricalMate(label, connector1, connector2, **_mate_kwargs(kwargs)),
+            solve=kwargs.pop("solve", True),
+        )
+
+    def pin_slot(
+        self,
+        label: str,
+        connector1: RigidJoint,
+        connector2: RigidJoint,
+        **kwargs,
+    ) -> PinSlotMate:
+        """Add a persistent Pin Slot mate."""
+
+        return self.add_mate(  # type: ignore[return-value]
+            PinSlotMate(label, connector1, connector2, **_mate_kwargs(kwargs)),
+            solve=kwargs.pop("solve", True),
+        )
+
+    def ball(
+        self,
+        label: str,
+        connector1: RigidJoint,
+        connector2: RigidJoint,
+        **kwargs,
+    ) -> BallMate:
+        """Add a persistent Ball mate."""
+
+        return self.add_mate(  # type: ignore[return-value]
+            BallMate(label, connector1, connector2, **_mate_kwargs(kwargs)),
+            solve=kwargs.pop("solve", True),
+        )
+
+    def parallel(
+        self,
+        label: str,
+        connector1: RigidJoint,
+        connector2: RigidJoint,
+        **kwargs,
+    ) -> ParallelMate:
+        """Add a persistent Parallel mate."""
+
+        return self.add_mate(  # type: ignore[return-value]
+            ParallelMate(label, connector1, connector2, **_mate_kwargs(kwargs)),
+            solve=kwargs.pop("solve", True),
+        )
+
+    def tangent(self, label: str, *args, **kwargs) -> TangentMate:
+        """Add a persistent Tangent mate."""
+
+        solve = kwargs.pop("solve", True)
+        return self.add_mate(  # type: ignore[return-value]
+            TangentMate(label, *args, **kwargs), solve=solve
+        )
+
+    def width(self, label: str, *args, **kwargs) -> WidthMate:
+        """Add a persistent Width mate."""
+
+        solve = kwargs.pop("solve", True)
+        return self.add_mate(  # type: ignore[return-value]
+            WidthMate(label, *args, **kwargs), solve=solve
+        )
+
+    def group(
+        self,
+        label: str,
+        components: Iterable[Shape],
+        **kwargs,
+    ) -> GroupMate:
+        """Add a persistent rigid group using the components' current origins."""
+
+        solve = kwargs.pop("solve", True)
+        return self.add_mate(  # type: ignore[return-value]
+            GroupMate(label, components, **kwargs), solve=solve
+        )
+
+    def solve(
+        self,
+        *,
+        tolerance: float = 1e-7,
+        max_iterations: int = 2000,
+        strict: bool = True,
+    ) -> MateSolveResult:
+        """Solve all active mates and relations simultaneously.
+
+        Explicitly fixed components remain at their current locations.  When
+        none are fixed, the first component is implicitly grounded to remove
+        the assembly's six global rigid-body degrees of freedom.
+        """
+
+        components = list(self.children)
+        if not components:
+            result = MateSolveResult(True, 0.0, 0.0, 0, 0, "empty assembly")
+            self.last_solve = result
+            return result
+
+        active_mates = [mate for mate in self.mates if not mate.suppressed]
+        active_relations = [
+            relation
+            for relation in self.relations
+            if not relation.suppressed
+            and not any(mate.suppressed for mate in relation.mates)
+        ]
+
+        initial_matrices = _PoseMap(
+            {
+                id(component): _location_matrix(component.location)
+                for component in components
+            }
+        )
+        fixed_ids = set(self._fixed_component_ids)
+        if not fixed_ids:
+            fixed_ids.add(id(components[0]))
+        variable_components = [
+            component for component in components if id(component) not in fixed_ids
+        ]
+        component_poses = [
+            _matrix_pose(initial_matrices[component])
+            for component in variable_components
+        ]
+        component_vector = (
+            np.concatenate(component_poses) if component_poses else np.empty(0)
+        )
+        pose_variable_count = len(component_vector)
+        tangent_parameter_slices: dict[int, slice] = {}
+        parameter_values: list[np.ndarray] = []
+        parameter_lower: list[np.ndarray] = []
+        parameter_upper: list[np.ndarray] = []
+        parameter_offset = pose_variable_count
+        for mate in active_mates:
+            if isinstance(mate, TangentMate):
+                values, lower, upper = mate.prepare_parameters(initial_matrices)
+                tangent_parameter_slices[id(mate)] = slice(
+                    parameter_offset, parameter_offset + len(values)
+                )
+                parameter_offset += len(values)
+                parameter_values.append(values)
+                parameter_lower.append(lower)
+                parameter_upper.append(upper)
+        contact_parameter_count = parameter_offset - pose_variable_count
+        initial_vector = np.concatenate((component_vector, *parameter_values))
+        lower_bounds = np.concatenate(
+            (np.full(pose_variable_count, -np.inf), *parameter_lower)
+        )
+        upper_bounds = np.concatenate(
+            (np.full(pose_variable_count, np.inf), *parameter_upper)
+        )
+
+        diagonals = [
+            component.bounding_box(optimal=False).diagonal
+            for component in components
+            if component.bounding_box(optimal=False).diagonal > 1e-12
+        ]
+        length_scale = float(np.median(diagonals)) if diagonals else 1.0
+
+        def unpack(vector: np.ndarray) -> _PoseMap:
+            poses = _PoseMap(initial_matrices)
+            for index, component in enumerate(variable_components):
+                poses[id(component)] = _pose_matrix(vector[index * 6 : index * 6 + 6])
+            return poses
+
+        def primary_residual(vector: np.ndarray) -> np.ndarray:
+            poses = unpack(vector)
+            residuals = [
+                (
+                    mate.residual(
+                        poses,
+                        length_scale,
+                        vector[tangent_parameter_slices[id(mate)]],
+                    )
+                    if isinstance(mate, TangentMate)
+                    else mate.residual(poses, length_scale)
+                )
+                for mate in active_mates
+            ]
+            residuals.extend(
+                relation.residual(poses, length_scale) for relation in active_relations
+            )
+            return np.concatenate(residuals) if residuals else np.empty(0, dtype=float)
+
+        def objective(vector: np.ndarray) -> np.ndarray:
+            primary = primary_residual(vector)
+            # Select the solution nearest the current configuration when the
+            # system is underconstrained, without materially weakening mates.
+            regularization = 1e-6 * (vector - initial_vector)
+            return np.concatenate((primary, regularization))
+
+        if initial_vector.size:
+            optimization = least_squares(
+                objective,
+                initial_vector,
+                method="trf",
+                bounds=(lower_bounds, upper_bounds),
+                xtol=1e-12,
+                ftol=1e-12,
+                gtol=1e-12,
+                max_nfev=max_iterations,
+            )
+            solved_vector = optimization.x
+            iterations = optimization.nfev
+            message = optimization.message
+            jacobian = optimization.jac
+        else:
+            solved_vector = initial_vector
+            iterations = 0
+            message = "all components fixed"
+            jacobian = np.empty((0, 0))
+
+        final_residual = primary_residual(solved_vector)
+        max_residual = (
+            float(np.max(np.abs(final_residual))) if final_residual.size else 0.0
+        )
+        cost = float(np.dot(final_residual, final_residual) / 2)
+        primary_jacobian = (
+            jacobian[: final_residual.size, :] if jacobian.size else jacobian
+        )
+        rank = (
+            int(np.linalg.matrix_rank(primary_jacobian, tol=1e-6))
+            if primary_jacobian.size
+            else 0
+        )
+        physical_rank = max(0, rank - contact_parameter_count)
+        degrees_of_freedom = max(0, pose_variable_count - physical_rank)
+        success = max_residual <= tolerance
+        result = MateSolveResult(
+            success,
+            cost,
+            max_residual,
+            iterations,
+            degrees_of_freedom,
+            str(message),
+        )
+        self.last_solve = result
+        if strict and not success:
+            raise MateSolveError(
+                "Assembly mates are inconsistent or failed to converge "
+                f"(max normalized residual {max_residual:.3g})"
+            )
+
+        solved_poses = unpack(solved_vector)
+        for component in variable_components:
+            component.locate(_matrix_location(solved_poses[component]))
+        self._rebuild_compounds()
+        return result
+
+    def _require_component(self, component: Shape):
+        if not any(component is child for child in self.children):
+            raise ValueError("Mate component is not a direct member of this assembly")
+
+    def _rebuild_compounds(self):
+        node: Compound | None = self
+        while isinstance(node, Compound):
+            # pylint: disable=attribute-defined-outside-init
+            node.wrapped = _make_topods_compound_from_shapes(
+                [child.wrapped for child in node.children]
+            )
+            node = node.parent
+
+
+def _mate_kwargs(kwargs: dict) -> dict:
+    """Remove Assembly-only convenience options from mate constructor kwargs."""
+
+    return {key: value for key, value in kwargs.items() if key != "solve"}
+
+
+def _raise_key_error(label: str):
+    raise KeyError(label)
+
+
+__all__ = [
+    "Assembly",
+    "BallMate",
+    "CylindricalMate",
+    "FastenedMate",
+    "GearRelation",
+    "GroupMate",
+    "LinearRelation",
+    "Mate",
+    "MateConnector",
+    "MateDOF",
+    "MateLimit",
+    "MateOffset",
+    "MateRelation",
+    "MateSolveError",
+    "MateSolveResult",
+    "ParallelMate",
+    "PinSlotMate",
+    "PlanarMate",
+    "RackAndPinionRelation",
+    "RevoluteMate",
+    "ScrewRelation",
+    "SliderMate",
+    "TangentMate",
+    "WidthMate",
+]

--- a/src/build123d/exporters3d.py
+++ b/src/build123d/exporters3d.py
@@ -71,6 +71,7 @@ from threejs_materials import PbrProperties, inject_materials
 from build123d.build_constants import UNITS_PER_METER
 from build123d.build_enums import PrecisionMode, Unit
 from build123d.geometry import Location
+from build123d.step_kinematics import inject_step_kinematics
 from build123d.topology import Compound, Curve, Part, Shape, Sketch
 
 
@@ -366,6 +367,7 @@ def export_step(
     precision_mode: PrecisionMode = PrecisionMode.AVERAGE,
     *,  # Too many positional arguments
     timestamp: str | datetime | None = None,
+    write_kinematics: bool = True,
 ) -> bool:
     """export_step
 
@@ -381,6 +383,9 @@ def export_step(
             Defaults to True.
         precision_mode (PrecisionMode, optional): geometric data precision.
             Defaults to PrecisionMode.AVERAGE.
+        write_kinematics (bool, optional): for an Assembly with mates, select
+            AP242 and write standard kinematics plus a lossless build123d
+            payload. Defaults to True.
 
     Raises:
         RuntimeError: Unknown Compound type
@@ -389,58 +394,90 @@ def export_step(
         bool: success
     """
 
-    # Create the XCAF document
-    doc = _create_xde(to_export, unit, auto_naming=True)
-
-    # Disable writing OCCT info to console
-    messenger = Message.DefaultMessenger_s()
-    for printer in messenger.Printers():
-        printer.SetTraceLevel(Message_Gravity.Message_Fail)
-
-    session = XSControl_WorkSession()
-    writer = STEPCAFControl_Writer(session, False)
-    writer.SetColorMode(True)
-    writer.SetLayerMode(True)
-    writer.SetNameMode(True)
-
-    header = APIHeaderSection_MakeHeader(writer.Writer().Model())
-
-    if not header.IsDone():  # As in OCCT 7.9.x
-        # Create an empty consistent header, i.e. IsDone() return True
-        header = APIHeaderSection_MakeHeader(0)
-        header.Apply(writer.Writer().Model())
-
-    if to_export.label:
-        header.SetName(TCollection_HAsciiString(to_export.label))
-    if timestamp is not None:
-        if isinstance(timestamp, datetime):
-            header.SetTimeStamp(TCollection_HAsciiString(timestamp.isoformat()))
-        else:
-            header.SetTimeStamp(TCollection_HAsciiString(timestamp))
-    # consider using e.g. the non *Value versions instead
-    # header.SetAuthorValue(1, TCollection_HAsciiString("Volker"));
-    # header.SetOrganizationValue(1, TCollection_HAsciiString("myCompanyName"));
-    header.SetOriginatingSystem(TCollection_HAsciiString("build123d"))
-    # header.SetDescriptionValue(1, TCollection_HAsciiString("myApplication Model"));
-
+    has_kinematics = bool(
+        write_kinematics
+        and getattr(to_export, "mates", None)
+        and hasattr(to_export, "components")
+    )
     STEPCAFControl_Controller.Init_s()
     STEPControl_Controller.Init_s()
     IGESControl_Controller.Init_s()
-    Interface_Static.SetIVal_s("write.surfacecurve.mode", int(write_pcurves))
-    Interface_Static.SetIVal_s("write.precision.mode", precision_mode.value)
-    writer.Transfer(doc, STEPControl_StepModelType.STEPControl_AsIs)
+    previous_schema = Interface_Static.CVal_s("write.step.schema")
+    if has_kinematics:
+        Interface_Static.SetCVal_s("write.step.schema", "AP242DIS")
 
-    if isinstance(file_path, (PathLike, str, bytes)):
-        status = writer.Write(fsdecode(file_path))
-    else:
-        # need to cast for type checker because BinaryIO is OK but OCP doesn't know
-        status = writer.WriteStream(cast(BytesIO, file_path))
+    try:
+        # Create the XCAF document
+        doc = _create_xde(to_export, unit, auto_naming=True)
 
-    success = status == IFSelect_ReturnStatus.IFSelect_RetDone
-    if not success:
-        raise RuntimeError("Failed to write STEP file")
+        # Disable writing OCCT info to console
+        messenger = Message.DefaultMessenger_s()
+        for printer in messenger.Printers():
+            printer.SetTraceLevel(Message_Gravity.Message_Fail)
 
-    return success
+        session = XSControl_WorkSession()
+        writer = STEPCAFControl_Writer(session, False)
+        if has_kinematics:
+            # STEPCAFControl_Writer initializes its work session and may restore
+            # the default schema, so select AP242 again after construction.
+            Interface_Static.SetCVal_s("write.step.schema", "AP242DIS")
+        writer.SetColorMode(True)
+        writer.SetLayerMode(True)
+        writer.SetNameMode(True)
+
+        header = APIHeaderSection_MakeHeader(writer.Writer().Model())
+
+        if not header.IsDone():  # As in OCCT 7.9.x
+            # Create an empty consistent header, i.e. IsDone() return True
+            header = APIHeaderSection_MakeHeader(0)
+            header.Apply(writer.Writer().Model())
+
+        if to_export.label:
+            header.SetName(TCollection_HAsciiString(to_export.label))
+        if timestamp is not None:
+            if isinstance(timestamp, datetime):
+                header.SetTimeStamp(TCollection_HAsciiString(timestamp.isoformat()))
+            else:
+                header.SetTimeStamp(TCollection_HAsciiString(timestamp))
+        # consider using e.g. the non *Value versions instead
+        # header.SetAuthorValue(1, TCollection_HAsciiString("Volker"));
+        # header.SetOrganizationValue(1, TCollection_HAsciiString("myCompanyName"));
+        header.SetOriginatingSystem(TCollection_HAsciiString("build123d"))
+        # header.SetDescriptionValue(1, TCollection_HAsciiString("myApplication Model"));
+
+        Interface_Static.SetIVal_s("write.surfacecurve.mode", int(write_pcurves))
+        Interface_Static.SetIVal_s("write.precision.mode", precision_mode.value)
+        if has_kinematics:
+            Interface_Static.SetIVal_s("write.step.schema", 5)
+        writer.Transfer(doc, STEPControl_StepModelType.STEPControl_AsIs)
+
+        if isinstance(file_path, (PathLike, str, bytes)):
+            output_path = Path(fsdecode(file_path))
+            status = writer.Write(str(output_path))
+        else:
+            output_path = None
+            # need to cast for type checker because BinaryIO is OK but OCP doesn't know
+            status = writer.WriteStream(cast(BytesIO, file_path))
+
+        success = status == IFSelect_ReturnStatus.IFSelect_RetDone
+        if not success:
+            raise RuntimeError("Failed to write STEP file")
+
+        if has_kinematics:
+            if output_path is not None:
+                output_path.write_bytes(
+                    inject_step_kinematics(output_path.read_bytes(), to_export)
+                )
+            else:
+                stream = cast(BytesIO, file_path)
+                encoded = inject_step_kinematics(stream.getvalue(), to_export)
+                stream.seek(0)
+                stream.write(encoded)
+                stream.truncate()
+        return success
+    finally:
+        if has_kinematics:
+            Interface_Static.SetCVal_s("write.step.schema", previous_schema)
 
 
 def export_stl(

--- a/src/build123d/exporters3d.py
+++ b/src/build123d/exporters3d.py
@@ -456,8 +456,9 @@ def export_step(
             status = writer.Write(str(output_path))
         else:
             output_path = None
+            output_stream = BytesIO() if has_kinematics else file_path
             # need to cast for type checker because BinaryIO is OK but OCP doesn't know
-            status = writer.WriteStream(cast(BytesIO, file_path))
+            status = writer.WriteStream(cast(BytesIO, output_stream))
 
         success = status == IFSelect_ReturnStatus.IFSelect_RetDone
         if not success:
@@ -469,11 +470,8 @@ def export_step(
                     inject_step_kinematics(output_path.read_bytes(), to_export)
                 )
             else:
-                stream = cast(BytesIO, file_path)
-                encoded = inject_step_kinematics(stream.getvalue(), to_export)
-                stream.seek(0)
-                stream.write(encoded)
-                stream.truncate()
+                encoded = inject_step_kinematics(output_stream.getvalue(), to_export)
+                file_path.write(encoded)
         return success
     finally:
         if has_kinematics:

--- a/src/build123d/importers.py
+++ b/src/build123d/importers.py
@@ -263,6 +263,31 @@ def import_step(filename: PathLike | str | bytes) -> Compound:
     return root
 
 
+def import_step_assembly(filename: PathLike | str | bytes):
+    """Import STEP geometry and restore build123d's persistent assembly mates.
+
+    The STEP file must contain the versioned lossless kinematics payload written
+    by :func:`build123d.export_step`. Standard AP242 kinematics remain available
+    to other readers; this function restores the additional Onshape-compatible
+    feature details that AP242 cannot express.
+    """
+
+    from build123d.step_kinematics import (  # pylint: disable=import-outside-toplevel
+        assembly_from_kinematics,
+        read_step_kinematics,
+    )
+
+    path = Path(fsdecode(filename))
+    manifest = read_step_kinematics(path.read_bytes())
+    if manifest is None:
+        raise ValueError("STEP file has no build123d assembly kinematics payload")
+    geometry = import_step(path)
+    components = list(geometry.children)
+    if not components and len(manifest["components"]) == 1:
+        components = [geometry]
+    return assembly_from_kinematics(manifest, components)
+
+
 def import_stl(file_name: PathLike | str | bytes, model_unit: Unit = Unit.MM) -> Face:
     """import_stl
 

--- a/src/build123d/step_kinematics.py
+++ b/src/build123d/step_kinematics.py
@@ -1,0 +1,1125 @@
+"""
+Lossless build123d assembly metadata and AP242 kinematics encoding.
+
+AP242 has native entities for common low-order pairs, ranges, and mechanism
+states, but it cannot represent every Onshape feature-level detail.  STEP files
+therefore contain both:
+
+* standard AP242 kinematics for faithfully representable motion; and
+* a versioned build123d payload in an ISO 10303-21 comment for exact round trips.
+
+The comment is deliberately supplemental.  AP242 readers that do not know
+build123d still see the standard mechanism, links, joints, pairs, placements,
+and ranges.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+import zlib
+from copy import deepcopy
+from math import inf, pi
+from typing import TYPE_CHECKING, Any, Mapping, Sequence
+
+import numpy as np
+
+from build123d.assembly import (
+    Assembly,
+    BallMate,
+    CylindricalMate,
+    FastenedMate,
+    GearRelation,
+    GroupMate,
+    LinearRelation,
+    Mate,
+    MateConnector,
+    MateDOF,
+    MateOffset,
+    ParallelMate,
+    PinSlotMate,
+    PlanarMate,
+    RackAndPinionRelation,
+    RevoluteMate,
+    ScrewRelation,
+    SliderMate,
+    TangentMate,
+    WidthMate,
+    _PoseMap,
+    _location_matrix,
+    _matrix_location,
+)
+from build123d.joints import RigidJoint
+from build123d.topology import Edge, Face, Shape, Vertex
+
+if TYPE_CHECKING:
+    from build123d.assembly import MateRelation
+
+
+MANIFEST_SCHEMA = "https://build123d.org/schemas/assembly-kinematics/1"
+_PAYLOAD_PREFIX = "build123d:assembly-kinematics:1:"
+_PAYLOAD_PATTERN = re.compile(
+    rb"/\*\s*" + re.escape(_PAYLOAD_PREFIX.encode()) + rb"([A-Za-z0-9+/=]+)\s*\*/"
+)
+
+_ONSHAPE_MATE_TYPES: dict[type[Mate], str] = {
+    FastenedMate: "FASTENED",
+    SliderMate: "SLIDER",
+    CylindricalMate: "CYLINDRICAL",
+    RevoluteMate: "REVOLUTE",
+    PinSlotMate: "PIN_SLOT",
+    PlanarMate: "PLANAR",
+    BallMate: "BALL",
+    ParallelMate: "PARALLEL",
+    TangentMate: "TANGENT",
+    WidthMate: "WIDTH",
+    GroupMate: "GROUP",
+}
+
+_AP242_PAIR_TYPES: dict[type[Mate], str | None] = {
+    FastenedMate: "FULLY_CONSTRAINED_PAIR",
+    RevoluteMate: "REVOLUTE_PAIR_WITH_RANGE",
+    SliderMate: "PRISMATIC_PAIR_WITH_RANGE",
+    PlanarMate: "PLANAR_PAIR_WITH_RANGE",
+    CylindricalMate: "CYLINDRICAL_PAIR_WITH_RANGE",
+    PinSlotMate: "LOW_ORDER_KINEMATIC_PAIR_WITH_RANGE",
+    BallMate: "SPHERICAL_PAIR",
+    ParallelMate: "LOW_ORDER_KINEMATIC_PAIR_WITH_RANGE",
+    TangentMate: None,
+    WidthMate: None,
+    GroupMate: "FULLY_CONSTRAINED_PAIR",
+}
+
+_AP242_EXTENSION_REASONS: dict[type[Mate], tuple[str, ...]] = {
+    PinSlotMate: ("AP242 has no Pin Slot feature identity; generic DOFs are used",),
+    BallMate: (
+        "Onshape's conical swing limit is not equivalent to AP242 yaw/pitch/roll ranges",
+    ),
+    ParallelMate: ("AP242 has no Parallel feature identity; generic DOFs are used",),
+    TangentMate: ("propagated face/edge/vertex selections are not one AP242 pair",),
+    WidthMate: ("multi-component centering/symmetry has no AP242 pair",),
+    GroupMate: ("the rigid pairs do not retain Onshape Group feature identity",),
+}
+
+_RELATION_AP242: dict[type[MateRelation], tuple[str | None, tuple[str, ...]]] = {
+    GearRelation: (
+        None,
+        (
+            "AP242 GEAR_PAIR requires both pitch radii, while Onshape stores only "
+            "a ratio",
+        ),
+    ),
+    RackAndPinionRelation: (
+        None,
+        (
+            "the Onshape relation references two existing mate coordinates rather "
+            "than one adjacent-link AP242 RACK_AND_PINION_PAIR",
+        ),
+    ),
+    ScrewRelation: (
+        None,
+        (
+            "the Onshape relation couples coordinates of an existing mate and "
+            "retains reverse and phase separately",
+        ),
+    ),
+    LinearRelation: (
+        None,
+        ("AP242 has no general linear-to-linear mate-coordinate coupling pair",),
+    ),
+}
+
+
+def _matrix_list(location) -> list[list[float]]:
+    return _location_matrix(location).tolist()
+
+
+def _finite_or_none(value: float) -> float | None:
+    return None if value in (-inf, inf) else float(value)
+
+
+def _component_index(assembly: Assembly, component: Shape) -> int:
+    return next(
+        index
+        for index, candidate in enumerate(assembly.components)
+        if candidate is component
+    )
+
+
+def _connector_record(assembly: Assembly, connector: RigidJoint) -> dict[str, Any]:
+    return {
+        "label": connector.label,
+        "component": _component_index(assembly, connector.parent),
+        "relativeTransform": _matrix_list(connector.relative_location),
+    }
+
+
+def _entity_record(component: Shape, entity: Shape) -> dict[str, Any]:
+    entity_type, candidates = (
+        ("FACE", component.faces())
+        if isinstance(entity, Face)
+        else (
+            ("EDGE", component.edges())
+            if isinstance(entity, Edge)
+            else (
+                ("VERTEX", component.vertices())
+                if isinstance(entity, Vertex)
+                else (None, ())
+            )
+        )
+    )
+    if entity_type is None:
+        raise TypeError("Mate entity must be a face, edge, or vertex")
+    index = next(
+        (
+            candidate_index
+            for candidate_index, candidate in enumerate(candidates)
+            if candidate.is_same(entity)
+        ),
+        None,
+    )
+    if index is None:
+        raise ValueError("Mate entity is not part of its owning component")
+    return {"type": entity_type, "index": index}
+
+
+def _onshape_limit_parameter_id(dof: MateDOF, bound: str) -> str:
+    axis = dof.value[-1].upper()
+    if dof in (MateDOF.TX, MateDOF.TY, MateDOF.TZ):
+        return f"limit{axis}{bound}"
+    if dof in (MateDOF.RX, MateDOF.RY, MateDOF.RZ):
+        return f"limitAxial{axis}{bound}"
+    if dof == MateDOF.SWING and bound == "Max":
+        return "limitEulerConeAngleMax"
+    return f"build123d:{dof.value}:{bound.lower()}"
+
+
+def _canonical_onshape_values(mate: Mate) -> dict[str, Any]:
+    """Return stable Onshape API parameter IDs without discarding raw records."""
+
+    values: dict[str, Any] = {
+        "mateType": _ONSHAPE_MATE_TYPES[type(mate)],
+        "limitsEnabled": bool(mate.limits),
+    }
+    if hasattr(mate, "flip_primary"):
+        values["primaryAxisAlignment"] = not bool(mate.flip_primary)
+    if hasattr(mate, "reorient_secondary"):
+        values["secondaryAxisAlignment"] = (
+            "PLUS_X",
+            "PLUS_Y",
+            "MINUS_X",
+            "MINUS_Y",
+        )[mate.reorient_secondary]
+    for dof, limit in mate.limits.items():
+        minimum = _finite_or_none(limit.minimum)
+        maximum = _finite_or_none(limit.maximum)
+        if minimum is not None and dof != MateDOF.SWING:
+            values[_onshape_limit_parameter_id(dof, "Min")] = minimum
+        if maximum is not None:
+            values[_onshape_limit_parameter_id(dof, "Max")] = maximum
+    return values
+
+
+def _base_mate_record(assembly: Assembly, mate: Mate) -> dict[str, Any]:
+    poses = _PoseMap(
+        {
+            id(component): _location_matrix(component.location)
+            for component in assembly.components
+        }
+    )
+    return {
+        "type": type(mate).__name__,
+        "label": mate.label,
+        "suppressed": mate.suppressed,
+        "limits": {
+            dof.value: {
+                "minimum": _finite_or_none(limit.minimum),
+                "maximum": _finite_or_none(limit.maximum),
+            }
+            for dof, limit in mate.limits.items()
+        },
+        "values": {dof.value: value for dof, value in mate.values.items()},
+        "currentValues": {
+            dof.value: mate.coordinate(poses, dof)
+            for dof in mate.free_dofs
+            if not isinstance(mate, (TangentMate, WidthMate, GroupMate))
+        },
+        "onshape": {
+            "values": _canonical_onshape_values(mate),
+            "parameters": deepcopy(mate.onshape_parameters),
+        },
+        "ap242": {
+            "pairType": _AP242_PAIR_TYPES[type(mate)],
+            "extensionReasons": list(_AP242_EXTENSION_REASONS.get(type(mate), ())),
+        },
+    }
+
+
+def _mate_record(assembly: Assembly, mate: Mate) -> dict[str, Any]:
+    record = _base_mate_record(assembly, mate)
+    if isinstance(mate, TangentMate):
+        record.update(
+            {
+                "components": [
+                    _component_index(assembly, mate.component1),
+                    _component_index(assembly, mate.component2),
+                ],
+                "entities": [
+                    [
+                        _entity_record(reference.component, reference.entity)
+                        for reference in mate.entities1
+                    ],
+                    [
+                        _entity_record(reference.component, reference.entity)
+                        for reference in mate.entities2
+                    ],
+                ],
+                "propagate": mate.propagate,
+                "flipPrimary": mate.flip_primary,
+            }
+        )
+    elif isinstance(mate, WidthMate):
+        record.update(
+            {
+                "tabs": [
+                    _connector_record(assembly, connector) for connector in mate.tabs
+                ],
+                "widths": [
+                    _connector_record(assembly, connector) for connector in mate.widths
+                ],
+            }
+        )
+    elif isinstance(mate, GroupMate):
+        record.update(
+            {
+                "components": [
+                    _component_index(assembly, component)
+                    for component in mate.components
+                ],
+                "relativeTransforms": [
+                    matrix.tolist() for matrix in mate._relative_poses
+                ],
+            }
+        )
+    else:
+        first_transform = _location_matrix(mate.connector1.relative_location)
+        second_transform = _location_matrix(mate.connector2.relative_location)
+        effective_second_transform = second_transform @ _inverse(
+            mate._alignment_matrix()
+        )
+        record.update(
+            {
+                "connectors": [
+                    _connector_record(assembly, mate.connector1),
+                    _connector_record(assembly, mate.connector2),
+                ],
+                "offset": {
+                    "translation": list(mate.offset.translation),
+                    "rotation": list(mate.offset.rotation),
+                },
+                "flipPrimary": mate.flip_primary,
+                "reorientSecondary": mate.reorient_secondary,
+            }
+        )
+        # The standard pair placements include Onshape's offset and axis
+        # alignment.  Raw connector frames and options remain separately
+        # available in the lossless manifest.
+        record["ap242"]["placements"] = [
+            first_transform.tolist(),
+            effective_second_transform.tolist(),
+        ]
+    return record
+
+
+def _relation_record(
+    mate_indices: Mapping[int, int], relation: MateRelation
+) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "type": type(relation).__name__,
+        "label": relation.label,
+        "suppressed": relation.suppressed,
+        "phase": relation._phase,
+        "mates": [mate_indices[id(mate)] for mate in relation.mates],
+        "onshape": {"parameters": deepcopy(relation.onshape_parameters)},
+        "ap242": {
+            "pairType": _RELATION_AP242[type(relation)][0],
+            "extensionReasons": list(_RELATION_AP242[type(relation)][1]),
+        },
+    }
+    if isinstance(relation, (GearRelation, LinearRelation)):
+        record.update(
+            {
+                "ratio": relation.ratio,
+                "reverse": relation.reverse,
+                "dofs": [relation.dof1.value, relation.dof2.value],
+            }
+        )
+    elif isinstance(relation, RackAndPinionRelation):
+        record.update(
+            {
+                "travelPerRevolution": relation.travel_per_revolution,
+                "reverse": relation.reverse,
+                "dofs": [
+                    relation.rotational_dof.value,
+                    relation.linear_dof.value,
+                ],
+            }
+        )
+    elif isinstance(relation, ScrewRelation):
+        record.update(
+            {
+                "travelPerRevolution": relation.travel_per_revolution,
+                "reverse": relation.reverse,
+                "dofs": [
+                    relation.rotational_dof.value,
+                    relation.linear_dof.value,
+                ],
+            }
+        )
+    return record
+
+
+def assembly_to_kinematics(assembly: Assembly) -> dict[str, Any]:
+    """Serialize every assembly constraint field into a versioned manifest."""
+
+    mate_indices = {id(mate): index for index, mate in enumerate(assembly.mates)}
+    return {
+        "$schema": MANIFEST_SCHEMA,
+        "label": assembly.label,
+        "units": {"length": "model-unit", "angle": "degree"},
+        "components": [
+            {
+                "label": component.label,
+                "fixed": assembly.is_fixed(component),
+                "transform": _matrix_list(component.location),
+            }
+            for component in assembly.components
+        ],
+        "mates": [_mate_record(assembly, mate) for mate in assembly.mates],
+        "relations": [
+            _relation_record(mate_indices, relation) for relation in assembly.relations
+        ],
+    }
+
+
+def encode_kinematics_payload(manifest: Mapping[str, Any]) -> str:
+    """Encode a deterministic, compressed payload safe for a STEP comment."""
+
+    data = json.dumps(
+        manifest,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    return base64.b64encode(zlib.compress(data, level=9)).decode()
+
+
+def decode_kinematics_payload(payload: str | bytes) -> dict[str, Any]:
+    """Decode and validate one build123d STEP kinematics payload."""
+
+    raw = payload.encode() if isinstance(payload, str) else payload
+    manifest = json.loads(zlib.decompress(base64.b64decode(raw)))
+    if manifest.get("$schema") != MANIFEST_SCHEMA:
+        raise ValueError("Unsupported build123d assembly kinematics schema")
+    return manifest
+
+
+def read_step_kinematics(step: str | bytes) -> dict[str, Any] | None:
+    """Read the lossless mate payload from STEP text or bytes."""
+
+    data = step.encode() if isinstance(step, str) else step
+    match = _PAYLOAD_PATTERN.search(data)
+    return decode_kinematics_payload(match.group(1)) if match else None
+
+
+def _limit_value(value: float | None, fallback: float) -> float:
+    return fallback if value is None else float(value)
+
+
+def _limits_from_record(
+    record: Mapping[str, Any],
+) -> dict[MateDOF, tuple[float, float]]:
+    return {
+        MateDOF(dof): (
+            _limit_value(bounds["minimum"], -inf),
+            _limit_value(bounds["maximum"], inf),
+        )
+        for dof, bounds in record["limits"].items()
+    }
+
+
+def _connector_from_record(
+    record: Mapping[str, Any], components: Sequence[Shape]
+) -> MateConnector:
+    component = components[int(record["component"])]
+    relative = _matrix_location(_as_matrix(record["relativeTransform"]))
+    return MateConnector(
+        str(record["label"]),
+        component,  # type: ignore[arg-type]
+        component.location * relative,
+    )
+
+
+def _entity_from_record(component: Shape, record: Mapping[str, Any]) -> Shape:
+    candidates = {
+        "FACE": component.faces,
+        "EDGE": component.edges,
+        "VERTEX": component.vertices,
+    }[str(record["type"])]()
+    try:
+        return candidates[int(record["index"])]
+    except IndexError as error:
+        raise ValueError(
+            "STEP topology no longer matches the stored TangentMate selection"
+        ) from error
+
+
+def assembly_from_kinematics(
+    manifest: Mapping[str, Any], components: Sequence[Shape]
+) -> Assembly:
+    """Recreate persistent mates and relations around imported STEP components."""
+
+    component_records = manifest["components"]
+    if len(components) != len(component_records):
+        raise ValueError(
+            "STEP assembly component count does not match its kinematics payload"
+        )
+    component_list = list(components)
+    for component, record in zip(component_list, component_records):
+        component.label = str(record["label"])
+        component.locate(_matrix_location(_as_matrix(record["transform"])))
+
+    assembly = Assembly(component_list, label=str(manifest["label"]))
+    for component, record in zip(component_list, component_records):
+        if record["fixed"]:
+            assembly.ground(component)
+
+    connector_mates: dict[str, type[Mate]] = {
+        mate_type.__name__: mate_type
+        for mate_type in (
+            FastenedMate,
+            RevoluteMate,
+            SliderMate,
+            PlanarMate,
+            CylindricalMate,
+            PinSlotMate,
+            BallMate,
+            ParallelMate,
+        )
+    }
+    restored_mates: list[Mate] = []
+    for record in manifest["mates"]:
+        mate_type = str(record["type"])
+        common = {
+            "suppressed": bool(record["suppressed"]),
+            "onshape_parameters": record["onshape"]["parameters"],
+        }
+        if mate_type in connector_mates:
+            connector1, connector2 = (
+                _connector_from_record(connector, component_list)
+                for connector in record["connectors"]
+            )
+            offset = record["offset"]
+            mate = connector_mates[mate_type](
+                str(record["label"]),
+                connector1,
+                connector2,
+                offset=MateOffset(
+                    tuple(offset["translation"]), tuple(offset["rotation"])
+                ),
+                limits=_limits_from_record(record),
+                flip_primary=bool(record["flipPrimary"]),
+                reorient_secondary=int(record["reorientSecondary"]),
+                **common,
+            )
+            for dof, value in record["values"].items():
+                mate.set_value(dof, float(value))
+        elif mate_type == "TangentMate":
+            component1, component2 = (
+                component_list[int(index)] for index in record["components"]
+            )
+            mate = TangentMate(
+                str(record["label"]),
+                component1,
+                _entity_from_record(component1, record["entities"][0][0]),
+                component2,
+                _entity_from_record(component2, record["entities"][1][0]),
+                propagate=bool(record["propagate"]),
+                flip_primary=bool(record["flipPrimary"]),
+                **common,
+            )
+        elif mate_type == "WidthMate":
+            tabs = [
+                _connector_from_record(connector, component_list)
+                for connector in record["tabs"]
+            ]
+            widths = [
+                _connector_from_record(connector, component_list)
+                for connector in record["widths"]
+            ]
+            mate = WidthMate(str(record["label"]), tabs, widths, **common)
+        elif mate_type == "GroupMate":
+            grouped = [component_list[int(index)] for index in record["components"]]
+            mate = GroupMate(str(record["label"]), grouped, **common)
+            mate._relative_poses = tuple(
+                _as_matrix(matrix) for matrix in record["relativeTransforms"]
+            )
+        else:
+            raise ValueError(f"Unsupported stored mate type {mate_type!r}")
+        assembly.add_mate(mate, solve=False)
+        restored_mates.append(mate)
+
+    relation_types: dict[str, type[MateRelation]] = {
+        relation_type.__name__: relation_type
+        for relation_type in (
+            GearRelation,
+            RackAndPinionRelation,
+            ScrewRelation,
+            LinearRelation,
+        )
+    }
+    for record in manifest["relations"]:
+        mate_refs = [restored_mates[int(index)] for index in record["mates"]]
+        common = {
+            "suppressed": bool(record["suppressed"]),
+            "onshape_parameters": record["onshape"]["parameters"],
+        }
+        relation_type = str(record["type"])
+        if relation_type in ("GearRelation", "LinearRelation"):
+            relation = relation_types[relation_type](
+                str(record["label"]),
+                *mate_refs,
+                ratio=float(record["ratio"]),
+                dof1=record["dofs"][0],
+                dof2=record["dofs"][1],
+                reverse=bool(record["reverse"]),
+                **common,
+            )
+        elif relation_type == "RackAndPinionRelation":
+            relation = RackAndPinionRelation(
+                str(record["label"]),
+                *mate_refs,
+                travel_per_revolution=float(record["travelPerRevolution"]),
+                rotational_dof=record["dofs"][0],
+                linear_dof=record["dofs"][1],
+                reverse=bool(record["reverse"]),
+                **common,
+            )
+        elif relation_type == "ScrewRelation":
+            relation = ScrewRelation(
+                str(record["label"]),
+                mate_refs[0],
+                travel_per_revolution=float(record["travelPerRevolution"]),
+                rotational_dof=record["dofs"][0],
+                linear_dof=record["dofs"][1],
+                reverse=bool(record["reverse"]),
+                **common,
+            )
+        else:
+            raise ValueError(f"Unsupported stored relation type {relation_type!r}")
+        relation._phase = record["phase"]
+        assembly.add_relation(relation, solve=False)
+    return assembly
+
+
+def _inverse(matrix):
+    """Return the inverse of a homogeneous transform."""
+    return np.linalg.inv(matrix)
+
+
+def _step_quote(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _step_real(value: float) -> str:
+    if abs(value) < 1e-15:
+        return "0."
+    text = f"{value:.15g}"
+    return text if any(character in text for character in ".Ee") else text + "."
+
+
+def _step_optional(value: float | None, *, angular: bool = False) -> str:
+    if value is None:
+        return "$"
+    return _step_real(value * pi / 180 if angular else value)
+
+
+class _StepEntities:
+    def __init__(self, first_id: int):
+        self.next_id = first_id
+        self.lines: list[str] = []
+
+    def add(self, entity: str) -> int:
+        """Append one Part 21 entity and return its numeric identifier."""
+        entity_id = self.next_id
+        self.next_id += 1
+        self.lines.append(f"#{entity_id} = {entity};")
+        return entity_id
+
+
+def _axis_placement(entities: _StepEntities, name: str, matrix) -> int:
+    point = entities.add(
+        "CARTESIAN_POINT("
+        + _step_quote(name + " origin")
+        + ",("
+        + ",".join(_step_real(float(value)) for value in matrix[:3, 3])
+        + "))"
+    )
+    axis = entities.add(
+        "DIRECTION("
+        + _step_quote(name + " primary")
+        + ",("
+        + ",".join(_step_real(float(value)) for value in matrix[:3, 2])
+        + "))"
+    )
+    ref = entities.add(
+        "DIRECTION("
+        + _step_quote(name + " secondary")
+        + ",("
+        + ",".join(_step_real(float(value)) for value in matrix[:3, 0])
+        + "))"
+    )
+    return entities.add(
+        f"AXIS2_PLACEMENT_3D({_step_quote(name)},#{point},#{axis},#{ref})"
+    )
+
+
+def _range(record: Mapping[str, Any], dof: str) -> tuple[float | None, float | None]:
+    limit = record["limits"].get(dof, {})
+    return limit.get("minimum"), limit.get("maximum")
+
+
+def _pair_entity(
+    record: Mapping[str, Any],
+    joint_id: int,
+    first_axis: int,
+    second_axis: int,
+) -> str | None:
+    # Explicit pair branches keep EXPRESS attribute ordering easy to audit.
+    # pylint: disable=too-many-return-statements
+    pair_type = record["ap242"]["pairType"]
+    if pair_type is None:
+        return None
+    free = {
+        "FastenedMate": (),
+        "RevoluteMate": ("rz",),
+        "SliderMate": ("tz",),
+        "PlanarMate": ("tx", "ty", "rz"),
+        "CylindricalMate": ("tz", "rz"),
+        "PinSlotMate": ("tx", "rz"),
+        "BallMate": ("rx", "ry", "rz"),
+        "ParallelMate": ("tx", "ty", "tz", "rz"),
+    }.get(record["type"])
+    if free is None:
+        return None
+    bools = ",".join(
+        ".T." if dof in free else ".F." for dof in ("tx", "ty", "tz", "rx", "ry", "rz")
+    )
+    common = (
+        f"{_step_quote(record['label'])},{_step_quote(record['label'] + ' placement')},"
+        f"$,#{first_axis},#{second_axis},#{joint_id},{bools}"
+    )
+    if record["type"] == "FastenedMate":
+        return f"FULLY_CONSTRAINED_PAIR({common})"
+    if record["type"] == "RevoluteMate":
+        lower, upper = _range(record, "rz")
+        return (
+            f"REVOLUTE_PAIR_WITH_RANGE({common},"
+            f"{_step_optional(lower, angular=True)},"
+            f"{_step_optional(upper, angular=True)})"
+        )
+    if record["type"] == "SliderMate":
+        lower, upper = _range(record, "tz")
+        return (
+            f"PRISMATIC_PAIR_WITH_RANGE({common},"
+            f"{_step_optional(lower)},{_step_optional(upper)})"
+        )
+    if record["type"] == "PlanarMate":
+        rz = _range(record, "rz")
+        tx = _range(record, "tx")
+        ty = _range(record, "ty")
+        values = (
+            _step_optional(rz[0], angular=True),
+            _step_optional(rz[1], angular=True),
+            _step_optional(tx[0]),
+            _step_optional(tx[1]),
+            _step_optional(ty[0]),
+            _step_optional(ty[1]),
+        )
+        return f"PLANAR_PAIR_WITH_RANGE({common},{','.join(values)})"
+    if record["type"] == "CylindricalMate":
+        tz = _range(record, "tz")
+        rz = _range(record, "rz")
+        values = (
+            _step_optional(tz[0]),
+            _step_optional(tz[1]),
+            _step_optional(rz[0], angular=True),
+            _step_optional(rz[1], angular=True),
+        )
+        return f"CYLINDRICAL_PAIR_WITH_RANGE({common},{','.join(values)})"
+    if record["type"] in ("PinSlotMate", "ParallelMate"):
+        values: list[str] = []
+        for dof in ("rx", "ry", "rz", "tx", "ty", "tz"):
+            lower, upper = _range(record, dof)
+            angular = dof.startswith("r")
+            values.extend(
+                (
+                    _step_optional(lower, angular=angular),
+                    _step_optional(upper, angular=angular),
+                )
+            )
+        return f"LOW_ORDER_KINEMATIC_PAIR_WITH_RANGE({common},{','.join(values)})"
+    if record["type"] == "BallMate":
+        return f"SPHERICAL_PAIR({common})"
+    return None
+
+
+def _find_representation_context(step_text: str) -> int:
+    matches = re.findall(
+        r"#(\d+)\s*=\s*\([^;]*GEOMETRIC_REPRESENTATION_CONTEXT\(3\)[^;]*"
+        r"REPRESENTATION_CONTEXT\(",
+        step_text,
+        flags=re.DOTALL,
+    )
+    if not matches:
+        raise ValueError("STEP file has no 3D representation context")
+    return int(matches[-1])
+
+
+def _step_statements(step_text: str) -> dict[int, str]:
+    return {
+        int(entity_id): body.strip()
+        for entity_id, body in re.findall(
+            r"#(\d+)\s*=\s*(.*?);", step_text, flags=re.DOTALL
+        )
+    }
+
+
+def _references(statement: str) -> list[int]:
+    return [int(value) for value in re.findall(r"#(\d+)", statement)]
+
+
+def _first_step_string(statement: str) -> str | None:
+    match = re.search(r"\(\s*'((?:''|[^'])*)'", statement)
+    return match.group(1).replace("''", "'") if match else None
+
+
+def _product_definition(statements: Mapping[int, str], label: str) -> int | None:
+    product = next(
+        (
+            entity_id
+            for entity_id, statement in statements.items()
+            if statement.startswith("PRODUCT(")
+            and _first_step_string(statement) == label
+        ),
+        None,
+    )
+    if product is None:
+        return None
+    formation = next(
+        (
+            entity_id
+            for entity_id, statement in statements.items()
+            if statement.startswith("PRODUCT_DEFINITION_FORMATION(")
+            and _references(statement)
+            and _references(statement)[-1] == product
+        ),
+        None,
+    )
+    if formation is None:
+        return None
+    return next(
+        (
+            entity_id
+            for entity_id, statement in statements.items()
+            if statement.startswith("PRODUCT_DEFINITION(")
+            and _references(statement)
+            and _references(statement)[0] == formation
+        ),
+        None,
+    )
+
+
+def _shape_representation(
+    statements: Mapping[int, str], product_definition: int
+) -> int | None:
+    definition_shape = next(
+        (
+            entity_id
+            for entity_id, statement in statements.items()
+            if statement.startswith("PRODUCT_DEFINITION_SHAPE(")
+            and _references(statement)
+            and _references(statement)[-1] == product_definition
+        ),
+        None,
+    )
+    if definition_shape is None:
+        return None
+    return next(
+        (
+            refs[1]
+            for statement in statements.values()
+            if statement.startswith("SHAPE_DEFINITION_REPRESENTATION(")
+            and len(refs := _references(statement)) >= 2
+            and refs[0] == definition_shape
+        ),
+        None,
+    )
+
+
+def _component_occurrence(
+    statements: Mapping[int, str],
+    parent_definition: int,
+    component_definition: int,
+) -> int | None:
+    return next(
+        (
+            entity_id
+            for entity_id, statement in statements.items()
+            if statement.startswith("NEXT_ASSEMBLY_USAGE_OCCURRENCE(")
+            and len(refs := _references(statement)) >= 2
+            and refs[-2:] == [parent_definition, component_definition]
+        ),
+        None,
+    )
+
+
+def _native_kinematics(step_text: str, manifest: Mapping[str, Any]) -> list[str]:
+    ids = [int(value) for value in re.findall(r"#(\d+)\s*=", step_text)]
+    entities = _StepEntities(max(ids, default=0) + 1)
+    context_id = _find_representation_context(step_text)
+
+    link_ids = [
+        entities.add(f"KINEMATIC_LINK({_step_quote(component['label'])})")
+        for component in manifest["components"]
+    ]
+    joint_ids: list[int] = []
+    pair_ids: list[int] = []
+    pair_value_ids: list[int] = []
+    component_placements: dict[int, list[int]] = {
+        index: [] for index in range(len(link_ids))
+    }
+
+    for record in manifest["mates"]:
+        if record["suppressed"] or "connectors" not in record:
+            continue
+        connector1, connector2 = record["connectors"]
+        component1, component2 = connector1["component"], connector2["component"]
+        joint_id = entities.add(
+            f"KINEMATIC_JOINT({_step_quote(record['label'])},"
+            f"#{link_ids[component1]},#{link_ids[component2]})"
+        )
+        joint_ids.append(joint_id)
+        first_placement, second_placement = record["ap242"]["placements"]
+        first_axis = _axis_placement(
+            entities, record["label"] + " first", _as_matrix(first_placement)
+        )
+        second_axis = _axis_placement(
+            entities,
+            record["label"] + " second",
+            _as_matrix(second_placement),
+        )
+        component_placements[component1].append(first_axis)
+        component_placements[component2].append(second_axis)
+        pair = _pair_entity(record, joint_id, first_axis, second_axis)
+        if pair is not None:
+            pair_id = entities.add(pair)
+            pair_ids.append(pair_id)
+            current = record["currentValues"]
+            actual_values = []
+            for dof in ("tx", "ty", "tz", "rx", "ry", "rz"):
+                value = float(current.get(dof, 0.0))
+                if dof.startswith("r"):
+                    value *= pi / 180
+                actual_values.append(_step_real(value))
+            pair_value_ids.append(
+                entities.add(
+                    f"LOW_ORDER_KINEMATIC_PAIR_VALUE("
+                    f"{_step_quote(record['label'] + ' state')},"
+                    f"#{pair_id},{','.join(actual_values)})"
+                )
+            )
+
+    identity_matrix = _as_matrix(
+        (
+            (1, 0, 0, 0),
+            (0, 1, 0, 0),
+            (0, 0, 1, 0),
+            (0, 0, 0, 1),
+        )
+    )
+    for record in manifest["mates"]:
+        if record["suppressed"] or record["type"] != "GroupMate":
+            continue
+        reference_component = int(record["components"][0])
+        for group_index, (component, expected) in enumerate(
+            zip(record["components"][1:], record["relativeTransforms"]), start=1
+        ):
+            component = int(component)
+            pair_label = f"{record['label']} {group_index}"
+            joint_id = entities.add(
+                f"KINEMATIC_JOINT({_step_quote(pair_label)},"
+                f"#{link_ids[reference_component]},#{link_ids[component]})"
+            )
+            joint_ids.append(joint_id)
+            first_axis = _axis_placement(
+                entities, pair_label + " first", _as_matrix(expected)
+            )
+            second_axis = _axis_placement(
+                entities, pair_label + " second", identity_matrix
+            )
+            component_placements[reference_component].append(first_axis)
+            component_placements[component].append(second_axis)
+            common = (
+                f"{_step_quote(pair_label)},"
+                f"{_step_quote(pair_label + ' placement')},$,"
+                f"#{first_axis},#{second_axis},#{joint_id},"
+                ".F.,.F.,.F.,.F.,.F.,.F."
+            )
+            pair_id = entities.add(f"FULLY_CONSTRAINED_PAIR({common})")
+            pair_ids.append(pair_id)
+            pair_value_ids.append(
+                entities.add(
+                    f"LOW_ORDER_KINEMATIC_PAIR_VALUE("
+                    f"{_step_quote(pair_label + ' state')},#{pair_id},"
+                    "0.,0.,0.,0.,0.,0.)"
+                )
+            )
+
+    # Tangent and Width constraints do not have a faithful standard pair.
+    # Their complete records still remain in the lossless payload.
+    if not pair_ids:
+        return []
+
+    link_representation_ids = []
+    for component_index, link_id in enumerate(link_ids):
+        placements = component_placements[component_index]
+        if not placements:
+            identity = _axis_placement(
+                entities,
+                manifest["components"][component_index]["label"] + " origin",
+                identity_matrix,
+            )
+            placements = [identity]
+        items = ",".join(f"#{placement}" for placement in placements)
+        link_representation_ids.append(
+            entities.add(
+                f"RIGID_LINK_REPRESENTATION("
+                f"{_step_quote(manifest['components'][component_index]['label'])},"
+                f"({items}),#{context_id},#{link_id})"
+            )
+        )
+
+    topology_items = ",".join(f"#{entity_id}" for entity_id in (*link_ids, *joint_ids))
+    topology = entities.add(
+        f"KINEMATIC_TOPOLOGY_STRUCTURE("
+        f"{_step_quote(manifest['label'] + ' topology')},"
+        f"({topology_items}),#{context_id})"
+    )
+    mechanism_items = ",".join(f"#{pair_id}" for pair_id in pair_ids)
+    mechanism = entities.add(
+        f"MECHANISM_REPRESENTATION("
+        f"{_step_quote(manifest['label'] + ' mechanism')},"
+        f"({mechanism_items}),#{context_id},#{topology})"
+    )
+    if pair_value_ids:
+        state_items = ",".join(f"#{value_id}" for value_id in pair_value_ids)
+        entities.add(
+            f"MECHANISM_STATE_REPRESENTATION("
+            f"{_step_quote(manifest['label'] + ' state')},"
+            f"({state_items}),#{context_id},#{mechanism})"
+        )
+    statements = _step_statements(step_text)
+    root_definition = _product_definition(statements, manifest["label"])
+    for component_index, component in enumerate(manifest["components"]):
+        component_definition = _product_definition(statements, component["label"])
+        if component_definition is None:
+            continue
+        shape_representation = _shape_representation(statements, component_definition)
+        if shape_representation is not None:
+            association = entities.add(
+                f"KINEMATIC_LINK_REPRESENTATION_ASSOCIATION("
+                f"{_step_quote(component['label'] + ' geometry')},$,"
+                f"#{link_representation_ids[component_index]},"
+                f"#{shape_representation})"
+            )
+        else:
+            association = None
+        if root_definition is not None and association is not None:
+            occurrence = _component_occurrence(
+                statements, root_definition, component_definition
+            )
+            if occurrence is not None:
+                relationship = entities.add(
+                    f"PRODUCT_DEFINITION_RELATIONSHIP_KINEMATICS("
+                    f"{_step_quote(component['label'] + ' occurrence')},$,"
+                    f"#{occurrence})"
+                )
+                entities.add(
+                    f"CONTEXT_DEPENDENT_KINEMATIC_LINK_REPRESENTATION("
+                    f"#{association},#{relationship})"
+                )
+    if root_definition is not None and link_representation_ids:
+        property_definition = entities.add(
+            f"PRODUCT_DEFINITION_KINEMATICS("
+            f"{_step_quote(manifest['label'] + ' kinematics')},$,"
+            f"#{root_definition})"
+        )
+        base_index = next(
+            (
+                index
+                for index, component in enumerate(manifest["components"])
+                if component["fixed"]
+            ),
+            0,
+        )
+        entities.add(
+            f"KINEMATIC_PROPERTY_MECHANISM_REPRESENTATION("
+            f"#{property_definition},#{mechanism},"
+            f"#{link_representation_ids[base_index]})"
+        )
+    return entities.lines
+
+
+def _as_matrix(values):
+    """Convert serialized nested sequences to a floating-point matrix."""
+    return np.asarray(values, dtype=float)
+
+
+def inject_step_kinematics(step: str | bytes, assembly: Assembly) -> bytes:
+    """Inject native AP242 entities and the exact build123d payload."""
+
+    step_text = step.decode() if isinstance(step, bytes) else step
+    # APIHeaderSection creates FILE_SCHEMA before STEPCAFControl_Writer copies
+    # write.step.schema into the model.  The APD and data are AP242 already;
+    # synchronize the early-created header during this physical-file pass.
+    step_text = re.sub(
+        r"FILE_SCHEMA\s*\(\('[^']*'\)\);",
+        "FILE_SCHEMA(('AP242_MANAGED_MODEL_BASED_3D_ENGINEERING_MIM_LF "
+        "{1 0 10303 442 1 1 4 }'));",
+        step_text,
+        count=1,
+    )
+    manifest = assembly_to_kinematics(assembly)
+    native = _native_kinematics(step_text, manifest)
+    payload = encode_kinematics_payload(manifest)
+    marker = "ENDSEC;\nEND-ISO-10303-21;"
+    if marker not in step_text:
+        raise ValueError("Invalid STEP physical file")
+    insertion = "\n".join(
+        (*native, f"/* {_PAYLOAD_PREFIX}{payload} */", "ENDSEC;", "END-ISO-10303-21;")
+    )
+    return step_text.rsplit(marker, 1)[0].encode() + insertion.encode()
+
+
+__all__ = [
+    "MANIFEST_SCHEMA",
+    "assembly_from_kinematics",
+    "assembly_to_kinematics",
+    "decode_kinematics_payload",
+    "encode_kinematics_payload",
+    "inject_step_kinematics",
+    "read_step_kinematics",
+]

--- a/src/build123d/step_kinematics.py
+++ b/src/build123d/step_kinematics.py
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
 
 
 MANIFEST_SCHEMA = "https://build123d.org/schemas/assembly-kinematics/1"
+MAX_KINEMATICS_PAYLOAD_BYTES = 16 * 1024 * 1024
 _PAYLOAD_PREFIX = "build123d:assembly-kinematics:1:"
 _PAYLOAD_PATTERN = re.compile(
     rb"/\*\s*" + re.escape(_PAYLOAD_PREFIX.encode()) + rb"([A-Za-z0-9+/=]+)\s*\*/"
@@ -420,7 +421,17 @@ def decode_kinematics_payload(payload: str | bytes) -> dict[str, Any]:
     """Decode and validate one build123d STEP kinematics payload."""
 
     raw = payload.encode() if isinstance(payload, str) else payload
-    manifest = json.loads(zlib.decompress(base64.b64decode(raw)))
+    compressed = base64.b64decode(raw, validate=True)
+    decompressor = zlib.decompressobj()
+    decoded = decompressor.decompress(compressed, MAX_KINEMATICS_PAYLOAD_BYTES + 1)
+    if len(decoded) > MAX_KINEMATICS_PAYLOAD_BYTES or decompressor.unconsumed_tail:
+        raise ValueError("build123d assembly kinematics payload exceeds size limit")
+    decoded += decompressor.flush(MAX_KINEMATICS_PAYLOAD_BYTES + 1 - len(decoded))
+    if len(decoded) > MAX_KINEMATICS_PAYLOAD_BYTES:
+        raise ValueError("build123d assembly kinematics payload exceeds size limit")
+    if not decompressor.eof or decompressor.unused_data:
+        raise ValueError("Invalid compressed build123d assembly kinematics payload")
+    manifest = json.loads(decoded)
     if manifest.get("$schema") != MANIFEST_SCHEMA:
         raise ValueError("Unsupported build123d assembly kinematics schema")
     return manifest

--- a/tests/test_assembly_mates.py
+++ b/tests/test_assembly_mates.py
@@ -1,0 +1,940 @@
+"""Tests for persistent Onshape-style assembly mates."""
+
+import copy
+from math import isclose
+
+import numpy as np
+import pytest
+
+import build123d.assembly as assembly_module
+from build123d import (
+    Align,
+    Assembly,
+    Axis,
+    BallMate,
+    Box,
+    Cylinder,
+    CylindricalMate,
+    Edge,
+    Face,
+    FastenedMate,
+    GearRelation,
+    GeomType,
+    GroupMate,
+    LinearRelation,
+    Location,
+    Mate,
+    MateConnector,
+    MateDOF,
+    MateLimit,
+    MateOffset,
+    MateRelation,
+    MateSolveError,
+    ParallelMate,
+    PinSlotMate,
+    PlanarMate,
+    Polyline,
+    Pos,
+    RackAndPinionRelation,
+    RevoluteMate,
+    ScrewRelation,
+    SliderMate,
+    Sphere,
+    TangentMate,
+    Vertex,
+    WidthMate,
+)
+
+
+def assert_vector(vector, expected, tolerance=1e-5):
+    """Assert a build123d vector against a tuple."""
+
+    assert np.allclose(tuple(vector), tuple(expected), atol=tolerance)
+
+
+def connector_pair():
+    """Create two labeled components with one connector each."""
+
+    base = Box(1, 1, 1)
+    base.label = "base"
+    moving = Pos(5, 3, 2) * Box(1, 1, 1)
+    moving.label = "moving"
+    fixed_connector = MateConnector("fixed", base, Location((0, 0, 1)))
+    moving_connector = MateConnector("moving", moving, Location((5, 3, 2)))
+    assembly = Assembly((base, moving), label="pair").ground(base)
+    return assembly, base, moving, fixed_connector, moving_connector
+
+
+@pytest.mark.parametrize(
+    ("mate_type", "values", "position", "orientation"),
+    [
+        (FastenedMate, {}, (0, 0, 1), (0, 0, 0)),
+        (RevoluteMate, {"rz": 30}, (0, 0, 1), (0, 0, 30)),
+        (SliderMate, {"tz": 2}, (0, 0, 3), (0, 0, 0)),
+        (
+            PlanarMate,
+            {"tx": 1, "ty": 2, "rz": 30},
+            (1, 2, 1),
+            (0, 0, 30),
+        ),
+        (
+            CylindricalMate,
+            {"tz": 2, "rz": 30},
+            (0, 0, 3),
+            (0, 0, 30),
+        ),
+        (PinSlotMate, {"tx": 2, "rz": 30}, (2, 0, 1), (0, 0, 30)),
+    ],
+)
+def test_connector_mate_motion(mate_type, values, position, orientation):
+    """Connector mate DOFs follow Onshape's Z-primary coordinate convention."""
+
+    assembly, _, moving, connector1, connector2 = connector_pair()
+    mate = assembly.add_mate(mate_type("mate", connector1, connector2), solve=False)
+    for dof, value in values.items():
+        mate.set_value(dof, value)
+
+    result = assembly.solve()
+
+    assert result.success
+    assert_vector(moving.location.position, position)
+    assert_vector(moving.location.orientation, orientation)
+
+
+def test_ball_mate_preserves_rotation_and_coincides_centers():
+    """Ball mates lock translation while retaining all rotational DOFs."""
+
+    assembly, _, moving, connector1, connector2 = connector_pair()
+    moving.location = Location((5, 3, 2), (20, 10, 30))
+    assembly.add_mate(BallMate("ball", connector1, connector2))
+
+    assert_vector(connector1.location.position, connector2.location.position)
+    assert_vector(moving.location.orientation, (20, 10, 30), tolerance=1e-4)
+
+
+def test_parallel_mate_locks_tilt_only():
+    """Parallel mates leave XYZ translation and Z rotation free."""
+
+    assembly, _, moving, connector1, connector2 = connector_pair()
+    moving.location = Location((5, 3, 2), (25, -15, 40))
+    assembly.add_mate(ParallelMate("parallel", connector1, connector2))
+
+    z1 = np.asarray(tuple(connector1.location.z_axis.direction))
+    z2 = np.asarray(tuple(connector2.location.z_axis.direction))
+    assert np.dot(z1, z2) > 1 - 1e-7
+    assert_vector(moving.location.position, (5, 3, 2), tolerance=1e-4)
+
+
+def test_tangent_mate_propagates_after_fixed_component_moves():
+    """Tangent contact is solved geometrically, including after penetration."""
+
+    base = Box(
+        10,
+        10,
+        1,
+        align=(Align.CENTER, Align.CENTER, Align.MIN),
+    )
+    base.label = "base"
+    ball = Pos(0, 0, 4) * Sphere(1)
+    ball.label = "ball"
+    top = base.faces().sort_by(Axis.Z)[-1]
+    sphere_face = ball.faces()[0]
+    assembly = Assembly((base, ball)).ground(base)
+    assembly.add_mate(
+        TangentMate(
+            "tangent",
+            base,
+            top,
+            ball,
+            sphere_face,
+            propagate=False,
+        )
+    )
+    assert_vector(ball.location.position, (0, 0, 2), tolerance=1e-4)
+
+    base.move(Pos(0, 0, 2))
+    result = assembly.solve(max_iterations=500)
+
+    assert result.success
+    assert_vector(ball.location.position, (0, 0, 4), tolerance=1e-4)
+
+
+def test_tangent_mate_accepts_analytic_faces():
+    """Analytic swept faces are valid Tangent mate selections."""
+
+    # A sphere provides an analytic control selection for the positive case.
+    sphere1 = Sphere(1)
+    sphere2 = Pos(3, 0, 0) * Sphere(1)
+    TangentMate(
+        "analytic",
+        sphere1,
+        sphere1.faces()[0],
+        sphere2,
+        sphere2.faces()[0],
+        propagate=False,
+    )
+
+
+def test_tangent_selection_validation(monkeypatch):
+    """Tangent validates components, selections, and unsupported surfaces."""
+
+    first = Box(1, 1, 1)
+    second = Pos(2, 0, 0) * Box(1, 1, 1)
+    with pytest.raises(ValueError):
+        TangentMate(
+            "same",
+            first,
+            first.faces()[0],
+            first,
+            first.faces()[1],
+        )
+    with pytest.raises(TypeError):
+        TangentMate("bad", first, first, second, second.faces()[0])
+
+    monkeypatch.setattr(
+        Face,
+        "geom_type",
+        property(lambda _: GeomType.BSPLINE),
+    )
+    with pytest.raises(ValueError):
+        TangentMate(
+            "spline",
+            first,
+            first.faces()[0],
+            second,
+            second.faces()[0],
+        )
+
+
+def test_tangent_mate_propagates_across_tangent_edges():
+    """Tangent propagation follows connected edges with continuous tangents."""
+
+    first = Polyline((0, 0), (1, 0), (2, 0))
+    second = Pos(0, 1, 0) * Polyline((0, 0), (1, 0), (2, 0))
+    mate = TangentMate(
+        "edge propagation",
+        first,
+        first.edges()[0],
+        second,
+        second.edges()[0],
+    )
+
+    assert len(mate.entities1) == 2
+    assert len(mate.entities2) == 2
+
+
+def test_tangent_helper_entity_combinations():
+    """Tangent helpers cover face, edge, and vertex selections."""
+
+    box = Box(2, 2, 2)
+    face = box.faces()[0]
+    edge = box.edges()[0]
+    vertex = box.vertices()[0]
+    other_edge = Edge.make_line((10, 0, 0), (11, 0, 0))
+
+    assert not assembly_module._shared_tangent_edge(box.faces()[0], box.faces()[-1])
+    assert not assembly_module._edges_tangent_at_shared_vertex(edge, other_edge)
+    assert assembly_module._propagated_faces(box, face)
+    assert assembly_module._propagated_entities(box, face)
+    assert assembly_module._propagated_faces(Box(1, 1, 1), face) == [face]
+    assert assembly_module._propagated_edges(box, edge)
+    assert assembly_module._propagated_edges(Box(1, 1, 1), other_edge) == [other_edge]
+    assert assembly_module._propagated_entities(box, vertex) == [vertex]
+
+    edge_parameters = assembly_module._entity_parameters(edge, edge.position_at(0.5))
+    assert len(edge_parameters) == 1
+    assert assembly_module._entity_parameters(vertex, vertex.center()) == []
+    for entity in (face, edge, vertex):
+        candidates = assembly_module._parameter_candidates(entity)
+        assert candidates
+        point, direction = assembly_module._entity_point_direction(
+            entity, candidates[0]
+        )
+        assert len(point) == 3
+        assert (direction is None) is isinstance(entity, Vertex)
+
+    face_direction = np.array((0.0, 0.0, 1.0))
+    edge_direction = np.array((1.0, 0.0, 0.0))
+    assert (
+        assembly_module._tangent_alignment_error(
+            vertex, None, edge, edge_direction, False
+        )
+        == 0
+    )
+    assert (
+        assembly_module._tangent_alignment_error(
+            face, face_direction, edge, edge_direction, False
+        )
+        == 0
+    )
+    assert (
+        assembly_module._tangent_alignment_error(
+            edge, edge_direction, other_edge, edge_direction, False
+        )
+        == 0
+    )
+    with pytest.raises(TypeError):
+        assembly_module._EntityReference(box, box)
+
+
+@pytest.mark.parametrize(
+    ("first_kind", "second_kind"),
+    [
+        ("face", "edge"),
+        ("edge", "face"),
+        ("edge", "edge"),
+        ("vertex", "vertex"),
+    ],
+)
+def test_tangent_residual_selection_pairs(first_kind, second_kind):
+    """Every supported Tangent entity pairing produces solver residuals."""
+
+    first = Box(2, 2, 2)
+    second = Pos(3, 0, 0) * Box(2, 2, 2)
+
+    def select(component, kind):
+        return {
+            "face": component.faces()[0],
+            "edge": component.edges()[0],
+            "vertex": component.vertices()[0],
+        }[kind]
+
+    mate = TangentMate(
+        "pair",
+        first,
+        select(first, first_kind),
+        second,
+        select(second, second_kind),
+        propagate=False,
+    )
+    poses = assembly_module._PoseMap(
+        {
+            id(first): assembly_module._location_matrix(first.location),
+            id(second): assembly_module._location_matrix(second.location),
+        }
+    )
+
+    assert mate.residual(poses, 1).size >= 3
+    assert mate.suppress().suppressed
+
+
+def test_width_mate_centers_one_tab_on_slot_plane():
+    """A one-tab Width mate behaves as a planar center constraint."""
+
+    slot = Box(10, 10, 1)
+    slot.label = "slot"
+    tab = Location((0, 6, 0), (-90, 0, 0)) * Box(2, 1, 1)
+    tab.label = "tab"
+    width1 = MateConnector("width1", slot, Location((0, -2, 0)))
+    width2 = MateConnector("width2", slot, Location((0, 2, 0)))
+    tab_connector = MateConnector("tab", tab, tab.location)
+    assembly = Assembly((slot, tab)).ground(slot)
+
+    assembly.add_mate(WidthMate("width", tab_connector, (width1, width2)))
+
+    assert isclose(tab_connector.location.position.Y, 0, abs_tol=1e-5)
+
+
+def test_width_mate_two_tabs_remain_symmetric():
+    """Two Width tabs on separate parts remain mirrored about the center plane."""
+
+    slot = Box(10, 10, 1)
+    slot.label = "slot"
+    tab1 = Location((0, -1, 0), (-90, 0, 0)) * Box(1, 1, 1)
+    tab1.label = "tab1"
+    tab2 = Location((0, 1, 0), (90, 0, 0)) * Box(1, 1, 1)
+    tab2.label = "tab2"
+    width1 = MateConnector("width1", slot, Location((0, -3, 0)))
+    width2 = MateConnector("width2", slot, Location((0, 3, 0)))
+    connector1 = MateConnector("tab1", tab1, tab1.location)
+    connector2 = MateConnector("tab2", tab2, tab2.location)
+    assembly = Assembly((slot, tab1, tab2)).ground(slot)
+
+    assembly.add_mate(WidthMate("width", (connector1, connector2), (width1, width2)))
+    tab1.move(Pos(0, -1, 0))
+    assembly.solve()
+
+    assert isclose(
+        connector1.location.position.Y,
+        -connector2.location.position.Y,
+        abs_tol=1e-5,
+    )
+
+
+def test_width_and_group_validation_and_suppression():
+    """Width and Group validate their multi-component selections."""
+
+    first = Box(1, 1, 1)
+    second = Pos(2, 0, 0) * Box(1, 1, 1)
+    third = Pos(4, 0, 0) * Box(1, 1, 1)
+    first_connector = MateConnector("first", first, first.location)
+    second_connector = MateConnector("second", second, second.location)
+    third_connector = MateConnector("third", third, third.location)
+
+    for tabs, widths in (
+        ((), (second_connector, third_connector)),
+        ((first_connector,), (second_connector,)),
+    ):
+        with pytest.raises(ValueError):
+            WidthMate("width", tabs, widths)
+    with pytest.raises(TypeError):
+        WidthMate(
+            "types",
+            (first_connector,),
+            (second_connector, object()),
+        )
+    with pytest.raises(ValueError):
+        WidthMate(
+            "overlap",
+            first_connector,
+            (first_connector, second_connector),
+        )
+
+    width = WidthMate(
+        "valid",
+        first_connector,
+        (second_connector, third_connector),
+    )
+    assert width.suppress().suppressed
+
+    with pytest.raises(ValueError):
+        GroupMate("few", (first,))
+    with pytest.raises(TypeError):
+        GroupMate("type", (first, object()))
+    with pytest.raises(ValueError):
+        GroupMate("duplicate", (first, first))
+    group = GroupMate("group", (first, second))
+    assert group.suppress().suppressed
+
+
+def test_offsets_flip_and_secondary_reorientation():
+    """Offsets and mate-connector orientation controls remain persistent."""
+
+    assembly, _, moving, connector1, connector2 = connector_pair()
+    mate = FastenedMate(
+        "offset",
+        connector1,
+        connector2,
+        offset=MateOffset((1, 2, 3), (0, 0, 15)),
+        flip_primary=True,
+        reorient_secondary=1,
+    )
+    assembly.add_mate(mate)
+
+    assert_vector(moving.location.position, (1, 2, 4), tolerance=1e-4)
+    assembly.component("base").move(Pos(5, 0, 0))
+    assembly.solve()
+    assert_vector(moving.location.position, (6, 2, 4), tolerance=1e-4)
+
+
+def test_offset_and_limit_validation():
+    """Each mate exposes only the Onshape-supported offset and limit fields."""
+
+    _, _, _, connector1, connector2 = connector_pair()
+    with pytest.raises(ValueError):
+        RevoluteMate(
+            "invalid-offset",
+            connector1,
+            connector2,
+            offset=MateOffset((1, 0, 0)),
+        )
+    with pytest.raises(ValueError):
+        SliderMate(
+            "invalid-limit",
+            connector1,
+            connector2,
+            limits={"rz": (-10, 10)},
+        )
+    with pytest.raises(ValueError):
+        MateLimit(10, -10)
+
+    limited = RevoluteMate(
+        "limited",
+        connector1,
+        connector2,
+        limits={"rz": (-30, 30)},
+    )
+    with pytest.raises(ValueError):
+        limited.set_value("rz", 45)
+
+
+def test_connector_mate_validation_and_coordinate_helpers():
+    """Connector validation covers all public coordinate forms."""
+
+    _, base, _, connector1, connector2 = connector_pair()
+    with pytest.raises(TypeError):
+        FastenedMate("bad", connector1, object())
+    same_component = MateConnector("same", base, Location())
+    with pytest.raises(ValueError):
+        FastenedMate("same", connector1, same_component)
+    with pytest.raises(ValueError):
+        CylindricalMate(
+            "rotation",
+            connector1,
+            connector2,
+            offset=MateOffset(rotation=(10, 0, 0)),
+        )
+    with pytest.raises(ValueError):
+        FastenedMate("fixed", connector1, connector2).set_value("tz", 1)
+
+    slider = SliderMate("slider", connector1, connector2)
+    slider.set_value("tz", 2).set_value("tz", None)
+    assert slider.values == {}
+    assert MateDOF.coerce("TZ") is MateDOF.TZ
+    assert MateLimit(-1, 1).contains(0)
+
+    relative = assembly_module._location_matrix(Location((1, 2, 3), (10, 20, 30)))
+    coordinates = {
+        dof: Mate.coordinate_from_relative(relative, dof)
+        for dof in (
+            MateDOF.TX,
+            MateDOF.TY,
+            MateDOF.TZ,
+            MateDOF.RX,
+            MateDOF.RY,
+            MateDOF.RZ,
+            MateDOF.SWING,
+        )
+    }
+    assert_vector(
+        (
+            coordinates[MateDOF.TX],
+            coordinates[MateDOF.TY],
+            coordinates[MateDOF.TZ],
+        ),
+        (1, 2, 3),
+    )
+
+    limited = SliderMate(
+        "range",
+        connector1,
+        connector2,
+        limits={"tz": (-1, 1)},
+    )
+    below = np.eye(4)
+    below[2, 3] = -2
+    within = np.eye(4)
+    assert limited._limit_residuals(below, 1)[0] < 0
+    assert limited._limit_residuals(within, 1) == [0]
+
+    with pytest.raises(ValueError):
+        assembly_module._normalized(np.zeros(3))
+
+
+def test_ball_conical_swing_limit():
+    """Ball limits are a maximum angular swing away from connector Z."""
+
+    assembly, _, moving, connector1, connector2 = connector_pair()
+    moving.location = Location((5, 3, 2), (60, 0, 0))
+    assembly.add_mate(
+        BallMate("ball", connector1, connector2, limits={"swing": (0, 20)})
+    )
+
+    relative_z = connector1.location.z_axis.direction.get_angle(
+        connector2.location.z_axis.direction
+    )
+    assert relative_z <= 20 + 1e-4
+
+
+def test_suppressed_mate_is_inactive():
+    """Suppression retains a mate while removing it from the solve."""
+
+    assembly, _, moving, connector1, connector2 = connector_pair()
+    mate = FastenedMate("mate", connector1, connector2, suppressed=True)
+    assembly.add_mate(mate)
+    assert_vector(moving.location.position, (5, 3, 2))
+
+    mate.suppress(False)
+    assembly.solve()
+    assert_vector(moving.location.position, (0, 0, 1))
+
+
+def test_inconsistent_mates_report_failure():
+    """Closed constraint graphs fail clearly when their equations conflict."""
+
+    assembly, base, _, connector1, connector2 = connector_pair()
+    assembly.add_mate(
+        FastenedMate("first", connector1, connector2),
+        solve=False,
+    )
+    base_conflict = MateConnector("conflict", base, Location((0, 0, 3)))
+    assembly.add_mate(
+        FastenedMate("second", base_conflict, connector2),
+        solve=False,
+    )
+
+    with pytest.raises(MateSolveError):
+        assembly.solve()
+
+
+def test_assembly_container_validation_and_convenience_methods():
+    """Assembly covers container errors, lookups, grounding, and shortcuts."""
+
+    duplicate1 = Box(1, 1, 1)
+    duplicate1.label = "same"
+    duplicate2 = Box(1, 1, 1)
+    duplicate2.label = "same"
+    with pytest.raises(ValueError):
+        Assembly((duplicate1, duplicate2))
+
+    empty = Assembly()
+    assert empty.components == ()
+    assert empty.solve().success
+    with pytest.raises(TypeError):
+        empty.add(object())
+
+    first = Box(1, 1, 1)
+    first.label = "first"
+    assembly = Assembly((first,))
+    with pytest.raises(ValueError):
+        assembly.add(first)
+    second = Box(1, 1, 1)
+    assembly.add(second, name="second", fixed=True)
+    assert assembly.is_fixed(second)
+    assembly.ground(second, False)
+    assert not assembly.is_fixed(second)
+    with pytest.raises(ValueError):
+        assembly.add(Box(1, 1, 1), name="second")
+    with pytest.raises(KeyError):
+        assembly.component("missing")
+    with pytest.raises(ValueError):
+        assembly.ground(Box(1, 1, 1))
+    with pytest.raises(TypeError):
+        assembly.add_mate(object())
+    with pytest.raises(TypeError):
+        assembly.add_relation(object())
+
+    assert Assembly((Box(1, 1, 1),)).solve().success
+
+    for method_name in (
+        "fastened",
+        "revolute",
+        "slider",
+        "planar",
+        "cylindrical",
+        "pin_slot",
+        "ball",
+        "parallel",
+    ):
+        current, _, _, connector1, connector2 = connector_pair()
+        result = getattr(current, method_name)(
+            method_name, connector1, connector2, solve=False
+        )
+        assert current.mate(method_name) is result
+
+    current, base, moving, _, _ = connector_pair()
+    tangent = current.tangent(
+        "tangent shortcut",
+        base,
+        base.faces()[0],
+        moving,
+        moving.faces()[0],
+        propagate=False,
+        solve=False,
+    )
+    assert current.mate("tangent shortcut") is tangent
+
+    slot = Box(1, 4, 1)
+    tab = Pos(0, 2, 0) * Box(1, 1, 1)
+    width1 = MateConnector("w1", slot, Location((0, -1, 0)))
+    width2 = MateConnector("w2", slot, Location((0, 1, 0)))
+    tab_connector = MateConnector("tab", tab, tab.location)
+    current = Assembly((slot, tab))
+    width = current.width(
+        "width shortcut",
+        tab_connector,
+        (width1, width2),
+        solve=False,
+    )
+    assert current.mate("width shortcut") is width
+
+    group = current.group("group shortcut", (slot, tab), solve=False)
+    assert current.mate("group shortcut") is group
+    with pytest.raises(ValueError):
+        current.add_mate(GroupMate("group shortcut", (slot, tab)), solve=False)
+    with pytest.raises(KeyError):
+        current.mate("missing")
+    with pytest.raises(KeyError):
+        current.relation("missing")
+
+
+def test_assembly_rolls_back_failed_features():
+    """Immediately solved invalid features are removed transactionally."""
+
+    assembly, base, _, connector1, connector2 = connector_pair()
+    assembly.add_mate(FastenedMate("first", connector1, connector2))
+    conflict = MateConnector("conflict", base, Location((0, 0, 3)))
+    with pytest.raises(MateSolveError):
+        assembly.add_mate(FastenedMate("second", conflict, connector2))
+    assert [mate.label for mate in assembly.mates] == ["first"]
+
+    class ImpossibleRelation(MateRelation):
+        @property
+        def mates(self):
+            return (assembly.mates[0],)
+
+        def residual(self, poses, length_scale):
+            return np.ones(1)
+
+    impossible = ImpossibleRelation("impossible")
+    with pytest.raises(MateSolveError):
+        assembly.add_relation(impossible)
+    assert impossible not in assembly.relations
+
+    result = assembly.add_relation(impossible, solve=False)
+    assert assembly.relation("impossible") is result
+    with pytest.raises(ValueError):
+        assembly.add_relation(impossible, solve=False)
+
+
+def test_shallow_copies_are_distinct_component_instances():
+    """Identity-based pose storage supports equal shallow-copy instances."""
+
+    bolt = Cylinder(1, 2)
+    bolt.label = "bolt1"
+    end1 = MateConnector("end", bolt, Location((0, 0, 0)))
+    bolt2 = copy.copy(bolt)
+    bolt2.label = "bolt2"
+    bolt2.move(Pos(5, 0, 0))
+    base = Box(10, 2, 1)
+    base.label = "base"
+    base1 = MateConnector("base1", base, Location((-2, 0, 1)))
+    base2 = MateConnector("base2", base, Location((2, 0, 1)))
+    end2 = bolt2.joints["end"]
+    assembly = Assembly((base, bolt, bolt2)).ground(base)
+    assembly.add_mate(FastenedMate("one", base1, end1), solve=False)
+    assembly.add_mate(FastenedMate("two", base2, end2), solve=False)
+
+    assembly.solve()
+
+    assert_vector(end1.location.position, (-2, 0, 1))
+    assert_vector(end2.location.position, (2, 0, 1))
+
+
+def test_deepcopy_preserves_independent_mates_and_grounding():
+    """Deep-copied assemblies retain independently solvable design intent."""
+
+    assembly, _, moving, connector1, connector2 = connector_pair()
+    mate = assembly.add_mate(RevoluteMate("hinge", connector1, connector2), solve=False)
+    mate.set_value("rz", 15)
+    assembly.solve()
+
+    cloned = copy.deepcopy(assembly)
+    assert cloned.is_fixed(cloned.component("base"))
+    cloned.mate("hinge").set_value("rz", 45)
+    cloned.solve()
+
+    assert isclose(moving.location.orientation.Z, 15, abs_tol=1e-4)
+    assert isclose(
+        cloned.component("moving").location.orientation.Z,
+        45,
+        abs_tol=1e-4,
+    )
+
+
+def test_group_mate_preserves_component_origin_relationships():
+    """A Group mate makes selected origins a persistent rigid cluster."""
+
+    base = Box(1, 1, 1)
+    base.label = "base"
+    first = Pos(2, 0, 0) * Box(1, 1, 1)
+    first.label = "first"
+    second = Pos(2, 3, 0) * Box(1, 1, 1)
+    second.label = "second"
+    assembly = Assembly((base, first, second)).ground(base)
+    assembly.add_mate(GroupMate("rigid cluster", (first, second)), solve=False)
+    connector1 = MateConnector("base", base, Location())
+    connector2 = MateConnector("group", first, first.location)
+    assembly.add_mate(FastenedMate("mount", connector1, connector2))
+
+    base.move(Pos(5, 0, 0))
+    assembly.solve()
+
+    assert_vector(first.location.position, (5, 0, 0), tolerance=1e-4)
+    assert_vector(second.location.position, (5, 3, 0), tolerance=1e-4)
+
+
+def rotational_pair():
+    """Create two revolute components attached to a fixed base."""
+
+    base = Box(1, 1, 1)
+    base.label = "base"
+    first = Pos(3, 0, 0) * Cylinder(1, 1)
+    first.label = "first"
+    second = Pos(-3, 0, 0) * Cylinder(1, 1)
+    second.label = "second"
+    base1 = MateConnector("base1", base, Location((3, 0, 1)))
+    base2 = MateConnector("base2", base, Location((-3, 0, 1)))
+    first_connector = MateConnector("first", first, Location((3, 0, 0)))
+    second_connector = MateConnector("second", second, Location((-3, 0, 0)))
+    assembly = Assembly((base, first, second)).ground(base)
+    mate1 = assembly.add_mate(
+        RevoluteMate("mate1", base1, first_connector), solve=False
+    )
+    mate2 = assembly.add_mate(
+        RevoluteMate("mate2", base2, second_connector), solve=False
+    )
+    assembly.solve()
+    return assembly, mate1, mate2
+
+
+def test_relation_validation_and_suppression():
+    """Mate relations reject incompatible DOFs and nonpositive ratios."""
+
+    _, _, _, connector1, connector2 = connector_pair()
+    revolute = RevoluteMate("revolute", connector1, connector2)
+    slider = SliderMate("slider", connector1, connector2)
+    cylindrical = CylindricalMate("cylindrical", connector1, connector2)
+    parallel = ParallelMate("parallel", connector1, connector2)
+
+    base_relation = MateRelation("base")
+    assert base_relation.suppress().suppressed
+    with pytest.raises(NotImplementedError):
+        _ = base_relation.mates
+    with pytest.raises(NotImplementedError):
+        base_relation.residual({}, 1)
+
+    with pytest.raises(ValueError):
+        GearRelation("missing", slider, revolute)
+    with pytest.raises(ValueError):
+        GearRelation(
+            "wrong kind",
+            parallel,
+            revolute,
+            dof1="tx",
+        )
+    with pytest.raises(ValueError):
+        GearRelation("ratio", revolute, revolute, ratio=0)
+
+    with pytest.raises(ValueError):
+        RackAndPinionRelation(
+            "rotation",
+            parallel,
+            slider,
+            1,
+            rotational_dof="tx",
+        )
+    with pytest.raises(ValueError):
+        RackAndPinionRelation(
+            "linear",
+            revolute,
+            parallel,
+            1,
+            linear_dof="rz",
+        )
+    with pytest.raises(ValueError):
+        RackAndPinionRelation("travel", revolute, slider, 0)
+
+    with pytest.raises(ValueError):
+        ScrewRelation("missing", revolute, 1)
+    with pytest.raises(ValueError):
+        ScrewRelation("travel", cylindrical, 0)
+
+    with pytest.raises(ValueError):
+        LinearRelation(
+            "kind",
+            parallel,
+            slider,
+            dof1="rz",
+        )
+    with pytest.raises(ValueError):
+        LinearRelation("ratio", slider, slider, ratio=0)
+
+
+def test_gear_relation():
+    """Gear relations couple rotational DOFs with ratio and direction."""
+
+    assembly, mate1, mate2 = rotational_pair()
+    assembly.add_relation(GearRelation("gear", mate1, mate2, ratio=2))
+    mate1.set_value("rz", 30)
+    assembly.solve()
+
+    assert isclose(
+        mate2.connector2.parent.location.orientation.Z,
+        -60,
+        abs_tol=1e-4,
+    )
+
+
+def test_rack_and_pinion_relation():
+    """Rack-and-pinion relates rotation to travel per revolution."""
+
+    assembly, rotational, _ = rotational_pair()
+    slider_component = Pos(0, 4, 0) * Box(1, 1, 1)
+    slider_component.label = "rack"
+    slider_base = MateConnector("rack-base", assembly.component("base"), Location())
+    slider_end = MateConnector("rack-end", slider_component, slider_component.location)
+    assembly.add(slider_component)
+    slider = assembly.add_mate(
+        SliderMate("slider", slider_base, slider_end), solve=False
+    )
+    assembly.solve()
+    assembly.add_relation(RackAndPinionRelation("rack", rotational, slider, 20))
+    rotational.set_value("rz", 180)
+    assembly.solve()
+
+    assert isclose(
+        slider.connector2.parent.location.position.Z,
+        10,
+        abs_tol=1e-4,
+    )
+
+
+def test_rack_and_pinion_preserves_multiple_revolutions():
+    """Commanded angles retain turn count when converted to linear travel."""
+
+    assembly, rotational, _ = rotational_pair()
+    slider_component = Pos(0, 4, 0) * Box(1, 1, 1)
+    slider_component.label = "rack"
+    slider_base = MateConnector("rack-base", assembly.component("base"), Location())
+    slider_end = MateConnector("rack-end", slider_component, slider_component.location)
+    assembly.add(slider_component)
+    slider = assembly.add_mate(
+        SliderMate("slider", slider_base, slider_end), solve=False
+    )
+    assembly.solve()
+    assembly.add_relation(RackAndPinionRelation("rack", rotational, slider, 20))
+    rotational.set_value("rz", 720)
+    assembly.solve()
+
+    assert isclose(slider_component.location.position.Z, 40, abs_tol=1e-4)
+
+
+def test_screw_relation():
+    """Screw relations couple two DOFs of one cylindrical mate."""
+
+    assembly, _, moving, connector1, connector2 = connector_pair()
+    mate = assembly.add_mate(
+        CylindricalMate("cylindrical", connector1, connector2), solve=False
+    )
+    assembly.solve()
+    assembly.add_relation(ScrewRelation("screw", mate, 2))
+    initial_z = moving.location.position.Z
+    mate.set_value("rz", 180)
+    assembly.solve()
+
+    assert isclose(moving.location.position.Z, initial_z + 1, abs_tol=1e-4)
+
+
+def test_linear_relation():
+    """Linear relations couple two translational DOFs."""
+
+    base = Box(1, 1, 1)
+    base.label = "base"
+    first = Pos(3, 0, 0) * Box(1, 1, 1)
+    first.label = "first"
+    second = Pos(-3, 0, 0) * Box(1, 1, 1)
+    second.label = "second"
+    base1 = MateConnector("base1", base, Location((3, 0, 0)))
+    base2 = MateConnector("base2", base, Location((-3, 0, 0)))
+    end1 = MateConnector("end1", first, first.location)
+    end2 = MateConnector("end2", second, second.location)
+    assembly = Assembly((base, first, second)).ground(base)
+    mate1 = assembly.add_mate(SliderMate("one", base1, end1), solve=False)
+    mate2 = assembly.add_mate(SliderMate("two", base2, end2), solve=False)
+    assembly.solve()
+    assembly.add_relation(LinearRelation("linear", mate1, mate2, ratio=0.5))
+    mate1.set_value("tz", 4)
+    assembly.solve()
+
+    assert isclose(second.location.position.Z, -2, abs_tol=1e-4)

--- a/tests/test_assembly_mates.py
+++ b/tests/test_assembly_mates.py
@@ -39,8 +39,10 @@ from build123d import (
     RevoluteMate,
     ScrewRelation,
     SliderMate,
+    Shape,
     Sphere,
     TangentMate,
+    Vector,
     Vertex,
     WidthMate,
 )
@@ -275,6 +277,79 @@ def test_tangent_helper_entity_combinations():
     )
     with pytest.raises(TypeError):
         assembly_module._EntityReference(box, box)
+
+
+def test_tangent_helpers_check_every_shared_boundary():
+    """A non-tangent first match does not hide a later tangent boundary."""
+
+    class FakeVertex:
+        def __init__(self, identity):
+            self.identity = identity
+
+        def is_same(self, other):
+            return self.identity == other.identity
+
+        def center(self):
+            return self.identity
+
+    class FakeEdge:
+        def __init__(self, identity, tangents=None):
+            self.identity = identity
+            self.tangents = tangents or {}
+
+        def is_same(self, other):
+            return self.identity == other.identity
+
+        def position_at(self, _):
+            return self.identity
+
+        def vertices(self):
+            return [FakeVertex("first"), FakeVertex("second")]
+
+        def tangent_at(self, point):
+            return self.tangents[point]
+
+    class FakeFace:
+        def __init__(self, edges, normals):
+            self._edges = edges
+            self.normals = normals
+
+        def edges(self):
+            return self._edges
+
+        def normal_at(self, point):
+            return self.normals[point]
+
+    edges1 = [FakeEdge("first"), FakeEdge("second")]
+    edges2 = [FakeEdge("first"), FakeEdge("second")]
+    face1 = FakeFace(edges1, {"first": Vector(1, 0, 0), "second": Vector(0, 1, 0)})
+    face2 = FakeFace(edges2, {"first": Vector(0, 1, 0), "second": Vector(0, 1, 0)})
+    assert assembly_module._shared_tangent_edge(face1, face2)
+
+    edge1 = FakeEdge("edge1", {"first": Vector(1, 0, 0), "second": Vector(0, 1, 0)})
+    edge2 = FakeEdge("edge2", {"first": Vector(0, 1, 0), "second": Vector(0, 1, 0)})
+    assert assembly_module._edges_tangent_at_shared_vertex(edge1, edge2)
+
+
+def test_tangent_parameter_preparation_does_not_repeat_distance(monkeypatch):
+    """Tangent pair selection performs only the closest-point distance query."""
+
+    first = Sphere(1)
+    second = Pos(3, 0, 0) * Sphere(1)
+    mate = TangentMate(
+        "tangent", first, first.faces()[0], second, second.faces()[0], propagate=False
+    )
+    poses = {
+        first: assembly_module._location_matrix(first.location),
+        second: assembly_module._location_matrix(second.location),
+    }
+    monkeypatch.setattr(
+        Shape,
+        "distance_to",
+        lambda *_: pytest.fail("distance_to should not be called"),
+    )
+
+    mate.prepare_parameters(poses)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_step_kinematics.py
+++ b/tests/test_step_kinematics.py
@@ -1,0 +1,271 @@
+"""AP242 and lossless STEP tests for persistent assembly mates."""
+
+from io import BytesIO
+
+import pytest
+from OCP.IFSelect import IFSelect_ReturnStatus
+from OCP.STEPControl import STEPControl_Reader
+
+from build123d import (
+    Assembly,
+    BallMate,
+    Box,
+    CylindricalMate,
+    FastenedMate,
+    GroupMate,
+    Location,
+    MateConnector,
+    MateLimit,
+    MateOffset,
+    ParallelMate,
+    PinSlotMate,
+    PlanarMate,
+    RevoluteMate,
+    ScrewRelation,
+    SliderMate,
+    assembly_to_kinematics,
+    export_step,
+    import_step_assembly,
+    read_step_kinematics,
+)
+
+
+def connector_assembly():
+    """Create a grounded two-component assembly and two connector frames."""
+
+    base = Box(2, 2, 2)
+    base.label = "base"
+    moving = Box(1, 1, 1).moved(Location((4, 0, 0)))
+    moving.label = "moving"
+    assembly = Assembly((base, moving), label="mechanism").ground(base)
+    first = MateConnector("first", base, Location((0, 0, 1)))
+    second = MateConnector("second", moving, Location((4, 0, 0)))
+    return assembly, first, second
+
+
+@pytest.mark.parametrize(
+    ("mate_type", "limits", "entity_name"),
+    [
+        (FastenedMate, {}, "FULLY_CONSTRAINED_PAIR"),
+        (RevoluteMate, {"rz": (-45, 90)}, "REVOLUTE_PAIR_WITH_RANGE"),
+        (SliderMate, {"tz": (-2, 4)}, "PRISMATIC_PAIR_WITH_RANGE"),
+        (
+            PlanarMate,
+            {"tx": (-2, 4), "ty": (-3, 5), "rz": (-45, 90)},
+            "PLANAR_PAIR_WITH_RANGE",
+        ),
+        (
+            CylindricalMate,
+            {"tz": (-2, 4), "rz": (-45, 90)},
+            "CYLINDRICAL_PAIR_WITH_RANGE",
+        ),
+        (
+            PinSlotMate,
+            {"tx": (-2, 4), "rz": (-45, 90)},
+            "LOW_ORDER_KINEMATIC_PAIR_WITH_RANGE",
+        ),
+        (BallMate, {"swing": (0, 35)}, "SPHERICAL_PAIR"),
+        (
+            ParallelMate,
+            {"tx": (-2, 4), "rz": (-45, 90)},
+            "LOW_ORDER_KINEMATIC_PAIR_WITH_RANGE",
+        ),
+    ],
+)
+def test_native_ap242_pair_types(tmp_path, mate_type, limits, entity_name):
+    """Every connector mate has the closest valid native AP242 pair."""
+
+    assembly, first, second = connector_assembly()
+    assembly.add_mate(
+        mate_type(
+            "test mate",
+            first,
+            second,
+            limits=limits,
+            onshape_parameters=[
+                {
+                    "parameterId": "limitEulerConeAngleMax",
+                    "expression": "0.610865238198 rad",
+                }
+            ],
+        ),
+        solve=False,
+    )
+    output = tmp_path / "kinematics.step"
+
+    export_step(assembly, output)
+    text = output.read_text()
+
+    assert "AP242_MANAGED_MODEL_BASED_3D_ENGINEERING_MIM_LF" in text
+    assert f"{entity_name}(" in text
+    assert "KINEMATIC_LINK(" in text
+    assert "KINEMATIC_JOINT(" in text
+    assert "MECHANISM_STATE_REPRESENTATION(" in text
+    manifest = read_step_kinematics(text)
+    assert manifest is not None
+    assert manifest["mates"][0]["onshape"]["parameters"][0] == {
+        "parameterId": "limitEulerConeAngleMax",
+        "expression": "0.610865238198 rad",
+    }
+
+    reader = STEPControl_Reader()
+    assert reader.ReadFile(str(output)) == IFSelect_ReturnStatus.IFSelect_RetDone
+
+
+def test_ball_cone_limit_keeps_onshape_semantics(tmp_path):
+    """The Onshape cone parameter stays exact instead of becoming Euler limits."""
+
+    assembly, first, second = connector_assembly()
+    assembly.add_mate(
+        BallMate(
+            "ball",
+            first,
+            second,
+            limits={"swing": MateLimit(0, 27.5)},
+            onshape_parameters=[
+                {
+                    "type": 149,
+                    "parameterId": "limitEulerConeAngleMax",
+                    "expression": "27.5 deg",
+                    "value": 0.479965544298,
+                }
+            ],
+        ),
+        solve=False,
+    )
+    output = tmp_path / "ball.step"
+
+    export_step(assembly, output)
+    mate = read_step_kinematics(output.read_bytes())["mates"][0]
+
+    assert mate["onshape"]["values"]["limitEulerConeAngleMax"] == 27.5
+    assert mate["onshape"]["parameters"][0]["expression"] == "27.5 deg"
+    assert "conical swing limit" in mate["ap242"]["extensionReasons"][0]
+
+
+def test_pair_placements_include_offset_and_axis_alignment(tmp_path):
+    """Native pair frames incorporate offset, flip, and secondary reorientation."""
+
+    assembly, first, second = connector_assembly()
+    mate = RevoluteMate(
+        "offset hinge",
+        first,
+        second,
+        offset=MateOffset((0, 0, 3), (10, 20, 30)),
+        flip_primary=True,
+        reorient_secondary=3,
+    )
+    assembly.add_mate(mate, solve=False)
+    output = tmp_path / "offset.step"
+
+    export_step(assembly, output)
+    stored = read_step_kinematics(output.read_bytes())["mates"][0]
+
+    assert (
+        stored["connectors"][1]["relativeTransform"] != stored["ap242"]["placements"][1]
+    )
+    assert stored["offset"]["translation"] == [0, 0, 3]
+    assert stored["offset"]["rotation"] == [10, 20, 30]
+    assert stored["flipPrimary"] is True
+    assert stored["reorientSecondary"] == 3
+
+
+def test_group_mate_expands_to_rigid_pairs(tmp_path):
+    """Each additional Group member is connected by a native rigid pair."""
+
+    components = []
+    for index in range(3):
+        component = Box(1, 1, 1).moved(Location((index * 2, 0, 0)))
+        component.label = f"part {index}"
+        components.append(component)
+    assembly = Assembly(components, label="group mechanism")
+    assembly.add_mate(GroupMate("group", components), solve=False)
+    output = tmp_path / "group.step"
+
+    export_step(assembly, output)
+    text = output.read_text()
+
+    assert text.count("FULLY_CONSTRAINED_PAIR(") == 2
+    assert read_step_kinematics(text)["mates"][0]["relativeTransforms"]
+
+
+def test_lossless_round_trip_restores_relation_and_raw_parameters(tmp_path):
+    """build123d rehydrates mate intent that generic AP242 cannot represent."""
+
+    assembly, first, second = connector_assembly()
+    mate = CylindricalMate(
+        "cylinder",
+        first,
+        second,
+        limits={"tz": (-5, 8), "rz": (-180, 180)},
+        onshape_parameters=[
+            {"parameterId": "limitsEnabled", "value": True},
+            {"parameterId": "limitZMin", "expression": "-0.5 cm"},
+        ],
+    )
+    mate.set_value("tz", 2)
+    mate.set_value("rz", 30)
+    assembly.add_mate(mate, solve=False)
+    relation = ScrewRelation(
+        "lead",
+        mate,
+        1.25,
+        reverse=True,
+        onshape_parameters=[
+            {"parameterId": "relationType", "value": "SCREW"},
+            {"parameterId": "pitch", "expression": "1.25 mm"},
+        ],
+    )
+    relation._phase = 0.125
+    assembly.add_relation(relation, solve=False)
+    output = tmp_path / "roundtrip.step"
+
+    export_step(assembly, output)
+    restored = import_step_assembly(output)
+
+    assert isinstance(restored, Assembly)
+    assert restored.label == assembly.label
+    assert restored.is_fixed(restored.component("base"))
+    assert isinstance(restored.mate("cylinder"), CylindricalMate)
+    restored_mate = restored.mate("cylinder")
+    assert restored_mate.values == mate.values
+    assert restored_mate.limits == mate.limits
+    assert restored_mate.onshape_parameters == mate.onshape_parameters
+    restored_relation = restored.relation("lead")
+    assert isinstance(restored_relation, ScrewRelation)
+    assert restored_relation.travel_per_revolution == 1.25
+    assert restored_relation.reverse is True
+    assert restored_relation._phase == 0.125
+    assert restored_relation.onshape_parameters == relation.onshape_parameters
+
+
+def test_bytes_io_and_opt_out():
+    """Kinematics support works in memory and remains explicitly optional."""
+
+    assembly, first, second = connector_assembly()
+    assembly.add_mate(RevoluteMate("hinge", first, second), solve=False)
+    stream = BytesIO()
+
+    export_step(assembly, stream)
+
+    assert read_step_kinematics(stream.getvalue()) is not None
+    assert b"REVOLUTE_PAIR_WITH_RANGE" in stream.getvalue()
+
+    without_kinematics = BytesIO()
+    export_step(assembly, without_kinematics, write_kinematics=False)
+    assert read_step_kinematics(without_kinematics.getvalue()) is None
+    assert b"KINEMATIC_LINK" not in without_kinematics.getvalue()
+
+
+def test_manifest_records_relation_loss_boundary():
+    """The manifest makes every standard-versus-extension boundary explicit."""
+
+    assembly, first, second = connector_assembly()
+    mate = CylindricalMate("cylinder", first, second)
+    assembly.add_mate(mate, solve=False)
+    assembly.add_relation(ScrewRelation("lead", mate, 2), solve=False)
+
+    record = assembly_to_kinematics(assembly)["relations"][0]
+
+    assert record["ap242"]["pairType"] is None
+    assert record["ap242"]["extensionReasons"]

--- a/tests/test_step_kinematics.py
+++ b/tests/test_step_kinematics.py
@@ -6,6 +6,8 @@ import pytest
 from OCP.IFSelect import IFSelect_ReturnStatus
 from OCP.STEPControl import STEPControl_Reader
 
+import build123d.step_kinematics as step_kinematics
+
 from build123d import (
     Assembly,
     BallMate,
@@ -255,6 +257,33 @@ def test_bytes_io_and_opt_out():
     export_step(assembly, without_kinematics, write_kinematics=False)
     assert read_step_kinematics(without_kinematics.getvalue()) is None
     assert b"KINEMATIC_LINK" not in without_kinematics.getvalue()
+
+
+def test_binary_file_handle_supports_kinematics(tmp_path):
+    """Kinematics post-processing supports generic writable binary streams."""
+
+    assembly, first, second = connector_assembly()
+    assembly.add_mate(RevoluteMate("hinge", first, second), solve=False)
+    output = tmp_path / "stream.step"
+
+    with output.open("wb") as stream:
+        export_step(assembly, stream)
+
+    data = output.read_bytes()
+    assert read_step_kinematics(data) is not None
+    assert b"REVOLUTE_PAIR_WITH_RANGE" in data
+
+
+def test_payload_decompression_is_bounded(monkeypatch):
+    """Compressed metadata cannot expand beyond the configured size limit."""
+
+    monkeypatch.setattr(step_kinematics, "MAX_KINEMATICS_PAYLOAD_BYTES", 128)
+    payload = step_kinematics.encode_kinematics_payload(
+        {"$schema": step_kinematics.MANIFEST_SCHEMA, "padding": "x" * 1024}
+    )
+
+    with pytest.raises(ValueError, match="exceeds size limit"):
+        step_kinematics.decode_kinematics_payload(payload)
 
 
 def test_manifest_records_relation_loss_boundary():


### PR DESCRIPTION
## Summary

Adds a persistent assembly constraint system alongside the existing one-shot Joint positioning API, then makes it portable through AP242 STEP.

- introduces `Assembly`, an exportable `Compound` that retains mates, relations, grounding, and solve diagnostics
- uses `MateConnector` as a `RigidJoint`-compatible local coordinate frame (Z primary, X secondary)
- solves all active constraints simultaneously with explicit/implicit grounding, underconstraint regularization, limits, driven values, suppression, and clear inconsistency errors
- preserves mate design intent and connector rebinding through deep copies

## Onshape-compatible feature surface

Connector/entity mates:

- Fastened
- Revolute
- Slider
- Planar
- Cylindrical
- Pin Slot
- Ball, including the single conical swing limit exposed by Onshape as `limitEulerConeAngleMax`
- Parallel
- Tangent, including face/edge/vertex selections, swept/analytic-face validation, flip behavior, and tangent propagation
- Width, with one/two tab connectors and two width connectors
- Group, capturing component-origin relationships without geometry dependencies

Mate relations:

- Gear
- Rack and Pinion
- Screw
- Linear

Raw Onshape API parameter objects can be attached to every mate/relation with `onshape_parameters`; order, parameter IDs, expressions, values, and extra fields are copied and retained exactly.

## AP242 STEP kinematics

`export_step()` now detects an `Assembly` with mates and writes AP242 by default. The file contains:

- standard `KINEMATIC_LINK`, `KINEMATIC_JOINT`, pair, range, mechanism, state, and product/geometry association entities
- native Fastened, Revolute, Slider, Planar, Cylindrical, Ball, and generic low-order Pin Slot/Parallel pairs
- offsets plus primary/secondary alignment incorporated into the native pair frames
- Group expanded into fully constrained pairs
- current pair values and finite/unbounded ranges in the appropriate STEP units
- a deterministic, versioned, compressed build123d payload in a legal Part 21 comment for exact round trips

`import_step_assembly()` restores the geometry, mate objects, raw Onshape fields, limits, values, suppression, connectors, offsets, selected entities, Group transforms, relations, ratio/travel/reverse settings, and relation phase. `write_kinematics=False` keeps the prior geometry-only behavior.

### Explicit interoperability boundary

No build123d/Onshape information is discarded. Some feature intent has no faithful one-to-one native AP242 entity, so it is retained in the versioned payload:

- Onshape Ball uses one cone-angle limit; AP242 spherical ranges use independent angular coordinates
- Tangent propagation/selections and Width centering are not single AP242 low-order pairs
- Pin Slot and Parallel have motion-compatible generic low-order pairs but no native feature identity
- Gear lacks the two absolute pitch radii required by AP242 when only an Onshape ratio is available
- mate-coordinate Gear/Rack-and-Pinion/Screw/Linear relations do not always describe one adjacent-link AP242 motion-coupling pair

Generic AP242 readers therefore get the faithful standard subset; build123d gets a lossless round trip including every extension detail.

## Validation

- full suite: `2202 passed, 2 skipped, 64 subtests passed`
- focused mate/export/import suite: `120 passed`
- new AP242 tests cover all connector pair families, Ball cone semantics, offset/alignment frames, Group expansion, raw API payloads, relation round-trip, byte streams, opt-out, and OCCT STEP parsing
- touched-module pylint: `10.00/10`, no errors/fatals
- Black and `git diff --check`: clean

## Documentation

Updates the persistent-mates guide with AP242 behavior, lossless round-trip usage, and the explicit standards boundary.
