### PR TITLE
Support ColorLike in ExportDXF

### DIFF
--- a/docs/import_export.rst
+++ b/docs/import_export.rst
@@ -220,6 +220,10 @@ Enum and are shown in the following diagram:
 ExportDXF
 ---------
 
+``ExportDXF`` accepts the standard :class:`~geometry.ColorLike` interface for
+document and layer colors. The older ``ColorIndex`` values remain supported
+during the transition but emit a ``DeprecationWarning``.
+
 .. autoclass:: exporters.ExportDXF
     :noindex:
 

--- a/src/build123d/exporters.py
+++ b/src/build123d/exporters.py
@@ -468,7 +468,9 @@ class ExportDXF(Export2D):
         unit (Unit, optional): The unit used for the exported DXF. It should be
             one of the Unit enums: Unit.MC, Unit.MM, Unit.CM,
             Unit.M, Unit.IN, or Unit.FT. Defaults to Unit.MM.
-        color (ColorLike | None, optional): The default color for shapes.
+        color (ColorLike | None, optional): The default color for shapes. Use a
+            color name, hexadecimal value, or normalized RGB(A) tuple. Legacy
+            ColorIndex values remain supported with a DeprecationWarning.
             Defaults to None.
         line_weight (Optional[float], optional): The default line weight
             (stroke width) for shapes, in millimeters. . Defaults to None.
@@ -558,7 +560,9 @@ class ExportDXF(Export2D):
         Args:
             name (str): The name of the layer definition. Must be unique among all layers.
             color (ColorLike | None, optional): The color for shapes on this layer.
-                Defaults to None.
+                Use a color name, hexadecimal value, or normalized RGB(A) tuple.
+                Legacy ColorIndex values remain supported with a
+                DeprecationWarning. Defaults to None.
             line_weight (Optional[float], optional): The line weight (stroke width) for shapes
                 on this layer, in millimeters. Defaults to None.
             line_type (Optional[LineType], optional): The line type for shapes on this layer.

--- a/src/build123d/exporters.py
+++ b/src/build123d/exporters.py
@@ -468,8 +468,8 @@ class ExportDXF(Export2D):
         unit (Unit, optional): The unit used for the exported DXF. It should be
             one of the Unit enums: Unit.MC, Unit.MM, Unit.CM,
             Unit.M, Unit.IN, or Unit.FT. Defaults to Unit.MM.
-        color (Optional[ColorIndex], optional): The default color index for shapes.
-            It can be specified as a ColorIndex enum or None.. Defaults to None.
+        color (ColorLike | None, optional): The default color for shapes.
+            Defaults to None.
         line_weight (Optional[float], optional): The default line weight
             (stroke width) for shapes, in millimeters. . Defaults to None.
         line_type (Optional[LineType], optional): e default line type for shapes.
@@ -481,7 +481,7 @@ class ExportDXF(Export2D):
         .. code-block:: python
 
             exporter = ExportDXF(unit=Unit.MM, line_weight=0.5)
-            exporter.add_layer("Layer 1", color=ColorIndex.RED, line_type=LineType.DASHED)
+            exporter.add_layer("Layer 1", color="red", line_type=LineType.DASHED)
             exporter.add_shape(shape_object, layer="Layer 1")
             exporter.write("output.dxf")
 
@@ -515,7 +515,7 @@ class ExportDXF(Export2D):
         self,
         version: str = ezdxf.DXF2013,
         unit: Unit = Unit.MM,
-        color: ColorIndex | None = None,
+        color: ColorLike | ColorIndex | None = None,
         line_weight: float | None = None,
         line_type: LineType | None = None,
     ):
@@ -535,7 +535,7 @@ class ExportDXF(Export2D):
 
         default_layer = self._document.layers.get("0")
         if color is not None:
-            default_layer.color = color.value
+            default_layer.update_dxf_attribs(self._color_attribs(color))
         if line_weight is not None:
             default_layer.dxf.lineweight = round(line_weight * 100)
         if line_type is not None:
@@ -547,7 +547,7 @@ class ExportDXF(Export2D):
         self,
         name: str,
         *,
-        color: ColorIndex | None = None,
+        color: ColorLike | ColorIndex | None = None,
         line_weight: float | None = None,
         line_type: LineType | None = None,
     ) -> Self:
@@ -557,8 +557,8 @@ class ExportDXF(Export2D):
 
         Args:
             name (str): The name of the layer definition. Must be unique among all layers.
-            color (Optional[ColorIndex], optional): The color index for shapes on this layer.
-                It can be specified as a ColorIndex enum or None. Defaults to None.
+            color (ColorLike | None, optional): The color for shapes on this layer.
+                Defaults to None.
             line_weight (Optional[float], optional): The line weight (stroke width) for shapes
                 on this layer, in millimeters. Defaults to None.
             line_type (Optional[LineType], optional): The line type for shapes on this layer.
@@ -576,13 +576,34 @@ class ExportDXF(Export2D):
             kwargs["linetype"] = linetype
 
         if color is not None:
-            kwargs["color"] = color.value
+            kwargs.update(self._color_attribs(color))
 
         if line_weight is not None:
             kwargs["lineweight"] = round(line_weight * 100)
 
         self._document.layers.add(name, **kwargs)
         return self
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    @staticmethod
+    def _color_attribs(color: ColorLike | ColorIndex) -> dict[str, int]:
+        """Convert a color into ezdxf layer attributes."""
+        if isinstance(color, ColorIndex):
+            warn(
+                "ExportDXF ColorIndex values are deprecated; use ColorLike values "
+                "such as 'red' or 0xFF0000 instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            return {"color": color.value}
+
+        red, green, blue, _ = tuple(Color(color))
+        return {
+            "true_color": ezdxf.rgb2int(
+                (round(red * 255), round(green * 255), round(blue * 255))
+            )
+        }
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -179,6 +179,24 @@ class ExportersTestCase(unittest.TestCase):
         svg.add_shape(sketch)
         svg.write("test-colors.svg")
 
+    def test_dxf_color_like(self):
+        """ExportDXF accepts the standard ColorLike interface."""
+        exporter = ExportDXF(color="red")
+        exporter.add_layer("blue", color=0x0000FF)
+
+        self.assertEqual(exporter._document.layers.get("0").rgb, RGB(255, 0, 0))
+        self.assertEqual(exporter._document.layers.get("blue").rgb, RGB(0, 0, 255))
+
+    def test_dxf_color_index_is_deprecated(self):
+        """Legacy DXF ColorIndex inputs still work while warning users."""
+        with self.assertWarns(DeprecationWarning):
+            exporter = ExportDXF(color=ColorIndex.RED)
+        with self.assertWarns(DeprecationWarning):
+            exporter.add_layer("blue", color=ColorIndex.BLUE)
+
+        self.assertEqual(exporter._document.layers.get("0").color, 1)
+        self.assertEqual(exporter._document.layers.get("blue").color, 5)
+
     def test_svg_color_like(self):
         """ExportSVG accepts and normalizes the standard ColorLike interface."""
         svg = ExportSVG(fill_color="#ff000080", line_color=0x0000FF)


### PR DESCRIPTION
## Summary

- accept the standard `ColorLike` interface for `ExportDXF` document and layer colors
- write new color values as DXF true-color attributes
- preserve legacy `ColorIndex` ACI behavior with a `DeprecationWarning`
- update the API documentation and example to prefer `ColorLike`

Closes #1437

## Root cause

`ExportDXF.__init__` and `add_layer` typed their color arguments as
`ColorIndex | None` and unconditionally accessed `.value`. Standard
`ColorLike` inputs such as `"red"` therefore failed with `AttributeError`.

The patch keeps the conversion local to `ExportDXF`: legacy enum values still
produce the same indexed-color attribute, while `ColorLike` values are
normalized through `Color` and stored using ezdxf's native true-color field.

## Scope and risk

This is a low-risk, reversible change limited to `ExportDXF` color argument
normalization, focused tests, and its documentation. Existing `ColorIndex`
values retain their original ACI values. Line type, line weight, geometry
conversion, shape-color inheritance, transparency, and SVG behavior are
unchanged.

The only open PR touching `exporters.py`, #1036, changes SVG wire traversal at
a separate code path and does not overlap this behavior.

## Reproduction and regression

Tested from upstream `dev@8f5ce0bf519a7532decedfda867621122f3126f6` with Python 3.11.0
and ezdxf 1.4.4.

Before the patch:

```
python -m pytest -q \
  tests/test_exporters.py::ExportersTestCase::test_dxf_color_like \
  tests/test_exporters.py::ExportersTestCase::test_dxf_color_index_is_deprecated
2 failed
```

After the patch:

```
python -m pytest -q \
  tests/test_exporters.py::ExportersTestCase::test_dxf_color_like \
  tests/test_exporters.py::ExportersTestCase::test_dxf_color_index_is_deprecated
2 passed
```

## Validation

- `python -m pytest -q tests/test_exporters.py`: 27 passed
- `python -m pytest`: 2,244 passed, 2 skipped
- `python -m pytest -n auto`: 2,243 passed, 2 skipped, with one unrelated
  `TestFontManager.test_register_system_fonts` failure caused by the shared
  macOS font database; the serial full suite passed it
- focused coverage plus `diff-cover coverage.xml --compare-branch=origin/dev`:
  100% diff coverage (9 executable lines)
- `mypy src/build123d`: success across 41 source files
- `pylint --disable=R0911 src/build123d/exporters.py`: 10.00/10; the disabled
  R0911 is an unchanged upstream `ExportSVG` warning reproduced on `origin/dev`
- Black 26 reports the same two pre-existing formatting deltas in
  `exporters.py` and `test_exporters.py` on both this branch and `origin/dev`;
  patch-authored code was formatted without retaining unrelated churn
- `make -C docs html SPHINXBUILD=../.venv/bin/sphinx-build`: 50 sources built,
  with seven unrelated existing docstring/local Graphviz warnings
- `python -m compileall -q src/build123d` and `git diff --check`: passed

## Documentation impact

The `ExportDXF` docstring and the 2D import/export guide now document
`ColorLike` and the temporary `ColorIndex` compatibility warning. No
changelog entry was added because this is an unreleased issue-level correction.

## Remaining gates

Maintainer review, repository CI, and merge remain external.

## Review follow-up (2026-09-05)

- clarified the constructor and layer docstrings per review so they list the
  standard ColorLike input forms and the temporary ColorIndex warning
- validated follow-up head 8e6b31ec against the current PR branch while using
  upstream dev@6a6d406317ac0a54ec5398e20d14149a53c4df34 for compatibility readback
- python -m pytest -q tests/test_exporters.py: 27 passed
- python -m pytest -q: 2,244 passed, 2 skipped, 68 subtests passed
- pylint --disable=too-many-return-statements src/build123d/exporters.py:
  10.00/10; the suppressed warning remains in unchanged ExportSVG code
- mypy src/build123d/exporters.py, compileall, diff check, and merge-tree
  compatibility check: passed
- Sphinx: 50 sources built with the same seven unrelated existing warnings
- Black's only proposed delta remains in unchanged ExportSVG code; the two
  edited docstrings require no formatting change
- current ARM xdist CI completed 2,247 passes and two skips with one unrelated
  fixed-filename GLB artifact race (test.bin left by a parallel test); the same
  test passed in the 2,244-test serial local suite, and this follow-up changes
  docstrings only
