### PR TITLE
Accept iterators in Locations

### DIFF
--- a/src/build123d/build_common.py
+++ b/src/build123d/build_common.py
@@ -134,8 +134,8 @@ def flatten_sequence(*obj: T) -> ShapeList[Any]:
     flat_list: ShapeList[Any] = ShapeList()
     for item in obj:
         # Note: an Iterable can't be used here as it will match with Vector & Vertex
-        # and break them into a list of floats.
-        if isinstance(item, (list, tuple, filter, set)) and not _is_point(item):
+        # and break them into a list of floats. Iterators are safe to consume.
+        if isinstance(item, (list, tuple, set, Iterator)) and not _is_point(item):
             flat_list.extend(flatten_sequence(*item))
         else:
             flat_list.append(item)

--- a/tests/test_build_common.py
+++ b/tests/test_build_common.py
@@ -87,6 +87,12 @@ class TestFlattenSequence(unittest.TestCase):
             flatten_sequence("a", ("b", "c", "d"), "e"), ["a", "b", "c", "d", "e"]
         )
 
+    def test_iterators(self):
+        self.assertListEqual(flatten_sequence(map(str, range(3))), ["0", "1", "2"])
+        self.assertListEqual(
+            flatten_sequence(str(value) for value in range(3)), ["0", "1", "2"]
+        )
+
     def test_points(self):
         self.assertListEqual(
             flatten_sequence("a", (1, 2, 3), "e"), ["a", (1, 2, 3), "e"]
@@ -495,6 +501,17 @@ class TestLocations(unittest.TestCase):
         self.assertTupleAlmostEquals(locs.locations[1].position, (2, 3, 0), 5)
         self.assertTupleAlmostEquals(locs.locations[2].position, (4, 5, 0), 5)
         self.assertTupleAlmostEquals(locs.locations[3].position, (6, 7, 0), 5)
+
+    def test_iterator_input(self):
+        for points in (
+            map(lambda value: (value, 0), [10, 20, 30]),
+            ((value, 0) for value in [10, 20, 30]),
+        ):
+            locs = Locations(points)
+            self.assertListEqual(
+                [tuple(location.position) for location in locs.locations],
+                [(10, 0, 0), (20, 0, 0), (30, 0, 0)],
+            )
 
 
 class TestProperties(unittest.TestCase):


### PR DESCRIPTION
## Summary

- flatten iterator inputs such as `map`, generators, `filter`, and list iterators
- keep the narrower iterator check instead of accepting every `Iterable`, so iterable geometry types such as `Vector` and `Vertex` remain atomic
- add regression coverage for both `flatten_sequence` and `Locations`

## Validation

- `uv run --no-sync python -m pytest tests/test_build_common.py::TestFlattenSequence tests/test_build_common.py::TestLocations -q` (24 passed)
- `uv run --no-sync python -m pytest -n auto` (2182 passed, 2 skipped)
- Black checks passed for the changed ranges
- `uv run --no-sync pylint src/build123d/build_common.py` (10.00/10)
- `uv run --no-sync mypy src/build123d/build_common.py` (no issues)

Closes #1359
