### PR TITLE
Document out-of-range curve position behavior

### DIFF
--- a/docs/build_line.rst
+++ b/docs/build_line.rst
@@ -61,6 +61,12 @@ line with ``l1 @ 0`` and the end with ``l1 @ 1``.  The ``@`` operator takes
 a float (or integer) parameter between 0 and 1 and determines a position
 at this fractional position along the line's length.
 
+Values outside the usual 0-to-1 range are also accepted by ``position_at``,
+``tangent_at``, and ``location_at``. On an ``Edge``, the underlying curve is
+evaluated beyond the trimmed edge where supported: open curves can extrapolate
+and periodic curves can wrap. On a ``Wire``, out-of-range values are clamped to
+the first or last point (and its corresponding tangent or location frame).
+
 This example can be improved on further by calculating the mid-point
 of the arc as follows:
 

--- a/docs/cheat_sheet.rst
+++ b/docs/cheat_sheet.rst
@@ -179,12 +179,16 @@ Cheat Sheet
     +----------+---------------------+-----------------------------------------+---------------------------------+
     | Operator | Operand             | Method                                  | Description                     |
     +==========+=====================+=========================================+=================================+
-    | @        | 0.0 <= float <= 1.0 | :meth:`~topology.Mixin1D.position_at`   | Position as Vector along object |
+    | @        | float               | :meth:`~topology.Mixin1D.position_at`   | Position as Vector along object |
     +----------+---------------------+-----------------------------------------+---------------------------------+
-    | %        | 0.0 <= float <= 1.0 | :meth:`~topology.Mixin1D.tangent_at`    | Tangent as Vector along object  |
+    | %        | float               | :meth:`~topology.Mixin1D.tangent_at`    | Tangent as Vector along object  |
     +----------+---------------------+-----------------------------------------+---------------------------------+
-    | ^        | 0.0 <= float <= 1.0 | :meth:`~topology.Mixin1D.location_at`   | Location along object           |
+    | ^        | float               | :meth:`~topology.Mixin1D.location_at`   | Location along object           |
     +----------+---------------------+-----------------------------------------+---------------------------------+
+
+    These operators normally use values from 0.0 to 1.0. Outside that range,
+    an ``Edge`` evaluates its underlying curve where supported, while a ``Wire``
+    clamps to its first or last point.
 
 .. card:: Shape Operators
 

--- a/src/build123d/topology/one_d.py
+++ b/src/build123d/topology/one_d.py
@@ -994,7 +994,7 @@ class Mixin1D(Shape[TOPODS]):
         Generate a location along the underlying curve.
 
         Args:
-            distance (float): distance or parameter value
+            distance (float): normalized parameter or length value
             position_mode (PositionMode, optional): position calculation mode.
                 Defaults to PositionMode.PARAMETER.
             frame_method (FrameMethod, optional): moving frame calculation method.
@@ -1005,6 +1005,12 @@ class Mixin1D(Shape[TOPODS]):
             x_dir (VectorLike, optional): override the x_dir to help with plane
                 creation along a 1D shape. Must be perpendicular to shapes tangent.
                 Defaults to None.
+
+        Note:
+            Numeric values are normally within the shape: ``[0.0, 1.0]`` in
+            parameter mode or ``[0.0, length]`` in length mode. Values outside
+            that range extrapolate or wrap on an Edge where its underlying curve
+            supports it, while a Wire clamps them to its first or last point.
 
         Returns:
             Location: A Location object representing local coordinate system
@@ -1263,12 +1269,18 @@ class Mixin1D(Shape[TOPODS]):
     ) -> Vector:
         """Position At
 
-        Generate a position along the underlying Wire.
+        Generate a position along the underlying 1D shape.
 
         Args:
-            position (float): distance or parameter value
+            position (float): normalized parameter or length value
             position_mode (PositionMode, optional): position calculation mode. Defaults to
                 PositionMode.PARAMETER.
+
+        Note:
+            Numeric values are normally within the shape: ``[0.0, 1.0]`` in
+            parameter mode or ``[0.0, length]`` in length mode. Values outside
+            that range extrapolate or wrap on an Edge where its underlying curve
+            supports it, while a Wire clamps them to its first or last point.
 
         Returns:
             Vector: position on the underlying curve
@@ -1521,6 +1533,12 @@ class Mixin1D(Shape[TOPODS]):
                 point on shape. Defaults to 0.5.
             position_mode (PositionMode, optional): position calculation mode.
                 Defaults to PositionMode.PARAMETER.
+
+        Note:
+            Numeric positions are normally within the shape: ``[0.0, 1.0]`` in
+            parameter mode or ``[0.0, length]`` in length mode. Values outside
+            that range evaluate the tangent of an extrapolated or periodic Edge
+            where supported, while a Wire uses its first or last tangent.
 
         Returns:
             Vector: tangent value


### PR DESCRIPTION
## Summary

- explain how `position_at`, `tangent_at`, and `location_at` handle numeric values outside their usual range
- distinguish Edge extrapolation/periodicity from Wire endpoint clamping
- update the BuildLine guide, cheat sheet, and generated API documentation source

Closes #1355.

## Root cause and scope

The public documentation described normalized positions as 0.0–1.0 but did not explain that the methods accept values outside that range or that Edge and Wire behavior differs. This low-risk patch documents the existing behavior only; it does not change geometry, parameter mapping, or any public API.

Non-goals: changing OCCT extrapolation, periodic evaluation, Wire clamping, or validation rules.

## Reproduction

Reproduced on current upstream `dev` at `817aaefc6c2e43d7b60a92bd6819158e9cfe433b`:

- an open line Edge evaluated `position_at(-0.5)` at `(-5, 0, 0)` and `position_at(1.5)` at `(15, 0, 0)`
- a two-segment Wire clamped the same values to its first and last points
- a circular Edge continued on its periodic underlying curve
- `tangent_at` and `location_at` followed the corresponding Edge or Wire behavior

## Validation

- `python -m pytest tests/test_direct_api/test_mixin1_d.py -q`: 40 passed
- `black --check src/build123d/topology/one_d.py`: passed
- `mypy src/build123d/topology/one_d.py`: passed
- `pylint src/build123d/topology/one_d.py`: 9.98/10; only three pre-existing unrelated unused argument/variable warnings
- `make -C docs html`: succeeded; the new guide, cheat-sheet, and API text all rendered (seven existing unrelated Sphinx/Graphviz warnings)
- `python -m pytest -n auto`: 2,223 passed, 2 failed, 2 skipped; both failures were the existing fixed-filename `test.gltf`/`test.glb` xdist race
- `python -m pytest tests/test_materials.py::TestMaterialGltfExport -q`: 4 passed serially, confirming the parallel-only file race
- `git diff --check`: passed

## Documentation impact

This PR is documentation-only. It updates the user-facing operator guide and cheat sheet plus the three API docstrings that feed the direct API reference.

Remaining gates: maintainer review, repository CI, and merge decision.
