### PR TITLE
.readthedocs.yaml -> skip PR if docs related items are unchanged, update to py311

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,13 +7,26 @@ formats:
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.10"
+    python: "3.11"
   apt_packages:
     - graphviz
   jobs:
     post_checkout:
-      # necessary to ensure that the development builds get a correct version tag
+      # Necessary to ensure that the development builds get a correct version tag
       - git fetch --unshallow || true
+      # Cancel PR build if no documentation-relevant files changed
+      - |
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ]; then
+          TARGET_BRANCH="${READTHEDOCS_BASE_REVISION:-origin/dev}"
+          if git diff --quiet "$TARGET_BRANCH" -- \
+              docs/ \
+              examples/ \
+              pyproject.toml \
+              .readthedocs.yaml; then
+            echo "No documentation-relevant changes detected. Skipping build."
+            exit 183
+          fi
+        fi
 
 # Build from the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
- Pre-requisite: requires PR builds are enabled on RTD admin page
- This PR enables skipping docs builds PRs if certain files or folders are not changed: currently that is `docs/ examples/ .readthedocs.yaml pyproject.toml`
  - if this condition is met it issues the special exit code 183 which signals to RTD to skip the build
- Technically changes to `src/` DO affect the docs builds, but I left that off for now (we can always add it in later if we find it necessary)
- Updated from python 3.10 to python 3.11 in advance of 3.10 EOL in end of Oct 2026