### PR TITLE
docs: explain mixing builder and algebra modes

### DIFF
--- a/docs/key_concepts_algebra.rst
+++ b/docs/key_concepts_algebra.rst
@@ -126,6 +126,24 @@ Examples:
         Plane.XZ * Rot(0, 100, 45) * Pos(0,1,2) * Box(1, 2, 3)
 
 
+Combining Builder and algebra modes
+===================================
+
+Builder contexts such as ``BuildPart`` collect operations; they are not shapes and
+therefore cannot be combined directly with algebra operators. Extract the completed
+geometry with ``.line``, ``.sketch``, or ``.part`` before using it in algebra mode:
+
+.. code-block:: build123d
+
+    with BuildPart() as base:
+        Box(80, 60, 10)
+
+    with BuildPart() as bore:
+        Cylinder(11, 10)
+
+    result = base.part - bore.part
+
+
 Combing both concepts
 ==========================
 
@@ -136,4 +154,3 @@ Combing both concepts
     b = Plane.XZ * Rot(X=30) * Box(1, 2, 3) + Plane.YZ * Pos(X=-1) * Cylinder(0.2, 5)
 
 **Note:** In Python ``*`` binds stronger then ``+``, ``-``, ``&``, hence brackets are not needed.
-


### PR DESCRIPTION
## Summary
- explain that builder contexts are not shapes and cannot be used directly with algebra operators
- show how to extract `.line`, `.sketch`, or `.part` before combining geometry
- add a focused `BuildPart` subtraction example

## Root cause and scope
The algebra-mode concepts page did not explain the boundary between builder contexts and their completed shape results, even though the runtime error points users to the `.part` attribute. This documentation-only patch adds that missing bridge in one file.

Risk: low. No runtime code, API, dependencies, generated assets, or workflows change.

Non-goals: changing builder arithmetic behavior, refactoring the surrounding algebra documentation, or changing existing error messages.

## Reproduction
On current `dev`, subtracting two `BuildPart` contexts raises the expected error that builders cannot be combined. Using `base.part - bore.part` succeeds and produces the expected volume (`44198.672889`).

## Validation
- focused builder/algebra snippet: expected builder error and correct `.part` subtraction volume
- `PATH="$PWD/.venv/bin:$PATH" make -C docs html`: succeeded; seven pre-existing warnings are outside this file
- `.venv/bin/python -m pytest -n auto`: 2223 passed, 2 skipped
- `git diff --check`: passed

Documentation impact: updates `docs/key_concepts_algebra.rst` with the mixed-mode guidance requested in #514.

Remaining gates: repository CI, maintainer review, and merge decision.

Closes #514
