### PR TITLE
docs: document vectorized location operations

### DIFF
--- a/docs/algebra_performance.rst
+++ b/docs/algebra_performance.rst
@@ -44,3 +44,15 @@ an empty ``Part``, ``Sketch`` or ``Curve``:
     ]
 
 This again ensures one single ``fuse`` and ``clean`` call.
+
+When the same object is placed at every location, the location collection can apply it
+directly. This avoids the list comprehension and is both more concise and faster:
+
+.. code-block:: build123d
+
+    polygons = Sketch() + GridLocations(40, 30, 2, 2) * RegularPolygon(
+        radius=5, side_count=5
+    )
+
+Use a list comprehension when each location needs different geometry or conditional
+logic; otherwise, prefer the vectorized form above.


### PR DESCRIPTION
## Summary

- document the vectorized `LocationList * Shape` form in the algebra performance guide
- explain when a list comprehension is still the clearer choice

Closes #1155.

## Root cause and minimal fix

The performance section described vectorized algebra operations, but its final example
still stopped at a Python list comprehension. Readers therefore did not see the more
direct location-collection multiplication supported by the current API.

This documentation-only patch adds that equivalent form immediately after the existing
example and keeps the list-comprehension guidance for conditional or per-location
geometry. No implementation or public API changes are involved.

## Scope and risk

- Risk: low; one RST file and 12 added lines
- Non-goals: no API changes, tutorial-wide rewrite, or machine-independent speed claim
- Reproduction on `dev@0c2bbe557`: both forms produced four faces with identical area;
  the vectorized form was about 2.89x faster in a bounded local median benchmark

## Validation

- Focused RST/content and geometry-equivalence assertions: passed
- `make -C docs html`: passed (8 pre-existing warnings outside this file)
- `python -m pytest -n auto -q`: 2,221 passed, 2 skipped, 68 subtests passed
- `python -m pytest -q`: 2,221 passed, 2 skipped, 68 subtests passed
- `git diff --check`: passed

## Documentation impact

This PR is the documentation update requested by #1155. The rendered performance guide
now shows the concise vectorized expression and the boundary where list comprehensions
remain useful.

## Remaining gates

- repository CI
- human maintainer review and merge decision
