### PR TITLE
Fix ConstrainedArcs Axis overload annotation

### DIFF
--- a/src/build123d/objects_curve.py
+++ b/src/build123d/objects_curve.py
@@ -760,7 +760,7 @@ class ConstrainedArcs(BaseCurveObject):
         tangency_one: tuple[Axis | Edge, Tangency] | Axis | Edge | Vertex | VectorLike,
         *,
         radius: float,
-        center_on: Edge,
+        center_on: Axis | Edge,
         selector: Callable[
             [ShapeList[Edge]], Edge | ShapeList[Edge]
         ] = lambda arcs: arcs,

--- a/tests/test_direct_api/test_constrained_arcs.py
+++ b/tests/test_direct_api/test_constrained_arcs.py
@@ -586,6 +586,9 @@ def test_higher_level_constrained_arcs():
     lines = ConstrainedArcs(unit_circle, Axis.Y, radius=1)
     assert len(lines.edges()) == 4
 
+    axis_centered = ConstrainedArcs(Line((0, 0), (4, 0)), radius=1, center_on=Axis.Y)
+    assert len(axis_centered.edges()) == 2
+
     with BuildLine() as drawing:
         ConstrainedArcs(
             unit_circle, Axis.Y, radius=1, selector=lambda a: a.group_by(Axis.Y)[-1]


### PR DESCRIPTION
## Summary

- Allow Axis as well as Edge in the single-tangent, radius, center_on ConstrainedArcs overload.
- Add a focused higher-level regression that exercises Axis.Y as the center locus.

Fixes #1369.

## Root cause

The runtime delegates to Edge.make_constrained_arcs, which already accepts Axis for this signature, and the docstring already describes Axis or Edge. Only the fifth public overload annotated center_on as Edge, so static type checking rejected a valid runtime call.

The patch changes that annotation to Axis | Edge and leaves runtime behavior unchanged.

## Scope and risk

Risk: low. This is a one-line overload correction plus one runtime regression. It does not change geometry construction, return values, selectors, builder behavior, or any other overload.

Non-goals: no constrained-arc algorithm changes, no overload refactor, and no broader typing cleanup.

## Reproduction

A temporary mypy probe calling ConstrainedArcs(Line(...), radius=1, center_on=Axis.Y) failed on current dev with call-overload while the same call ran successfully. After the annotation change, the identical probe passes.

## Validation

- python -m pytest tests/test_direct_api/test_constrained_arcs.py -q: 38 passed.
- mypy --config-file mypy.ini src/build123d: passed for 41 source files.
- pylint src/build123d/objects_curve.py: 10.00/10.
- black --check --target-version py313 tests/test_direct_api/test_constrained_arcs.py: passed. The source file has identical pre-existing formatter drift on current dev and the patched tree, so unrelated lines were not reformatted.
- make -C docs html: succeeded for 50 sources with seven pre-existing warnings.
- python -m pytest -n auto: 2,223 passed, two failed, two skipped. The two failures were the existing shared test.gltf/test.glb xdist fixed-file race in TestMaterialGltfExport; that full class then passed 4/4 serially.
- git diff --check: passed.

## Documentation impact

None. The existing public docstring already states center_on accepts Axis | Edge; this patch aligns the overload annotation with that documented and existing runtime contract.

## Remaining gates

Repository CI, maintainer review, and merge remain external gates.