### PR TITLE
Guard unnamed STEP component imports

### DIFF
--- a/src/build123d/importers.py
+++ b/src/build123d/importers.py
@@ -147,7 +147,9 @@ def import_step(filename: PathLike | str | bytes) -> Compound:
         """Extract name and format"""
         name = ""
         std_name = TDataStd_Name()
-        if label.FindAttribute(TDataStd_Name.GetID_s(), std_name):
+        if label.IsAttribute(TDataStd_Name.GetID_s()) and label.FindAttribute(
+            TDataStd_Name.GetID_s(), std_name
+        ):
             name = TCollection_AsciiString(std_name.Get()).ToCString()
         # Remove characters that cause ocp_vscode to fail
         clean_name = "".join(ch for ch in name if unicodedata.category(ch)[0] != "C")

--- a/tests/test_importers.py
+++ b/tests/test_importers.py
@@ -1,9 +1,10 @@
-from io import StringIO
+from io import BytesIO, StringIO
 import os
 from os import fsencode, fsdecode
 import unittest
 import urllib.request
 import tempfile
+import zipfile
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -214,6 +215,24 @@ class ImportSTEP(unittest.TestCase):
         fused = Solid.fuse(*assembly.solids())
         # If the parts where placed correctly they all touch and can be fused
         self.assertEqual(len(fused.solids()), 1)
+
+    def test_unnamed_component(self):
+        file_name = "nist_ctc_02_asme1_ap242-e2.stp"
+        temp_dir = tempfile.gettempdir()
+        file_path = os.path.join(temp_dir, "NIST-PMI-STEP-Files", file_name)
+        if not os.path.exists(file_path):
+            request = urllib.request.Request(
+                "https://www.nist.gov/system/files/documents/noindex/2024/06/19/NIST-PMI-STEP-Files.zip",
+                headers={"User-Agent": "build123d test suite"},
+            )
+            with urllib.request.urlopen(request) as response:
+                with zipfile.ZipFile(BytesIO(response.read())) as archive:
+                    archive.extract(f"NIST-PMI-STEP-Files/{file_name}", temp_dir)
+
+        imported = import_step(file_path)
+
+        self.assertIsInstance(imported, Compound)
+        self.assertIn("", [child.label for child in imported.children])
 
     def test_roundtrip_nested_labels_colors(self):
         a = Solid.make_sphere(1)


### PR DESCRIPTION
## Description

I guard the OCP name lookup before accessing the attribute. Previously, an unnamed assembly component could terminate `import_step`; now it imports with the existing empty-label behavior.

Fixes #1433

## Why

STEP assemblies may omit component names, which should not terminate the interpreter.

## Verification

- Before: importing `nist_ctc_02_asme1_ap242-e2.stp` exited 139.
- After: the same file imports as a `Compound` and retains an empty label for the unnamed component.
- `python -m pytest tests/test_importers.py -q`
