### PR TITLE
Report offset_2d builder failures clearly

### DIFF
--- a/src/build123d/topology/one_d.py
+++ b/src/build123d/topology/one_d.py
@@ -1156,6 +1156,7 @@ class Mixin1D(Shape[TOPODS]):
             closed (bool, optional): if Side!=BOTH, close the LEFT or RIGHT
                 offset. Defaults to True.
         Raises:
+            RuntimeError: 2D offset calculation failed
             RuntimeError: Multiple Wires generated
             RuntimeError: Unexpected result type
 
@@ -1185,6 +1186,8 @@ class Mixin1D(Shape[TOPODS]):
         # offset_builder.SetApprox(True)
         offset_builder.AddWire(topods_wire)
         offset_builder.Perform(distance)
+        if not offset_builder.IsDone():
+            raise RuntimeError(f"2D offset failed with distance {distance}")
 
         obj = downcast(offset_builder.Shape())
         if isinstance(obj, TopoDS_Compound):

--- a/tests/test_direct_api/test_mixin1_d.py
+++ b/tests/test_direct_api/test_mixin1_d.py
@@ -400,6 +400,18 @@ class TestMixin1D(unittest.TestCase):
         # self.assertTrue(offset_edge.geom_type == GeomType.LINE)
         # self.assertAlmostEqual(offset_edge.position_at(0).X, 3)
 
+    def test_offset_2d_builder_failure(self):
+        """Verify that OCCT offset failures are reported before reading Shape()."""
+        with patch("build123d.topology.one_d.BRepOffsetAPI_MakeOffset") as builder:
+            offset_builder = builder.return_value
+            offset_builder.IsDone.return_value = False
+            offset_builder.Shape.side_effect = ValueError("Null TopoDS_Shape object")
+
+            with self.assertRaisesRegex(RuntimeError, "2D offset failed.*0.1"):
+                Wire.make_rect(1, 1).offset_2d(0.1)
+
+            offset_builder.Shape.assert_not_called()
+
     def test_common_plane(self):
         # Straight and circular lines
         l = Edge.make_line((0, 0, 0), (5, 0, 0))


### PR DESCRIPTION
## Summary

- check `BRepOffsetAPI_MakeOffset.IsDone()` before reading its result shape
- raise a contextual `RuntimeError` that includes the requested offset distance
- add a focused regression proving that a failed builder never reaches `Shape()`

Fixes #1425

## Root cause

`Mixin1D.offset_2d()` called `Shape()` immediately after `Perform()`. When OCCT reports the operation as not done, that result can be null, so the generic `ValueError: Null TopoDS_Shape object` escaped before build123d could identify the failed offset operation.

## Scope and risk

Risk is low. The patch adds one guard on the existing OCCT completion state and leaves the method signature, successful path, return types, join behavior, and side-selection logic unchanged.

Non-goals: changing offset algorithms, retrying failed offsets, handling multiple generated wires, or changing any other topology operation.

## Reproduction

On current `dev` (`2851b011`), a deterministic builder-failure regression showed that `IsDone()` was never called and `Shape()` was called once, surfacing `ValueError: Null TopoDS_Shape object`. With this patch, the same failure state raises `RuntimeError: 2D offset failed with distance 0.1`, and `Shape()` is not called.

## Validation

- `python -m pytest tests/test_direct_api/test_mixin1_d.py -q`: 41 passed
- focused failure regression: passed; diff coverage 100% for the two new production lines
- `black --check` on both changed files: unchanged
- `mypy src/build123d`: passed for 41 source files
- `pylint src/build123d/topology/one_d.py`: 9.98/10; three pre-existing warnings
- `python -m pytest -n auto`: 2,226 passed, 2 skipped, 1 failed

The sole full-suite failure is the existing environment-sensitive `TestFontManager.test_register_system_fonts` count assertion. It also fails serially on the untouched `2851b011` baseline with the same 1,828-after versus 2,382-before counts, so it is unrelated to these two changed files.

## Documentation impact

The public method docstring now documents the offset-calculation `RuntimeError`. No separate guide or example changes are needed because the successful API and workflow are unchanged.

## Remaining gates

Repository CI, maintainer review, and merge remain external gates.
