### PR TITLE
Add first and last properties to GroupBy

### DIFF
--- a/docs/topology_selection.rst
+++ b/docs/topology_selection.rst
@@ -185,7 +185,13 @@ Rather than returning a |ShapeList|, |group_by| returns a ``GroupBy``, a list of
 |ShapeList| objects sorted by the grouping criteria. ``GroupBy`` can be printed to view
 the members of each group, indexed like a list to retrieve a |ShapeList|, and accessed
 by key with the ``group`` method. If the group keys are unknown they can be discovered
-with ``key_to_group_index``.
+with ``key_to_group_index``. The ``first`` and ``last`` properties return the first
+and last |ShapeList| groups, respectively, so selectors can be chained directly::
+
+    part.faces().group_by(SortBy.AREA).first.edges()
+
+These properties follow the group order, including when ``reverse=True`` is passed
+to |group_by|, and raise ``IndexError`` if there are no groups.
 
 If we want only the edges from the smallest faces by area we can get the faces, then
 group by ``SortBy.AREA``. The |ShapeList| of smallest faces is available from the first

--- a/src/build123d/topology/shape_core.py
+++ b/src/build123d/topology/shape_core.py
@@ -3020,6 +3020,18 @@ class GroupBy(Generic[T, K]):
             self.groups.append(ShapeList(shapegroup))
             self.key_to_group_index.append((key, i))
 
+    # ---- Properties ----
+
+    @property
+    def first(self) -> ShapeList[T]:
+        """First group. Raises IndexError if there are no groups."""
+        return self[0]
+
+    @property
+    def last(self) -> ShapeList[T]:
+        """Last group. Raises IndexError if there are no groups."""
+        return self[-1]
+
     # ---- Instance Methods ----
 
     def __getitem__(self, key: int):

--- a/tests/test_direct_api/test_group_by.py
+++ b/tests/test_direct_api/test_group_by.py
@@ -31,7 +31,7 @@ import unittest
 
 from build123d import Cylinder
 from build123d.geometry import Axis
-from build123d.topology import Edge, Shape, Solid
+from build123d.topology import Edge, Shape, ShapeList, Solid
 from build123d.objects_curve import CenterArc
 
 
@@ -40,6 +40,33 @@ class TestGroupBy(unittest.TestCase):
     def setUp(self):
         # Ensure the class variable is in its default state before each test
         self.v = Solid.make_box(1, 1, 1).vertices().group_by(Axis.Z)
+
+    def test_first_last(self):
+        for reverse in (False, True):
+            with self.subTest(reverse=reverse):
+                grouped = (
+                    Solid.make_box(1, 1, 2).vertices().group_by(Axis.Z, reverse=reverse)
+                )
+                self.assertIs(grouped.first, grouped[0])
+                self.assertIs(grouped.last, grouped[-1])
+                self.assertEqual(
+                    grouped.first.sort_by(Axis.X).first.Z, 2 if reverse else 0
+                )
+                self.assertEqual(
+                    grouped.last.sort_by(Axis.X).last.Z, 0 if reverse else 2
+                )
+
+    def test_first_last_single_group(self):
+        grouped = Solid.make_box(1, 1, 1).edges().group_by(Edge.length)
+        self.assertIs(grouped.first, grouped.last)
+        self.assertEqual(len(grouped.first), 12)
+
+    def test_first_last_empty(self):
+        grouped = ShapeList().group_by(Axis.Z)
+        with self.assertRaises(IndexError):
+            _ = grouped.first
+        with self.assertRaises(IndexError):
+            _ = grouped.last
 
     def test_str(self):
         self.assertEqual(


### PR DESCRIPTION
`GroupBy.first` and `GroupBy.last` now return the existing first and last `ShapeList` groups, allowing selectors to continue directly after `group_by()`. This fixes the missing-attribute error in #1102 without changing grouping, indexing, or ordering. Empty results raise `IndexError`, consistent with `ShapeList.first` and `.last`.

The implementation adds only two typed properties. Regression tests cover ascending/reversed groups, chained selectors, single groups, and empty results; the selection guide documents the new properties. Risk is low: this is an additive convenience API with no geometry or sorting changes.

Validation on upstream `dev` at `5b1b4b5da481a7b0140cb71d32b7fa93fe8032ce`, using Python 3.11 and OCP 7.9.3.1.1:

- Before the implementation, the new regressions fail with `AttributeError` for the missing properties.
- `pytest tests/test_direct_api/test_group_by.py tests/test_direct_api/test_shape_list.py -q --benchmark-disable`: 66 passed, 2 subtests passed.
- `pytest --benchmark-disable --cov --cov-report=xml -q`: 2,466 passed, 2 skipped; 97.48% total coverage.
- `diff-cover coverage.xml --config-file pyproject.toml --compare-branch=origin/dev`: 100% patch coverage.
- `pytest -n auto --dist loadscope --benchmark-disable -q`: 2,466 passed, 2 skipped. Class-based scheduling keeps the existing file-based test fixtures together.
- Repository mypy check: 43 source files passed. Pylint: 10.00/10. Black and `git diff --check`: passed.
- Sphinx HTML documentation build: passed (existing docstring-formatting and unavailable Graphviz warnings).

Cross-platform CI and maintainer review remain pending.

Fixes #1102.
