### PR TITLE
Fix full_round return type annotation

### DIFF
--- a/src/build123d/operations_sketch.py
+++ b/src/build123d/operations_sketch.py
@@ -55,7 +55,7 @@ def full_round(
     invert: bool = False,
     voronoi_point_count: int = 100,
     mode: Mode = Mode.REPLACE,
-) -> tuple[Sketch, Vector, float]:
+) -> Sketch:
     """Sketch Operation: full_round
 
     Given an edge from a Face/Sketch, modify the face by replacing the given edge with the

--- a/tests/test_build123d_type.py
+++ b/tests/test_build123d_type.py
@@ -1,3 +1,5 @@
+from typing import get_type_hints
+
 import pytest
 
 from build123d import (
@@ -20,6 +22,7 @@ from build123d import (
     Vector,
     Vertex,
     Wire,
+    full_round,
 )
 
 
@@ -49,3 +52,7 @@ from build123d import (
 )
 def test_build123d_type(cls):
     assert cls.build123d_type == cls.__name__
+
+
+def test_full_round_return_type():
+    assert get_type_hints(full_round)["return"] is Sketch


### PR DESCRIPTION
## Summary

- Correct `full_round()`'s declared return type from a three-item tuple to `Sketch`.
- Add a regression test that resolves the public annotation and verifies it matches the value the function returns.

Fixes #1020.

## Root cause

`full_round()` has always returned `Sketch([pending_face])`, and its docstring also documents a `Sketch`, but its annotation still declared `tuple[Sketch, Vector, float]`. The patch changes only that stale annotation and adds a focused type-metadata regression.

## Scope and risk

Risk: low. This is a static typing and generated-API-signature correction; runtime geometry and the public calling convention are unchanged.

Non-goals:

- no geometry or builder behavior changes;
- no refactor of `full_round()`;
- no changes to adjacent sketch operations.

## Reproduction and validation

On current upstream `dev` (`2851b0119`), the focused regression failed because `get_type_hints(full_round)["return"]` resolved to `tuple[Sketch, Vector, float]`. It passes after the annotation correction.

- `.venv/bin/python -m pytest tests/test_build123d_type.py::test_full_round_return_type -q` — 1 passed.
- `.venv/bin/black --check --target-version py312 src/build123d/operations_sketch.py tests/test_build123d_type.py` — passed.
- `.venv/bin/pylint src/build123d/operations_sketch.py` — 10.00/10.
- `.venv/bin/mypy src/build123d/operations_sketch.py tests/test_build123d_type.py` — passed.
- `.venv/bin/python -m pytest -n auto` — 2,219 passed, 2 skipped; eight `ImportSTEP` setup errors were caused by the local Python CA store rejecting the public test-fixture download.
- After caching the unchanged public fixture by SHA-256, `.venv/bin/python -m pytest tests/test_importers.py::ImportSTEP -q` — 8 passed.
- `PATH="$PWD/.venv/bin:$PATH" make -C docs html` — all 50 sources built successfully with seven pre-existing warnings.
- `git diff --check` — passed.

## Documentation impact

No prose documentation change is needed. The corrected annotation fixes the generated API signature and now agrees with the existing docstring and runtime return value.

## Remaining gates

Repository CI, maintainer review, and the merge decision remain external.
