### PR TITLE
docs: add conda-forge installation option

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -13,6 +13,13 @@ The recommended method for most users to install **build123d** is:
 	The `ocp-vscode <https://github.com/bernhard-42/vscode-ocp-cad-viewer>`_ viewer has
 	the ability to install **build123d**.
 
+To install the version available from the
+`conda-forge package <https://anaconda.org/conda-forge/build123d>`_, use:
+
+.. doctest::
+
+	>>> conda install conda-forge::build123d
+
 Install build123d from GitHub:
 ------------------------------
 


### PR DESCRIPTION
## Summary

- document the conda-forge installation command
- link directly to the conda-forge package page
- describe it as the version available from conda-forge, without implying that it always matches the newest PyPI release

## Root cause and scope

The installation page documents pip, GitHub, and Poetry workflows but omits the existing conda-forge package requested in #703. This is a documentation-only, low-risk change to `docs/installation.rst`; it does not change package metadata, dependencies, runtime behavior, or the recommended default installation method.

## Validation

- `git diff --check`
- `PATH="$PWD/.venv/bin:$PATH" make -C docs html` — passed; 7 pre-existing warnings remain outside this change
- rendered `installation.html` contains the package link and command
- `.venv/bin/python -m pytest -n auto -q` — 2,224 passed, 2 skipped, 68 subtests; one unrelated fixed-filename glTF xdist race
- isolated glTF test — 1 passed
- `.venv/bin/python -m pytest -q` — 2,225 passed, 2 skipped, 68 subtests

## Documentation impact

This PR is the documentation update: users can now discover the conda-forge package and copy its supported channel-qualified install command.

## Remaining gates

- maintainer review
- repository CI
- merge decision

Closes #703
