### PR TITLE
Defer font manager initialization until use

### DIFF
--- a/src/build123d/text.py
+++ b/src/build123d/text.py
@@ -289,4 +289,6 @@ class FontManager:
         return fonts
 
 
-available_fonts = FontManager().available_fonts
+def available_fonts() -> list[FontInfo]:
+    """Get available fonts without initializing the font manager on import."""
+    return FontManager().available_fonts()

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -11,6 +11,7 @@ desc: Unit tests for the build123d font and text module
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from fontTools.ttLib import TTCollection, TTFont
 from OCP.TCollection import TCollection_AsciiString
@@ -224,6 +225,16 @@ class TestFontHelpers(unittest.TestCase):
 
         names = [font.name for font in fonts]
         self.assertEqual(names, sorted(names))
+
+    def test_available_fonts_initializes_manager_when_called(self):
+        """Font discovery should be deferred until the helper is called."""
+        expected_fonts = []
+
+        with patch("build123d.text.FontManager") as manager:
+            manager.return_value.available_fonts.return_value = expected_fonts
+
+            self.assertIs(available_fonts(), expected_fonts)
+            manager.assert_called_once_with()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- defer `FontManager` construction until `available_fonts()` is called
- preserve the existing public `available_fonts()` API and return type
- add a regression proving font discovery initializes only on demand

Fixes #1407.

## Root cause

`available_fonts` was assigned to `FontManager().available_fonts` at module scope. Importing `build123d.text` therefore constructed the OCCT font manager even when callers only used geometry APIs. On Linux, that eager construction can scan fontconfig and emit warnings during a plain `import build123d`.

The patch replaces the bound-method assignment with a small function that constructs `FontManager` only when font discovery is requested.

## Scope and risk

Risk: low. The change is limited to `src/build123d/text.py` and one focused test. Calls to `available_fonts()` still return the same sorted `list[FontInfo]` through the same public import.

Non-goals:

- no fontconfig environment or system configuration changes
- no changes to `Text`, font registration, or lookup behavior
- no dependency, workflow, or compatibility-policy changes

## Reproduction and regression evidence

Before the patch, replacing `build123d.text.FontManager` after import showed that `available_fonts()` remained bound to the import-time instance (`manager_calls=0`), and the new regression failed. After the patch, the regression passes and a fresh-process probe confirms `import build123d` does not call `Font_FontMgr.GetInstance_s`.

## Validation

- `python -m pytest tests/test_text.py -q`: 13 passed
- fresh-process import probe with mocked `Font_FontMgr.GetInstance_s`: passed
- `python -m pytest -n auto`: 2,224 passed, 2 skipped, with one unrelated fixed-filename glTF export race under xdist
- isolated glTF rerun: 1 passed
- `python -m pytest -q`: 2,225 passed, 2 skipped, 68 subtests passed
- `black --check src/build123d/text.py`: passed
- `pylint src/build123d/text.py`: 10.00/10
- `mypy src/build123d/text.py`: passed
- `git diff --check`: passed

## Documentation impact

None. The public API and user-facing font behavior are unchanged; initialization is only deferred until first font use.

## Remaining gates

Repository CI, maintainer review, and merge decision remain external.