### PR TITLE
Preserve colors when exporting base part objects to 3MF

### DIFF
--- a/src/build123d/mesher.py
+++ b/src/build123d/mesher.py
@@ -399,7 +399,7 @@ class Mesher:
             if isinstance(input_shape, Compound):
                 if input_shape.children:
                     shapes.extend(input_shape.children)
-                elif input_shape.label:
+                elif input_shape.label or input_shape.color is not None:
                     shapes.append(input_shape)
                 else:
                     shapes.extend(list(input_shape))

--- a/tests/test_mesher.py
+++ b/tests/test_mesher.py
@@ -167,6 +167,26 @@ class TestAddShape(DirectApiTestCase):
         self.assertTupleAlmostEquals(tuple(box.color), (0, 0, 1, 1), 5)
         self.assertTupleAlmostEquals(tuple(cone.color), (1, 0, 0, 1), 5)
 
+    def test_add_colored_base_part_objects(self):
+        """Parent colors survive 3MF export of BasePartObject wrappers."""
+        parts = [Box(1, 1, 1), Box(1, 1, 1).locate(Location((2, 0, 0)))]
+        expected_colors = [Color("red"), Color(0, 0, 1, 0.25)]
+        for part, color in zip(parts, expected_colors):
+            part.color = color
+
+        exporter = Mesher()
+        exporter.add_shape(parts)
+        filename = temp_3mf_file()
+        exporter.write(filename)
+
+        importer = Mesher()
+        imported_parts = importer.read(filename)
+        self.assertEqual(importer.mesh_count, 2)
+        for imported_part, expected_color in zip(imported_parts, expected_colors):
+            self.assertTupleAlmostEquals(
+                tuple(imported_part.color), tuple(expected_color), 2
+            )
+
     def test_add_compound(self):
         exporter = Mesher()
         box = Solid.make_box(1, 1, 1)


### PR DESCRIPTION
## Summary

- preserve color metadata when Mesher.add_shape receives colored BasePartObject wrappers such as Box or Cone
- keep the existing split behavior for unlabeled, uncolored Compounds
- add a round-trip regression covering opaque and transparent colors

Fixes #929

## Root cause

Mesher.add_shape preserved Compound wrappers with labels, but still expanded an unlabeled wrapper even when it carried color metadata. The extracted sub-shapes did not retain the wrapper color, so the generated 3MF meshes had no material color.

The fix extends the existing wrapper-preservation condition to color metadata. This is the smallest change that keeps object-level color attached through the current 3MF material path.

## Scope and risk

Risk: low. The change is one condition in 3MF shape normalization plus a focused regression.

Non-goals: no changes to STEP, glTF, STL, general color inheritance, Compound construction, or assembly semantics.

## Reproduction and validation

Current upstream dev reproduced the issue: two colored Box/Cone wrappers exported as two meshes, but both colors read back as None. The new regression failed before the implementation and passes after it.

- python -m pytest tests/test_mesher.py::TestAddShape::test_add_colored_base_part_objects -q: 1 passed
- python -m pytest tests/test_mesher.py -q: 23 passed, 5 subtests passed
- python -m pytest -n auto: 2227 passed, 2 skipped
- black --check src/build123d/mesher.py tests/test_mesher.py: unchanged
- pylint src/build123d/mesher.py: 10.00/10
- mypy src/build123d: 41 source files passed
- diff-cover coverage.xml --compare-branch=origin/dev --fail-under=95: 100% diff coverage
- git diff --check: passed

## Documentation impact

None. This restores the documented 3MF color behavior for an existing public input type without changing the API or workflow.

## Remaining gates

Repository CI, maintainer review, and the maintainer merge decision remain external.