### PR TITLE
Fix Text resolved font attributes

### DIFF
--- a/src/build123d/objects_sketch.py
+++ b/src/build123d/objects_sketch.py
@@ -681,8 +681,9 @@ class Text(BaseSketchObject):
             text_path=path,
             single_line_width=single_line_width,
         )
-        self.font = text_string.font
-        self.font_path = text_string.font_path
+        self.font, self.font_path, _ = Compound.resolve_font(
+            font, font_path, font_style
+        )
         super().__init__(text_string, rotation, None, mode)
 
 

--- a/src/build123d/objects_sketch.py
+++ b/src/build123d/objects_sketch.py
@@ -604,8 +604,10 @@ class Text(BaseSketchObject):
     Args:
         txt (str): text to render
         font_size (float): size of the font in model units
-        font (str, optional): font name. Defaults to "Arial"
-        font_path (PathLike | str, optional): system path to font file. Defaults to None
+        font (str, optional): requested font name. After construction, this attribute
+            contains the resolved font name. Defaults to "Arial"
+        font_path (PathLike | str, optional): system path to font file. After
+            construction, this attribute contains the resolved font path. Defaults to None
         font_style (Font_Style, optional): font style, REGULAR, BOLD, BOLDITALIC, or
             ITALIC. Defaults to Font_Style.REGULAR
         text_align (tuple[TextAlign, TextAlign], optional): horizontal text align
@@ -679,6 +681,8 @@ class Text(BaseSketchObject):
             text_path=path,
             single_line_width=single_line_width,
         )
+        self.font = text_string.font
+        self.font_path = text_string.font_path
         super().__init__(text_string, rotation, None, mode)
 
 

--- a/src/build123d/topology/composite.py
+++ b/src/build123d/topology/composite.py
@@ -65,6 +65,7 @@ from bd_materials import FinishedMaterial
 
 import OCP.TopAbs as ta
 from OCP.BRepAlgoAPI import BRepAlgoAPI_Fuse
+from OCP.Font import Font_SystemFont
 from OCP.gp import gp_Ax3
 from OCP.Graphic3d import (
     Graphic3d_HTA_LEFT,
@@ -238,6 +239,42 @@ class Compound(Mixin3D[TopoDS_Compound]):
         """
         return Compound(TopoDS.Compound(_extrude_topods_shape(obj.wrapped, direction)))
 
+    @staticmethod
+    def resolve_font(
+        font: str = "Arial",
+        font_path: PathLike[str] | str | None = None,
+        font_style: FontStyle = FontStyle.REGULAR,
+    ) -> tuple[str, str, Font_SystemFont]:
+        """Resolve a requested font to its name, path, and system font.
+
+        Args:
+            font (str, optional): requested font name. Defaults to "Arial"
+            font_path (PathLike | str, optional): system path to font file.
+                Defaults to None
+            font_style (FontStyle, optional): requested font style.
+                Defaults to FontStyle.REGULAR
+
+        Returns:
+            tuple[str, str, Font_SystemFont]: resolved font name, resolved font
+                path, and OpenCascade system font
+        """
+        requested_path = fspath(font_path) if font_path is not None else None
+        manager = FontManager()
+
+        if requested_path and manager.check_font(requested_path):  # pragma: no cover
+            face_names = manager.register_font(requested_path, True, False)
+            selected_name = font if font in face_names else face_names[0]
+        else:
+            selected_name = font
+
+        system_font = manager.find_font(selected_name, font_style)
+        aspect = FONT_ASPECT[font_style]
+        return (
+            system_font.FontName().ToCString(),
+            system_font.FontPath(aspect).ToCString(),
+            system_font,
+        )
+
     @classmethod
     def make_text(
         cls,
@@ -309,16 +346,9 @@ class Compound(Mixin3D[TopoDS_Compound]):
                 -wire_angle,
             )
 
-        font_path_str = fspath(font_path) if font_path is not None else None
-
-        manager = FontManager()
-        if font_path_str and manager.check_font(font_path_str):  # pragma: no cover
-            face_names = manager.register_font(font_path_str, True, False)
-            # Check if font (name) is in face names and not bad or default (Arial)
-            font_name = font if font in face_names else face_names[0]
-            system_font = manager.find_font(font_name, font_style)
-        else:
-            system_font = manager.find_font(font, font_style)
+        resolved_font, resolved_font_path, system_font = cls.resolve_font(
+            font, font_path, font_style
+        )
 
         # Validate TextAlign parameters
         if text_align[0] not in [TextAlign.LEFT, TextAlign.CENTER, TextAlign.RIGHT]:
@@ -353,8 +383,8 @@ class Compound(Mixin3D[TopoDS_Compound]):
 
         logger.info(
             "Creating text with font %s located at %s",
-            system_font.FontName().ToCString(),
-            system_font.FontPath(FONT_ASPECT[font_style]).ToCString(),
+            resolved_font,
+            resolved_font_path,
         )
 
         # Write text to shape
@@ -412,10 +442,6 @@ class Compound(Mixin3D[TopoDS_Compound]):
                     "produces invalid faces. Try a smaller width"
                 )
 
-        # pylint: disable-next=attribute-defined-outside-init
-        text_flat.font = system_font.FontName().ToCString()
-        # pylint: disable-next=attribute-defined-outside-init
-        text_flat.font_path = system_font.FontPath(FONT_ASPECT[font_style]).ToCString()
         return text_flat
 
     @classmethod

--- a/src/build123d/topology/composite.py
+++ b/src/build123d/topology/composite.py
@@ -412,6 +412,10 @@ class Compound(Mixin3D[TopoDS_Compound]):
                     "produces invalid faces. Try a smaller width"
                 )
 
+        # pylint: disable-next=attribute-defined-outside-init
+        text_flat.font = system_font.FontName().ToCString()
+        # pylint: disable-next=attribute-defined-outside-init
+        text_flat.font_path = system_font.FontPath(FONT_ASPECT[font_style]).ToCString()
         return text_flat
 
     @classmethod

--- a/tests/test_build_sketch.py
+++ b/tests/test_build_sketch.py
@@ -494,12 +494,15 @@ class TestBuildSketchObjects(unittest.TestCase):
         resolved_font = FontManager().find_font(requested_font, FontStyle.REGULAR)
 
         text = Text("test", 2, font=requested_font)
+        compound = Compound.make_text("test", 2, font=requested_font)
 
         self.assertEqual(text.font, resolved_font.FontName().ToCString())
         self.assertEqual(
             text.font_path,
             resolved_font.FontPath(FONT_ASPECT[FontStyle.REGULAR]).ToCString(),
         )
+        self.assertFalse(hasattr(compound, "font"))
+        self.assertFalse(hasattr(compound, "font_path"))
 
     def test_text_singleline(self):
         font_size = 10

--- a/tests/test_build_sketch.py
+++ b/tests/test_build_sketch.py
@@ -32,6 +32,7 @@ from math import atan2, degrees, gamma, pi, sqrt
 import pytest
 
 from build123d import *
+from build123d.text import FONT_ASPECT, FontManager
 
 
 def _assertTupleAlmostEquals(self, expected, actual, places, msg=None):
@@ -472,8 +473,12 @@ class TestBuildSketchObjects(unittest.TestCase):
             t = Text("test", 2)
         self.assertEqual(t.txt, "test")
         self.assertEqual(t.font_size, 2)
-        self.assertEqual(t.font, "Arial")
-        self.assertIsNone(t.font_path)
+        resolved_font = FontManager().find_font("Arial", FontStyle.REGULAR)
+        self.assertEqual(t.font, resolved_font.FontName().ToCString())
+        self.assertEqual(
+            t.font_path,
+            resolved_font.FontPath(FONT_ASPECT[FontStyle.REGULAR]).ToCString(),
+        )
         self.assertEqual(t.font_style, FontStyle.REGULAR)
         self.assertEqual(t.text_align, (TextAlign.CENTER, TextAlign.CENTER))
         self.assertIsNone(t.align)
@@ -483,6 +488,18 @@ class TestBuildSketchObjects(unittest.TestCase):
         self.assertEqual(t.mode, Mode.ADD)
         self.assertEqual(len(test.sketch.faces()), 4)
         self.assertEqual(t.faces()[0].normal_at(), Vector(0, 0, 1))
+
+    def test_text_resolved_font_attributes(self):
+        requested_font = "__missing_build123d_font__"
+        resolved_font = FontManager().find_font(requested_font, FontStyle.REGULAR)
+
+        text = Text("test", 2, font=requested_font)
+
+        self.assertEqual(text.font, resolved_font.FontName().ToCString())
+        self.assertEqual(
+            text.font_path,
+            resolved_font.FontPath(FONT_ASPECT[FontStyle.REGULAR]).ToCString(),
+        )
 
     def test_text_singleline(self):
         font_size = 10


### PR DESCRIPTION
## Summary

- expose the font name and file path that OpenCascade actually resolved on `Text.font` and `Text.font_path`
- centralize font lookup in the owner-proposed `Compound.resolve_font()` helper
- preserve the existing `Compound.make_text()` return type and avoid adding attributes to `Compound`
- add a regression for a missing requested font that falls back to a system font

Fixes #1235.

## Root cause

`Text` stored the caller-provided `font` and `font_path` values before `Compound.make_text()` resolved them through `FontManager`. When OpenCascade substituted a fallback font, the geometry used the fallback while the public attributes still reported the request.

The revision follows the maintainer's proposed design: `Compound.resolve_font()` returns the resolved name, path, and system-font object. `make_text()` uses it without changing its output, while `Text` uses the same helper to populate its existing public attributes. No dynamic metadata is attached to `Compound` or `Shape`.

## Scope and risk

Risk: low. The change is limited to resolving and reporting text font metadata. Glyph generation, alignment, paths, single-line outlining, and the `Compound.make_text()` signature and return type are unchanged.

Non-goals: changing fallback selection, font registration, font discovery, OpenCascade rendering, or introducing a generic metadata API.

## Reproduction and validation

Reproduced on current `dev` at `b8f85510840712ab63b2eb3c12b004f0ef4ad0a3`: requesting a deliberately missing font rendered with the OpenCascade fallback but left `Text.font` set to the missing name.

- focused text tests: 4 passed, 49 deselected
- required parallel suite: 2,225 passed, 2 skipped, with one `TestFontManager.test_register_system_fonts` failure
- the exact font-inventory failure reproduces in isolation on an unmodified `upstream/dev` worktree, so it is not caused by this PR
- full serial suite excluding that exact baseline test: 2,225 passed, 2 skipped, 1 deselected, 68 subtests passed
- Mypy on both changed source files: passed
- `git diff --check`: passed
- Sphinx HTML: passed with 7 pre-existing warnings
- Black reports only pre-existing formatting in `objects_sketch.py` and `test_build_sketch.py`; the changed `composite.py` is clean
- Pylint reports only two pre-existing `wrapped` attribute warnings in `composite.py`; the new lines add no warnings

## Documentation impact

The `Text` docstring states that `font` and `font_path` contain the resolved values after construction. No separate guide change is needed because the constructor inputs and user workflow are unchanged.

## Remaining gates

Repository CI, maintainer review, and merge remain external.
