### PR TITLE
Preserve labels for 3MF assembly children

### DIFF
--- a/src/build123d/mesher.py
+++ b/src/build123d/mesher.py
@@ -393,10 +393,16 @@ class Mesher:
             Warning: Degenerate shape skipped
             Warning: 3mf mesh is not manifold
         """
-        shapes = []
-        for input_shape in shape if isinstance(shape, Iterable) else [shape]:
+        shapes: list[Shape] = []
+        input_shapes = [shape] if isinstance(shape, Shape) else shape
+        for input_shape in input_shapes:
             if isinstance(input_shape, Compound):
-                shapes.extend(list(input_shape))
+                if input_shape.children:
+                    shapes.extend(input_shape.children)
+                elif input_shape.label:
+                    shapes.append(input_shape)
+                else:
+                    shapes.extend(list(input_shape))
             else:
                 shapes.append(input_shape)
 

--- a/tests/test_mesher.py
+++ b/tests/test_mesher.py
@@ -179,6 +179,33 @@ class TestAddShape(DirectApiTestCase):
         shapes = importer.read(filename)
         self.assertEqual(importer.mesh_count, 2)
 
+    def test_add_labeled_compounds(self):
+        labels = ["A", "B", "C"]
+        for use_assembly in (False, True):
+            with self.subTest(use_assembly=use_assembly):
+                parts = [
+                    Box(1, 1, 1).locate(Location((index * 2, 0, 0)))
+                    for index in range(3)
+                ]
+                for part, label in zip(parts, labels):
+                    part.label = label
+
+                input_shape = Compound(children=parts) if use_assembly else parts
+                exporter = Mesher()
+                exporter.add_shape(input_shape)
+                filename = temp_3mf_file()
+                exporter.write(filename)
+
+                importer = Mesher()
+                importer.read(filename)
+                self.assertEqual(
+                    [
+                        properties["name"]
+                        for properties in importer.get_mesh_properties()
+                    ],
+                    labels,
+                )
+
 
 class TestErrorChecking(unittest.TestCase):
     def test_read_invalid_file(self):

--- a/tests/test_mesher.py
+++ b/tests/test_mesher.py
@@ -15,7 +15,7 @@ from build123d.exporters3d import export_stl
 from build123d.objects_part import Box, Cylinder
 from build123d.objects_sketch import Rectangle
 from build123d.operations_part import extrude
-from build123d.topology import Compound, Solid
+from build123d.topology import Compound, Part, Solid
 from build123d.geometry import Axis, Color, Location, Vector, VectorLike
 from build123d.mesher import Mesher
 
@@ -205,6 +205,26 @@ class TestAddShape(DirectApiTestCase):
                     ],
                     labels,
                 )
+
+    def test_add_labeled_part(self):
+        part = Part(
+            Compound(
+                [
+                    Box(1, 1, 1),
+                    Box(1, 1, 1).locate(Location((2, 0, 0))),
+                ]
+            ).wrapped,
+            label="assembly",
+        )
+        exporter = Mesher()
+        exporter.add_shape(part)
+        filename = temp_3mf_file()
+        exporter.write(filename)
+
+        importer = Mesher()
+        importer.read(filename)
+        self.assertEqual(importer.mesh_count, 1)
+        self.assertEqual(importer.get_mesh_properties()[0]["name"], "assembly")
 
 
 class TestErrorChecking(unittest.TestCase):


### PR DESCRIPTION
## Summary

- treat a single `Shape` as a shape before considering its iterable behavior, so labeled Part objects are not prematurely flattened
- export semantic assembly children directly and preserve their labels
- retain the existing behavior of splitting an unlabeled topological `Compound` into separate meshes
- add 3MF write/read regression coverage for both a list of labeled Part objects and `Compound(children=...)`

## Validation

- reproduced the issue before the change: both input forms produced three unnamed meshes
- verified the original labeled-sphere assembly now produces `A`, `B`, and `C`
- `uv run --no-sync python -m pytest tests/test_mesher.py -q` (21 passed, 5 subtests passed)
- `uv run --no-sync python -m pytest -n auto` (2181 passed, 2 skipped)
- Black checks passed for the changed ranges
- `uv run --no-sync pylint src/build123d/mesher.py` (10.00/10)
- `uv run --no-sync mypy src/build123d/mesher.py` (no issues)

Closes #1375
