### PR TITLE
Fix stochastic font registration test failures

### DIFF
--- a/src/build123d/text.py
+++ b/src/build123d/text.py
@@ -203,15 +203,24 @@ class FontManager:
                 "/Library/Fonts/Supplemental",
                 os.path.expanduser("~/Library/Fonts"),
             ]
-        else:
-            paths = [
-                "/system/fonts",  # Android
+        else:  # Linux / Unix
+            base_paths = [
+                "/system/fonts",
                 "/usr/share/fonts",
                 "/usr/local/share/fonts",
+                os.path.expanduser("~/.fonts"),
+                os.path.expanduser("~/.local/share/fonts"),
+            ]
+            paths = [
+                root
+                for path in base_paths
+                if os.path.exists(path)
+                for root, _, _ in os.walk(path)
             ]
 
         for path in paths:
-            self.register_folder(path)
+            if os.path.exists(path):
+                self.register_folder(path)
 
     def _get_font_faces(
         self, ft_font: TTFont, path: str

--- a/src/build123d/text.py
+++ b/src/build123d/text.py
@@ -196,7 +196,13 @@ class FontManager:
             ]
         elif platform.system() == "Darwin":  # pragma: no cover
             # macOS
-            paths = ["/System/Library/Fonts", "/Library/Fonts"]
+            paths = [
+                "/System/Library/Fonts",
+                "/System/Library/Fonts/Supplemental",
+                "/Library/Fonts",
+                "/Library/Fonts/Supplemental",
+                os.path.expanduser("~/Library/Fonts"),
+            ]
         else:
             paths = [
                 "/system/fonts",  # Android

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -23,6 +23,12 @@ from build123d.text import FONT_ASPECT, FontInfo, FontManager
 class TestFontManager(unittest.TestCase):
     """Tests for FontManager."""
 
+    def tearDown(self):
+        """Restore font database for subsequent tests in the same worker."""
+        manager = FontManager()
+        manager.register_system_fonts()
+        manager.__init__()
+    
     def test_persistence(self):
         """OCP FontMgr expected to persist db over multiple instances"""
         instance1 = FontManager()


### PR DESCRIPTION
- We started noticing failures on runners related to `test_register_system_fonts`. This seemed to especially happen on the macos-15-intel runner but also noticed a failure on ubuntu-22.04. I believe these failures started occuring with merge of https://github.com/gumyr/build123d/pull/1413
- After further investigation I believe this is caused by flushing the FontMgr global singleton and tests running in different orders due to our use of pytest-xdist
- The key mitigation in this PR is to implement `unittest` `tearDown` to ensure consistent runner state even when tests are run in different order because of pytest-xdist
- I also added a few additional paths to Darwin and Linux / Unix platforms. There were also some changes to Linux / Unix side because on this platform fonts are typically stored in subdirectories rather than the directory itself.