### PR TITLE
Document local and global assembly locations

### DIFF
--- a/docs/assemblies.rst
+++ b/docs/assemblies.rst
@@ -77,6 +77,26 @@ and now the screw is part of the assembly.
         ├── outer hinge Hinge    at 0x7fc9292c3f40, Location(p=(-150, 60, 50), o=(90, 0, 90))
         └── M6 screw    Compound at 0x7fc8ee235310, Location(p=(-157, -40, 70), o=(-0, -90, -60))
 
+.. _assembly_locations:
+
+**************************
+Local and Global Locations
+**************************
+
+Each shape's :attr:`~topology.Shape.location` is relative to its parent in the
+assembly tree. To find the accumulated placement in the global coordinate
+system, use :attr:`~topology.Shape.global_location`. For example:
+
+.. code:: python
+
+    child = Box(1, 1, 1)
+    child.location = Location((0, 2, 0))
+    assembly = Compound(children=[child])
+    assembly.location = Location((3, 0, 0))
+
+    child.location.position         # (0, 2, 0), relative to assembly
+    child.global_location.position  # (3, 2, 0), relative to world origin
+
 .. _shallow_copy:
 
 *********************************


### PR DESCRIPTION
## Summary

- explain that `Shape.location` is relative to the parent assembly node
- document `Shape.global_location` as the accumulated world-space placement
- add a minimal nested placement example with concrete local and global coordinates

Closes #1028.

## Root cause

`global_location` already has tested runtime behavior, but the Assemblies guide showed component locations without explaining whether they were parent-relative or world-relative. This made the property difficult to discover from the primary assembly documentation.

## Scope and risk

Risk: low, documentation-only.

The change is limited to `docs/assemblies.rst`. It does not modify runtime behavior, public APIs, tests, exports, or assembly semantics.

## Reproduction and evidence

On current upstream `dev` at `44a8d7c12abced5a3af93813a07147d271e5922d`, a child at `(0, 2, 0)` under an assembly at `(3, 0, 0)` reports:

- `child.location.position == (0, 2, 0)`
- `child.global_location.position == (3, 2, 0)`

The existing `TestGlobalLocation` coverage also verifies nested translation and orientation composition.

## Validation

- focused executable probe: passed
- `.venv/bin/python -m pytest tests/test_direct_api/test_shape.py::TestGlobalLocation -q`: 2 passed
- `PATH="$PWD/.venv/bin:$PATH" make -C docs clean html`: 50 sources built successfully; 7 pre-existing warnings
- `.venv/bin/python -m pytest -n auto`: 2226 passed, 2 skipped
- `git diff --check`: passed

## Documentation impact

The Assemblies guide now distinguishes local and global placement and provides a concrete example at the point where assembly component locations are first shown.

## Non-goals

- no changes to location composition behavior
- no new assembly APIs
- no unrelated documentation reformatting

## Remaining gates

Repository CI, maintainer review, and maintainer merge decision.