### PR TITLE
docs: clarify constrained geometry terminology

### DIFF
--- a/docs/tutorial_constraints.rst
+++ b/docs/tutorial_constraints.rst
@@ -500,9 +500,12 @@ Overview
 
 1. Two curve-tangency or point-incidence targets + fixed radius
 2. Two curve-tangency or point-incidence targets + center constrained on a locus
-3. Three curve-tangency or point-incidence targets
+3. Three curve-tangency targets
 4. One curve-tangency or point-incidence target + fixed center
 5. One curve-tangency or point-incidence target + fixed radius + center constrained on a locus
+
+Point inputs are supported by signatures 1, 2, 4, and 5. The three-target
+signature requires curve inputs.
 
 ``sagitta`` selects short/long/both arc branches:
 
@@ -566,8 +569,8 @@ Signature C: Three constraints
 .. figure:: ./assets/tan3_ex.svg
    :align: center
 
-Use for an arc constrained by three curve-tangency or point-incidence targets. This can
-produce several branches; always consider using ``selector``.
+Use for an arc tangent to three curve targets. This can produce several branches;
+always consider using ``selector``.
 
 Signature D: One constraint + fixed ``center``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/tutorial_constraints.rst
+++ b/docs/tutorial_constraints.rst
@@ -410,8 +410,9 @@ Tangency Constraints
 Both :class:`~objects_curve.ConstrainedArcs` and :class:`~objects_curve.ConstrainedLines` 
 return a :class:`~topology.Curve` containing one or more :class:`~topology.Edge` objects.
 
-These constructors solve tangent/contact problems from mixed numeric and geometric inputs.
-Because tangency is often ambiguous, multiple valid branches are expected.
+These constructors combine curve-tangency constraints with point-incidence, center-locus,
+and orientation constraints. Because tangency is often ambiguous, multiple valid branches
+are expected.
 
 
 Multiple solutions
@@ -497,11 +498,11 @@ Overview
 
 :class:`~objects_curve.ConstrainedArcs` supports several signature families for planar circular arcs:
 
-1. Two tangency/contact objects + fixed radius
-2. Two tangency/contact objects + center constrained on a locus
-3. Three tangency/contact objects
-4. One tangency/contact object + fixed center
-5. One tangency/contact object + fixed radius + center constrained on a locus
+1. Two curve-tangency or point-incidence targets + fixed radius
+2. Two curve-tangency or point-incidence targets + center constrained on a locus
+3. Three curve-tangency or point-incidence targets
+4. One curve-tangency or point-incidence target + fixed center
+5. One curve-tangency or point-incidence target + fixed radius + center constrained on a locus
 
 ``sagitta`` selects short/long/both arc branches:
 
@@ -528,7 +529,8 @@ Signature A: Two constraints + ``radius``
 .. figure:: ./assets/tan2_rad_ex.svg
    :align: center
 
-Use when radius is known and arc must satisfy two contact/tangency conditions.
+Use when radius is known and the arc must be tangent to each curve input or pass through
+each point input.
 
 Signature B: Two constraints + ``center_on``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -564,8 +566,8 @@ Signature C: Three constraints
 .. figure:: ./assets/tan3_ex.svg
    :align: center
 
-Use for "arc tangent/contact to three entities". This can produce several branches;
-always consider using ``selector``.
+Use for an arc constrained by three curve-tangency or point-incidence targets. This can
+produce several branches; always consider using ``selector``.
 
 Signature D: One constraint + fixed ``center``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -605,9 +607,8 @@ Allowed constraint objects
 
 For arc constraints, accepted objects include:
 
-- :class:`~topology.Edge`
-- :class:`~geometry.Axis`
-- :class:`~geometry.Vertex` / :class:`~geometry.VectorLike` point
+- :class:`~topology.Edge` and :class:`~geometry.Axis` as curve-tangency targets
+- :class:`~geometry.Vertex` / :class:`~geometry.VectorLike` as point-incidence targets
 - optional qualifier wrapper: ``(object, Tangency.XXX)``
 
 ConstrainedLines
@@ -618,9 +619,9 @@ Overview
 
 :class:`~objects_curve.ConstrainedLines` supports these signature families:
 
-1. Tangent/contact to two objects
-2. Tangent/contact to one object and passing through a fixed point
-3. Tangent/contact to one object with fixed orientation (``angle`` or ``direction``)
+1. Tangent to two curves
+2. Tangent to one curve and passing through a fixed point
+3. Tangent to one curve with fixed orientation (``angle`` or ``direction``)
 
 Signature A: Two constraints
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -668,8 +669,8 @@ Signature C: One constraint + fixed orientation
 
 Exactly one of ``angle`` or ``direction`` should be provided.
 
-For all signatures, qualifiers can be attached to tangency inputs when side selection
-must be controlled.
+For all signatures, qualifiers can be attached to curve-tangency inputs when side
+selection must be controlled.
 
 Builder vs Algebra mode
 -----------------------

--- a/src/build123d/objects_curve.py
+++ b/src/build123d/objects_curve.py
@@ -685,11 +685,9 @@ class ConstrainedArcs(BaseCurveObject):
     @overload
     def __init__(
         self,
-        tangency_one: tuple[Axis | Edge, Tangency] | Axis | Edge | Vertex | VectorLike,
-        tangency_two: tuple[Axis | Edge, Tangency] | Axis | Edge | Vertex | VectorLike,
-        tangency_three: (
-            tuple[Axis | Edge, Tangency] | Axis | Edge | Vertex | VectorLike
-        ),
+        tangency_one: tuple[Axis | Edge, Tangency] | Axis | Edge,
+        tangency_two: tuple[Axis | Edge, Tangency] | Axis | Edge,
+        tangency_three: tuple[Axis | Edge, Tangency] | Axis | Edge,
         *,
         sagitta: Sagitta = Sagitta.SHORT,
         selector: Callable[
@@ -702,8 +700,8 @@ class ConstrainedArcs(BaseCurveObject):
 
         Args:
             tangency_one, tangency_two, tangency_three
-                (tuple[Axis | Edge, PositionConstraint] | Axis | Edge | Vertex | VectorLike):
-                Curve tangency targets or point-incidence targets for the circle(s)
+                (tuple[Axis | Edge, PositionConstraint] | Axis | Edge):
+                Curve tangency targets for the circle(s)
             sagitta (LengthConstraint, optional): returned arc selector
                 (i.e. either the short, long or both arcs). Defaults to
                 LengthConstraint.SHORT.

--- a/src/build123d/objects_curve.py
+++ b/src/build123d/objects_curve.py
@@ -620,13 +620,13 @@ class ConstrainedArcs(BaseCurveObject):
         mode: Mode = Mode.ADD,
     ):
         """
-        Create all planar circular arcs of a given radius that are tangent/contacting
-        the two provided objects on the XY plane.
+        Create all planar circular arcs of a given radius that are tangent to curve
+        inputs or pass through point inputs on the XY plane.
 
         Args:
             tangency_one, tangency_two
                 (tuple[Axis | Edge, PositionConstraint] | Axis | Edge | Vertex | VectorLike):
-                Geometric entities to be contacted/touched by the circle(s)
+                Curve tangency targets or point-incidence targets for the circle(s)
             radius (float): arc radius
             sagitta (LengthConstraint, optional): returned arc selector
                 (i.e. either the short, long or both arcs). Defaults to
@@ -663,7 +663,7 @@ class ConstrainedArcs(BaseCurveObject):
         Args:
             tangency_one, tangency_two
                 (tuple[Axis | Edge, PositionConstraint] | Axis | Edge | Vertex | VectorLike):
-                Geometric entities to be contacted/touched by the circle(s)
+                Curve tangency targets or point-incidence targets for the circle(s)
             center_on (Axis | Edge): center must lie on this object
             sagitta (LengthConstraint, optional): returned arc selector
                 (i.e. either the short, long or both arcs). Defaults to
@@ -703,7 +703,7 @@ class ConstrainedArcs(BaseCurveObject):
         Args:
             tangency_one, tangency_two, tangency_three
                 (tuple[Axis | Edge, PositionConstraint] | Axis | Edge | Vertex | VectorLike):
-                Geometric entities to be contacted/touched by the circle(s)
+                Curve tangency targets or point-incidence targets for the circle(s)
             sagitta (LengthConstraint, optional): returned arc selector
                 (i.e. either the short, long or both arcs). Defaults to
                 LengthConstraint.SHORT.
@@ -736,13 +736,13 @@ class ConstrainedArcs(BaseCurveObject):
         mode: Mode = Mode.ADD,
     ):
         """
-        Create planar circle(s) on XY whose center is fixed and that are tangent/contacting
-        a single object.
+        Create planar circle(s) on XY whose center is fixed and that are tangent to a
+        curve input or pass through a point input.
 
         Args:
             tangency_one
                 (tuple[Axis | Edge, PositionConstraint] | Axis | Edge | Vertex | VectorLike):
-                Geometric entity to be contacted/touched by the circle(s)
+                Curve tangency target or point-incidence target for the circle(s)
             center (VectorLike): center position
             selector (Callable, optional): typically a lambda which chooses one or more of the
                 results. Defaults to lambda arcs: arcs.
@@ -771,14 +771,14 @@ class ConstrainedArcs(BaseCurveObject):
         """
 
         Create planar circle(s) on XY that:
-        - are tangent/contacting a single object, and
+        - are tangent to a curve input or pass through a point input, and
         - have a fixed radius, and
         - have their CENTER constrained to lie on a given locus curve.
 
         Args:
             tangency_one
                 (tuple[Axis | Edge, PositionConstraint] | Axis | Edge | Vertex | VectorLike):
-                Geometric entity to be contacted/touched by the circle(s)
+                Curve tangency target or point-incidence target for the circle(s)
             radius (float): arc radius
             center_on (Axis | Edge): center must lie on this object
             selector (Callable, optional): typically a lambda which chooses one or more of the
@@ -854,7 +854,7 @@ class ConstrainedLines(BaseCurveObject):
         Args:
             tangency_one, tangency_two
                 (tuple[Edge, Tangency] | Axis | Edge):
-                Geometric entities to be contacted/touched by the line(s).
+                Curves to which the line(s) must be tangent.
             selector (Callable, optional): typically a lambda which chooses one or more of the
                 results. Defaults to lambda lines: lines.
             mode (Mode, optional): combination mode. Defaults to Mode.ADD.
@@ -885,7 +885,7 @@ class ConstrainedLines(BaseCurveObject):
         Args:
             tangency_one
                 (tuple[Edge, Tangency] | Edge):
-                Geometric entity to be contacted/touched by the line(s).
+                Curve to which the line(s) must be tangent.
             tangency_two (VectorLike):
                 Fixed point through which the line(s) must pass.
             selector (Callable, optional): typically a lambda which chooses one or more of the
@@ -943,12 +943,14 @@ class ConstrainedLines(BaseCurveObject):
 
     def __init__(self, *args, **kwargs) -> None:
         """
-        Create planar line(s) on XY subject to tangency/contact constraints.
+        Create planar line(s) on XY subject to tangency, point-incidence, or
+        orientation constraints.
 
         Supported cases
         ---------------
         1. Tangent to two curves
         2. Tangent to one curve and passing through a given point
+        3. Tangent to one curve with a fixed orientation
         """
 
         selector = kwargs.pop("selector", lambda lines: lines)

--- a/src/build123d/topology/constrained_lines.py
+++ b/src/build123d/topology/constrained_lines.py
@@ -323,14 +323,14 @@ def _make_2tan_rad_arcs(
     edge_factory: Callable[[TopoDS_Edge], Edge],
 ) -> ShapeList[Edge]:
     """
-    Create all planar circular arcs of a given radius that are tangent/contacting
-    the two provided objects on the XY plane.
+    Create all planar circular arcs of a given radius that are tangent to curve
+    inputs or pass through point inputs on the XY plane.
 
     Inputs must be coplanar with ``Plane.XY``. Non-coplanar edges are not supported.
 
     Args:
         tangencies (tuple[Edge, PositionConstraint] | Edge | Vertex | VectorLike:
-            Geometric entity to be contacted/touched by the circle(s)
+            Curve tangency targets or point-incidence targets for the circle(s)
         radius (float): Circle radius for all candidate solutions.
 
     Raises:
@@ -650,8 +650,8 @@ def _make_tan_cen_arcs(
     edge_factory: Callable[[TopoDS_Edge], Edge],
 ) -> ShapeList[Edge]:
     """
-    Create planar circle(s) on XY whose center is fixed and that are tangent/contacting
-    a single object.
+    Create planar circle(s) on XY whose center is fixed and that are tangent to a
+    curve input or pass through a point input.
 
     Notes
     -----
@@ -735,7 +735,7 @@ def _make_tan_on_rad_arcs(
 ) -> ShapeList[Edge]:
     """
     Create planar circle(s) on XY that:
-      - are tangent/contacting a single object, and
+      - are tangent to a curve input or pass through a point input, and
       - have a fixed radius, and
       - have their CENTER constrained to lie on a given locus curve.
 

--- a/src/build123d/topology/one_d.py
+++ b/src/build123d/topology/one_d.py
@@ -1760,11 +1760,9 @@ class Edge(Mixin1D[TopoDS_Edge]):
     @classmethod
     def make_constrained_arcs(
         cls,
-        tangency_one: tuple[Axis | Edge, Tangency] | Axis | Edge | Vertex | VectorLike,
-        tangency_two: tuple[Axis | Edge, Tangency] | Axis | Edge | Vertex | VectorLike,
-        tangency_three: (
-            tuple[Axis | Edge, Tangency] | Axis | Edge | Vertex | VectorLike
-        ),
+        tangency_one: tuple[Axis | Edge, Tangency] | Axis | Edge,
+        tangency_two: tuple[Axis | Edge, Tangency] | Axis | Edge,
+        tangency_three: tuple[Axis | Edge, Tangency] | Axis | Edge,
         *,
         sagitta: Sagitta = Sagitta.SHORT,
     ) -> ShapeList[Edge]:
@@ -1773,8 +1771,8 @@ class Edge(Mixin1D[TopoDS_Edge]):
 
         Args:
             tangency_one, tangency_two, tangency_three
-                (tuple[Axis | Edge, PositionConstraint] | Axis | Edge | Vertex | VectorLike):
-                Curve tangency targets or point-incidence targets for the circle(s)
+                (tuple[Axis | Edge, PositionConstraint] | Axis | Edge):
+                Curve tangency targets for the circle(s)
             sagitta (LengthConstraint, optional): returned arc selector
                 (i.e. either the short, long or both arcs). Defaults to
                 LengthConstraint.SHORT.

--- a/src/build123d/topology/one_d.py
+++ b/src/build123d/topology/one_d.py
@@ -1714,12 +1714,12 @@ class Edge(Mixin1D[TopoDS_Edge]):
         sagitta: Sagitta = Sagitta.SHORT,
     ) -> ShapeList[Edge]:
         """
-        Create all planar circular arcs of a given radius that are tangent/contacting
-        the two provided objects on the XY plane.
+        Create all planar circular arcs of a given radius that are tangent to curve
+        inputs or pass through point inputs on the XY plane.
         Args:
             tangency_one, tangency_two
                 (tuple[Axis | Edge, PositionConstraint] | Axis | Edge | Vertex | VectorLike):
-                Geometric entities to be contacted/touched by the circle(s)
+                Curve tangency targets or point-incidence targets for the circle(s)
             radius (float): arc radius
             sagitta (LengthConstraint, optional): returned arc selector
                 (i.e. either the short, long or both arcs). Defaults to
@@ -1746,7 +1746,7 @@ class Edge(Mixin1D[TopoDS_Edge]):
         Args:
             tangency_one, tangency_two
                 (tuple[Axus | Edge, PositionConstraint] | Axis | Edge | Vertex | VectorLike):
-                Geometric entities to be contacted/touched by the circle(s)
+                Curve tangency targets or point-incidence targets for the circle(s)
             center_on (Axis | Edge): center must lie on this object
             sagitta (LengthConstraint, optional): returned arc selector
                 (i.e. either the short, long or both arcs). Defaults to
@@ -1774,7 +1774,7 @@ class Edge(Mixin1D[TopoDS_Edge]):
         Args:
             tangency_one, tangency_two, tangency_three
                 (tuple[Axis | Edge, PositionConstraint] | Axis | Edge | Vertex | VectorLike):
-                Geometric entities to be contacted/touched by the circle(s)
+                Curve tangency targets or point-incidence targets for the circle(s)
             sagitta (LengthConstraint, optional): returned arc selector
                 (i.e. either the short, long or both arcs). Defaults to
                 LengthConstraint.SHORT.
@@ -1793,13 +1793,13 @@ class Edge(Mixin1D[TopoDS_Edge]):
     ) -> ShapeList[Edge]:
         """make_constrained_arcs
 
-        Create planar circle(s) on XY whose center is fixed and that are tangent/contacting
-        a single object.
+        Create planar circle(s) on XY whose center is fixed and that are tangent to a
+        curve input or pass through a point input.
 
         Args:
             tangency_one
                 (tuple[Axis | Edge, PositionConstraint] | Axis | Edge | Vertex | VectorLike):
-                Geometric entity to be contacted/touched by the circle(s)
+                Curve tangency target or point-incidence target for the circle(s)
             center (VectorLike): center position
 
         Returns:
@@ -1818,14 +1818,14 @@ class Edge(Mixin1D[TopoDS_Edge]):
         """make_constrained_arcs
 
         Create planar circle(s) on XY that:
-        - are tangent/contacting a single object, and
+        - are tangent to a curve input or pass through a point input, and
         - have a fixed radius, and
         - have their CENTER constrained to lie on a given locus curve.
 
         Args:
             tangency_one
                 (tuple[Axis | Edge, PositionConstraint] | Axis | Edge | Vertex | VectorLike):
-                Geometric entity to be contacted/touched by the circle(s)
+                Curve tangency target or point-incidence target for the circle(s)
             radius (float): arc radius
             center_on (Axis | Edge): center must lie on this object
             sagitta (LengthConstraint, optional): returned arc selector
@@ -1957,7 +1957,7 @@ class Edge(Mixin1D[TopoDS_Edge]):
         Args:
             tangency_one, tangency_two
                 (tuple[Edge, Tangency] | Axis | Edge):
-                Geometric entities to be contacted/touched by the line(s).
+                Curves to which the line(s) must be tangent.
 
         Returns:
             ShapeList[Edge]: tangent lines
@@ -1977,7 +1977,7 @@ class Edge(Mixin1D[TopoDS_Edge]):
         Args:
             tangency_one
                 (tuple[Edge, Tangency] | Edge):
-                Geometric entity to be contacted/touched by the line(s).
+                Curve to which the line(s) must be tangent.
             tangency_two (Vector):
                 Fixed point through which the line(s) must pass.
 
@@ -2016,12 +2016,14 @@ class Edge(Mixin1D[TopoDS_Edge]):
     @classmethod
     def make_constrained_lines(cls, *args, **kwargs) -> ShapeList[Edge]:
         """
-        Create planar line(s) on XY subject to tangency/contact constraints.
+        Create planar line(s) on XY subject to tangency, point-incidence, or
+        orientation constraints.
 
         Supported cases
         ---------------
         1. Tangent to two curves
         2. Tangent to one curve and passing through a given point
+        3. Tangent to one curve with a fixed orientation
         """
         tangency_one = args[0] if len(args) > 0 else None
         tangency_two = args[1] if len(args) > 1 else None


### PR DESCRIPTION
## Summary

Clarify the constraint terminology used by `ConstrainedArcs`, `ConstrainedLines`, and their direct-API counterparts.

The documentation now distinguishes:

- tangency to curve inputs;
- incidence through point inputs;
- center-locus and fixed-orientation constraints.

This avoids describing every supported overload as a generic tangent/contact problem while preserving the point-input cases that are not tangency constraints.

Closes #1382.

## Root cause

The overloads accept both curve and point inputs, but the tutorial and docstrings used umbrella phrases such as tangent/contact and contacted/touched. Those phrases blurred two different geometric conditions. Replacing contact with tangent everywhere would also be inaccurate because several arc overloads accept point-incidence targets.

The patch is limited to terminology in the public tutorial, public constructor docstrings, direct API docstrings, and matching internal solver docstrings. Solver behavior, signatures, dependencies, and generated geometry are unchanged.

## Scope and risk

- Risk: low; documentation and docstrings only.
- No API or runtime behavior changes.
- No dependency, solver, qualification, or selection changes.
- No broad documentation rewrite or unrelated formatting.

## Reproduction and evidence

Before the patch, the affected files repeatedly used `tangent/contact`, `tangent/contacting`, and `contacted/touched` across overloads that support both curves and points. A focused post-change search finds none of those ambiguous phrases in the four affected files.

## Validation

- `git diff --check`: passed.
- Focused constrained-geometry tests: 58 passed.
- Full suite: 2,209 passed, 2 skipped, 1 unrelated local system-font registry failure. The failing test was rerun alone and reproduced without involving any changed file.
- `mypy` on the three changed Python modules: passed.
- `pylint` on the three changed Python modules: no errors; 9.97/10 with existing warnings outside the changed lines.
- Sphinx HTML build: passed; existing warnings remain outside the changed lines.
- `black --check`: the current upstream `objects_curve.py` would be reformatted in unrelated sections, and the local Python 3.11 runner also warns about the configured Python 3.14 target. I left those unrelated formatting differences untouched.

## Documentation impact

Updated the tutorial and API docstrings because this issue is specifically a terminology mismatch in public documentation. No changelog entry is needed because behavior and API are unchanged.

## Remaining gates

- Repository CI on the submitted head.
- Maintainer review and merge decision.
