### PR TITLE
docs: document Draft configuration

### DIFF
--- a/docs/objects.rst
+++ b/docs/objects.rst
@@ -420,6 +420,7 @@ Reference
 .. autoclass:: drafting.ArrowHead
 .. autoclass:: Circle
 .. autoclass:: drafting.DimensionLine
+.. autoclass:: drafting.Draft
 .. autoclass:: Ellipse
 .. autoclass:: drafting.ExtensionLine
 .. autoclass:: Polygon

--- a/docs/tech_drawing_tutorial.rst
+++ b/docs/tech_drawing_tutorial.rst
@@ -28,13 +28,19 @@ The script uses the `project_to_viewport` method to project the 3D part geometry
 A helper function, `project_to_2d`, sets up the viewport (camera origin and up direction)
 and places the result onto a virtual drawing sheet.
 
+The :class:`~drafting.Draft` dataclass collects the shared appearance and number-formatting
+options for annotations. In this example, one ``Draft`` instance sets the font size,
+decimal precision, and unit display for every :class:`~drafting.ExtensionLine`, keeping
+the dimensions consistent across all views.
+
 The steps involved are:
 
 1. Load or construct a 3D part (in this case, a stepper motor).
 2. Define a `TechnicalDrawing` border and title block using A4 page size.
-3. Generate each of the standard views and apply transformations to place them.
-4. Add dimensions using `ExtensionLine` and labels using `Text`.
-5. Export the drawing using `ExportSVG`, separating visible and hidden edges by layer
+3. Create a `Draft` configuration for the drawing annotations.
+4. Generate each of the standard views and apply transformations to place them.
+5. Add dimensions using `ExtensionLine` and labels using `Text`.
+6. Export the drawing using `ExportSVG`, separating visible and hidden edges by layer
    and style.
 
 Result


### PR DESCRIPTION
## Summary

- add the public `Draft` dataclass to the 2D object API reference;
- explain how the Technical Drawing tutorial uses one `Draft` instance to keep annotation appearance and number formatting consistent;
- link the tutorial directly to the rendered `Draft` and `ExtensionLine` API entries.

Closes #1222.

## User-visible behavior

Readers of the Technical Drawing tutorial can now see what `Draft` configures and follow a working cross-reference to its complete API signature and fields.

## Root cause and minimal fix

The existing technical drawing example already creates and passes a `Draft` instance, but the tutorial narrative did not explain it and the 2D object reference omitted the dataclass. This patch changes only those two documentation surfaces; it does not change the example, API, or runtime behavior.

## Scope and risk

- Risk: low, documentation-only.
- Scope: `docs/tech_drawing_tutorial.rst` and `docs/objects.rst`.
- Non-goals: changing drafting defaults, annotation behavior, or reorganizing the wider object reference.

## Reproduction / regression evidence

On current `dev` (`de862238e`), the example script used `Draft`, but the tutorial contained no `Draft` explanation and `docs/objects.rst` had no `drafting.Draft` autoclass entry. After this patch, the generated tutorial links to `objects.html#drafting.Draft`, and the object reference renders the dataclass signature and fields.

## Validation

- `git diff --check` — passed.
- `make -C docs html` — succeeded; 8 existing warnings remain in unchanged docstrings/RST plus the local Graphviz availability warning.
- Generated HTML check — the tutorial link resolves to the rendered `drafting.Draft` API entry.
- `python -m pytest tests/test_importers.py -n 0` — 37 passed.
- `python -m pytest -n auto --dist loadscope` — 2213 passed, 2 skipped.
- The repository-prescribed `python -m pytest -n auto` first completed 2205 tests with 2 skips and 8 setup errors because local Python could not download the public STEP fixture through its CA store. After prefetching that fixture with normal TLS verification (SHA-256 `038be659c54b16c9f3da8d7b2da7b63e3fd8879d3abe5b7826108336a7c0bae9`), the importer file exposed a separate fixed-filename race under xdist (36 passed, 1 failed); serial importer coverage and full `loadscope` coverage both pass as reported above.

## Documentation impact

This PR is the documentation update requested by #1222. It adds both tutorial guidance and API reference coverage; no changelog or behavior note is needed because no API or runtime behavior changes.

## Remaining gates

- Repository CI.
- Maintainer review and merge decision.
