### PR TITLE
Raise error for missing STL export directory

### DIFF
--- a/src/build123d/exporters3d.py
+++ b/src/build123d/exporters3d.py
@@ -469,7 +469,14 @@ def export_stl(
 
     Returns:
         bool: Success
+
+    Raises:
+        FileNotFoundError: The destination directory does not exist.
     """
+    output_path = Path(fsdecode(file_path))
+    if not output_path.parent.exists():
+        raise FileNotFoundError(output_path.parent)
+
     mesh = BRepMesh_IncrementalMesh(
         to_export.wrapped, tolerance, True, angular_tolerance, True
     )
@@ -478,7 +485,7 @@ def export_stl(
     writer = StlAPI_Writer()
 
     writer.ASCIIMode = ascii_format
-    return writer.Write(to_export.wrapped, fsdecode(file_path))
+    return writer.Write(to_export.wrapped, str(output_path))
 
 
 def export_to_pcbway(

--- a/src/build123d/exporters3d.py
+++ b/src/build123d/exporters3d.py
@@ -474,7 +474,7 @@ def export_stl(
         FileNotFoundError: The destination directory does not exist.
     """
     output_path = Path(fsdecode(file_path))
-    if not output_path.parent.exists():
+    if not output_path.parent.is_dir():
         raise FileNotFoundError(output_path.parent)
 
     mesh = BRepMesh_IncrementalMesh(

--- a/tests/test_exporters3d.py
+++ b/tests/test_exporters3d.py
@@ -406,6 +406,14 @@ def test_export_stl_missing_destination_directory(tmp_path):
         export_stl(Box(1, 1, 1), output_path)
 
 
+def test_export_stl_destination_parent_is_file(tmp_path):
+    parent_path = tmp_path / "not-a-directory"
+    parent_path.touch()
+
+    with pytest.raises(FileNotFoundError, match="not-a-directory"):
+        export_stl(Box(1, 1, 1), parent_path / "box.stl")
+
+
 @pytest.mark.parametrize("exporter", (export_step, export_brep))
 def test_exporters_in_memory(exporter):
     buffer = io.BytesIO()

--- a/tests/test_exporters3d.py
+++ b/tests/test_exporters3d.py
@@ -399,6 +399,13 @@ def test_pathlike_exporters(tmp_path, format, exporter):
     exporter(box, path)
 
 
+def test_export_stl_missing_destination_directory(tmp_path):
+    output_path = tmp_path / "missing" / "box.stl"
+
+    with pytest.raises(FileNotFoundError, match="missing"):
+        export_stl(Box(1, 1, 1), output_path)
+
+
 @pytest.mark.parametrize("exporter", (export_step, export_brep))
 def test_exporters_in_memory(exporter):
     buffer = io.BytesIO()


### PR DESCRIPTION
## Summary

- validate the STL destination parent directory before meshing
- raise `FileNotFoundError` when the directory is missing
- add a focused regression test for the reported case

Closes #1379

## Validation

- `.venv/bin/python -m pytest tests/test_exporters3d.py -q` — 34 passed
- diff coverage — 100% (4/4 changed source lines)
- Black — changed source file and test hunk clean
- pylint — 10.00/10 for `src/build123d/exporters3d.py`
- mypy — no issues in the changed source and test files
- full `pytest -n auto --benchmark-disable` — 2151 passed, 2 skipped, with one unrelated local macOS font-database failure in `TestFontManager.test_register_system_fonts`; the failing test persists in isolation
