### PR TITLE
Add a reference to the ExportToPython project in the external tools

### DIFF
--- a/docs/external.rst
+++ b/docs/external.rst
@@ -235,3 +235,17 @@ standardized tooling to interface with your projects. It makes it easy to:
   * generate logs for compilation and web interface events that can be consumed by an OpenTelemetry platform
 
 See: `Partomatic <https://github.com/x0pherl/partomatic>`_
+
+ExportToPython
+==============
+
+ExportToPython is a Fusion 360 add-in script that converts parametric Fusion designs into editable Python code for build123d.
+It recreates the design timeline using native build123d operations while preserving user parameters and dimensional expressions where possible.
+Unsupported or partially supported features are clearly identified with inline `TODO` comments and export notes.
+
+  * parametric output — preserves Fusion user parameters and expressions as Python variables and expressions
+  * Fusion feature support — exports sketches, extrudes, revolves, sweeps, lofts, patterns, fillets, chamfers, shells, holes, primitives, transforms, and more
+  * transparent conversion — unsupported or imperfectly translated features are flagged with `TODO` comments and plain-English export notes
+  * editable output — generated scripts can be used directly or further developed into fully parametric CAD generators
+
+See: `ExportToPython <https://github.com/Visionware-Solutions/ExportToPython>`_


### PR DESCRIPTION
Add a reference to the ExportToPython project in the external tools and libraries section in the documentation.