### PR TITLE
Warn when Plane ignores origin with a Face

### DIFF
--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -2901,6 +2901,11 @@ class Plane(metaclass=PlaneMeta):
             surface = BRep_Tool.Surface_s(arg_face.wrapped)
             if not arg_face.is_planar:
                 raise ValueError("Planes can only be created from planar faces")
+            if arg_origin is not None:
+                warnings.warn(
+                    "The origin parameter is ignored when creating a Plane from a Face",
+                    stacklevel=2,
+                )
             properties = GProp_GProps()
             BRepGProp.SurfaceProperties_s(arg_face.wrapped, properties)
             origin = Vector(properties.CentreOfMass())

--- a/tests/test_direct_api/test_plane.py
+++ b/tests/test_direct_api/test_plane.py
@@ -234,6 +234,20 @@ class TestPlane(unittest.TestCase):
             self.assertAlmostEqual(p.y_dir, expected[i][1], 6)
             self.assertAlmostEqual(p.z_dir, expected[i][2], 6)
 
+    def test_plane_from_face_with_origin_warns(self):
+        face = Face.make_rect(1, 1)
+        for args, kwargs in [
+            ((face,), {"origin": (1, 2, 3)}),
+            ((), {"face": face, "origin": (1, 2, 3)}),
+        ]:
+            with self.subTest(args=args, kwargs=kwargs):
+                with self.assertWarnsRegex(
+                    UserWarning,
+                    "origin parameter is ignored when creating a Plane from a Face",
+                ):
+                    plane = Plane(*args, **kwargs)
+                self.assertAlmostEqual(plane.origin, (0, 0, 0), 6)
+
     def test_plane_from_axis(self):
         origin = Vector(1, 2, 3)
         direction = Vector(0, 0, 1)


### PR DESCRIPTION
## Summary

- warn when `origin` is ignored while constructing a `Plane` from a `Face`
- preserve the existing face-center behavior
- cover positional and keyword `face` construction paths

## Validation

- `python -m pytest tests/test_direct_api/test_plane.py -q`
- `python -m pytest -n auto --benchmark-disable`
- `pylint --rcfile=.pylintrc --fail-under=9.5 --fail-on=E,F src/build123d`
- `mypy --config-file mypy.ini src/build123d`

Closes #1371
