### PR TITLE
Declare fontTools as a direct dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "svgpathtools >= 1.5.1, < 2",
     "anytree >= 2.8.0, < 3",
     "ezdxf >= 1.1.0, < 2",
+    "fonttools >= 4.39.0, < 5",
     "ipython >= 8.0.0, < 10",
     "ocpsvg >= 0.6, < 0.7",
     "ocp_gordon >= 0.2, < 0.3",


### PR DESCRIPTION
## Summary

- declare `fonttools` as a direct runtime dependency
- require 4.39.0 or newer because 4.39.0 is the first tested release that exposes `TTLibFileIsCollectionError` alongside the other APIs imported by `build123d.text`
- follow the existing dependency policy by limiting the requirement to the current major version

## Validation

- `fonttools==4.38.0`: confirmed `TTLibFileIsCollectionError` cannot be imported
- `fonttools==4.39.0`: confirmed `TTFont`, `TTLibFileIsCollectionError`, and `ttCollection` can be imported
- `uv run --extra development --with 'fonttools==4.39.0' python -m pytest tests/test_text.py -q` (9 passed)
- `uv run --extra development --with 'fonttools==4.39.0' python -m pytest -n auto` (2180 passed, 2 skipped)

Closes #1393
