### PR TITLE
Fix angular mesh refinement and expose absolute deflection

### DIFF
--- a/src/build123d/topology/shape_core.py
+++ b/src/build123d/topology/shape_core.py
@@ -1718,23 +1718,41 @@ class Shape(NodeMixin, Generic[TOPODS]):
         shape_copy.wrapped.Location(loc.wrapped)
         return shape_copy
 
-    def mesh(self, tolerance: float, angular_tolerance: float = 0.1):
-        """Generate triangulation if none exists.
+    def mesh(
+        self, tolerance: float, angular_tolerance: float = 0.1, *, relative: bool = True
+    ):
+        """Generate or refine the shape's triangulation.
 
         Args:
-          tolerance: float:
-          angular_tolerance: float:  (Default value = 0.1)
+            tolerance: Linear deflection. With relative=True, OCCT scales this
+                value by each edge's size; otherwise it is in model length units.
+            angular_tolerance: Angular deflection in radians. Defaults to 0.1.
+            relative: Scale linear deflection by edge size. Defaults to True.
 
-        Returns:
-
+        Existing finer triangulations may be reused. Cached polygons are discarded
+        when their recorded angle is insufficient or unknown.
         """
         if self._wrapped is None:
             raise ValueError("Cannot mesh an empty shape")
 
-        if not BRepTools.Triangulation_s(self.wrapped, tolerance):
-            BRepMesh_IncrementalMesh(
-                self.wrapped, tolerance, True, angular_tolerance, True
-            )
+        # OCCT checks cached linear deflection, but not angular deflection.
+        for face in self.faces():
+            triangulation = BRep_Tool.Triangulation_s(face.wrapped, TopLoc_Location())
+            if triangulation is None:
+                continue
+            parameters = triangulation.Parameters()
+            if (
+                parameters is None
+                or not parameters.HasAngle()
+                or parameters.Angle() > angular_tolerance
+            ):
+                # Clear shared edge polygons together with the face triangulations.
+                BRepTools.Clean_s(self.wrapped)
+                break
+
+        BRepMesh_IncrementalMesh(
+            self.wrapped, tolerance, relative, angular_tolerance, True
+        )
 
     def mirror(self, mirror_plane: Plane | None = None) -> Self:
         """
@@ -2209,13 +2227,20 @@ class Shape(NodeMixin, Generic[TOPODS]):
         raise ValueError(f"Unsupported Keep value {keep}")  # pragma: no cover
 
     def tessellate(
-        self, tolerance: float, angular_tolerance: float = 0.1
+        self, tolerance: float, angular_tolerance: float = 0.1, *, relative: bool = True
     ) -> tuple[list[Vector], list[tuple[int, int, int]]]:
-        """General triangulated approximation"""
+        """Return vertices and triangle indices approximating the shape.
+
+        Args:
+            tolerance: Linear deflection, scaled by edge size if relative=True,
+                or in model length units if relative=False.
+            angular_tolerance: Angular deflection in radians. Defaults to 0.1.
+            relative: Scale linear deflection by edge size. Defaults to True.
+        """
         if self._wrapped is None:
             raise ValueError("Cannot tessellate an empty shape")
 
-        self.mesh(tolerance, angular_tolerance)
+        self.mesh(tolerance, angular_tolerance, relative=relative)
 
         vertices: list[Vector] = []
         triangles: list[tuple[int, int, int]] = []
@@ -2263,6 +2288,8 @@ class Shape(NodeMixin, Generic[TOPODS]):
         angular_tolerance: float = 0.1,
         atlas_packing: bool = True,
         atlas_gutter: float = 0.0,
+        *,
+        relative: bool = True,
     ) -> tuple[
         list[Vector],
         list[tuple[int, int, int]],
@@ -2281,8 +2308,10 @@ class Shape(NodeMixin, Generic[TOPODS]):
         all faces into a single [0, 1] texture atlas.
 
         Args:
-            tolerance: linear deflection for tessellation.
-            angular_tolerance: angular deflection for tessellation. Default 0.1.
+            tolerance: linear deflection, scaled by edge size if relative=True,
+                or in model length units if relative=False.
+            angular_tolerance: angular deflection in radians. Default 0.1.
+            relative: scale linear deflection by edge size. Defaults to True.
             atlas_packing: if True (default), pack per-face UVs into a single
                 texture atlas.  If False, each face's UVs are independently
                 normalized to [0, 1].
@@ -2303,7 +2332,7 @@ class Shape(NodeMixin, Generic[TOPODS]):
         if self._wrapped is None:
             raise ValueError("Cannot tessellate an empty shape")
 
-        self.mesh(tolerance, angular_tolerance)
+        self.mesh(tolerance, angular_tolerance, relative=relative)
 
         all_vertices: list[Vector] = []
         all_triangles: list[tuple[int, int, int]] = []

--- a/tests/test_direct_api/test_shape.py
+++ b/tests/test_direct_api/test_shape.py
@@ -34,6 +34,9 @@ from unittest.mock import PropertyMock, patch
 
 import numpy as np
 from OCP.BRepAlgoAPI import BRepAlgoAPI_Cut, BRepAlgoAPI_Fuse
+from OCP.BRep import BRep_Tool
+from OCP.Poly import Poly_TriangulationParameters
+from OCP.TopLoc import TopLoc_Location
 from anytree import PreOrderIter
 from build123d.build_enums import CenterOf, GeomType, Keep
 from build123d.geometry import (
@@ -305,6 +308,49 @@ class TestShape(unittest.TestCase):
         verts, triangles = box123.tessellate(1e-6)
         self.assertEqual(len(verts), 24)
         self.assertEqual(len(triangles), 12)
+
+    def test_tessellate_angular_refinement(self):
+        """Tighter angles refine an existing triangulation to fresh-mesh resolution."""
+        for relative in (True, False):
+            with self.subTest(relative=relative):
+                sphere = Solid.make_sphere(1)
+                _, coarse = sphere.tessellate(0.01, 0.3, relative=relative)
+                _, fine = sphere.tessellate(0.01, 0.1, relative=relative)
+                _, fresh = Solid.make_sphere(1).tessellate(0.01, 0.1, relative=relative)
+                self.assertGreater(len(fine), len(coarse))
+                self.assertEqual(len(fine), len(fresh))
+                _, repeated = sphere.tessellate(0.01, 0.1, relative=relative)
+                self.assertEqual(len(repeated), len(fine))
+
+                for parameters in (None, Poly_TriangulationParameters()):
+                    sphere = Solid.make_sphere(1)
+                    sphere.mesh(0.01, 0.3, relative=relative)
+                    for face in sphere.faces():
+                        triangulation = BRep_Tool.Triangulation_s(
+                            face.wrapped, TopLoc_Location()
+                        )
+                        triangulation.Parameters(parameters)
+                    _, refined = sphere.tessellate(0.01, 0.1, relative=relative)
+                    self.assertEqual(len(refined), len(fresh))
+
+    def test_tessellate_absolute_deflection(self):
+        """Absolute deflection scales with length units and controls sphere error."""
+        for method in ("tessellate", "tessellate_with_uvs"):
+            with self.subTest(method=method):
+                counts, errors = [], []
+                for radius, tolerance in ((1, 0.01), (10, 0.1), (10, 0.01)):
+                    vertices, triangles, *_ = getattr(
+                        Solid.make_sphere(radius), method
+                    )(tolerance, 1.0, relative=False)
+                    points = np.array([tuple(vertex) for vertex in vertices]) / radius
+                    centers = points[triangles].mean(axis=1)
+                    counts.append(len(triangles))
+                    errors.append((1 - np.linalg.norm(centers, axis=1)).max())
+                # Changing length units must preserve the normalized sphere mesh.
+                self.assertEqual(counts[0], counts[1])
+                self.assertAlmostEqual(errors[0], errors[1])
+                self.assertGreater(counts[2], counts[1])
+                self.assertLess(errors[2], errors[1])
 
     def test_transformed(self):
         """Validate that transformed works the same as changing location"""

--- a/tests/test_exporters3d.py
+++ b/tests/test_exporters3d.py
@@ -472,13 +472,15 @@ class TestTessellateWithUVs(DirectApiTestCase):
             def __getattr__(self, name):
                 return getattr(self.wrapped, name)
 
+        box = Box(1, 1, 1)
+        box.mesh(0.1)
         with patch(
             "build123d.topology.shape_core.BRep_Tool.Triangulation_s",
             side_effect=lambda face, location: NoUVTriangulation(
                 triangulation(face, location)
             ),
         ):
-            _, _, _, uvs = Box(1, 1, 1).tessellate_with_uvs(0.1, atlas_packing=False)
+            _, _, _, uvs = box.tessellate_with_uvs(0.1, atlas_packing=False)
 
         self.assertTrue(uvs)
         self.assertTrue(all(uv == (0.0, 0.0) for uv in uvs))


### PR DESCRIPTION
I have a usecase where I need to control tessellation tolerances in absolute length units and refine existing meshes. I found that tightening `angular_tolerance` could return the same coarse mesh, even though meshing a fresh copy at that tolerance produced many more triangles. Currently, build123d always uses relative linear deflection, and both its cache check and OCCT's can reuse an existing mesh without checking whether the requested angular tolerance is tighter

This change checks the stored angular deflection before reusing a mesh, clearing the cached polygons when the recorded angle is insufficient or unavailable. OCCT still handles linear refinement.

This also adds keyword-only `relative=False` to `Shape.mesh`, `tessellate`, and `tessellate_with_uvs`, allowing linear deflection to be specified in model length units. I kept relative deflection as the the default.

Added a few quick tests too.