### PR TITLE
Support local two-tuples in Plane.shift_origin

### DIFF
--- a/src/build123d/geometry.py
+++ b/src/build123d/geometry.py
@@ -3276,12 +3276,14 @@ class Plane(metaclass=PlaneMeta):
     def shift_origin(self, locator: Axis | VectorLike | Vertex) -> Plane:
         """shift plane origin
 
-        Creates a new plane with the origin moved within the plane to the point of intersection
-        of the axis or at the given Vertex. The plane's x_dir and z_dir are unchanged.
+        Creates a new plane with the origin moved within the plane to the given point
+        or the intersection with an axis. The plane's x_dir and z_dir are unchanged.
 
         Args:
-            locator (Axis | VectorLike | Vertex): Either Axis that intersects the new
-                plane origin or Vertex within Plane.
+            locator (Axis | VectorLike | Vertex): A two-tuple specifies local x and y
+                coordinates relative to this plane's origin. A three-tuple, Vector, or
+                Vertex specifies a global point within the plane. An Axis specifies its
+                intersection with the plane.
 
         Raises:
             ValueError: Vertex isn't within plane
@@ -3297,6 +3299,8 @@ class Plane(metaclass=PlaneMeta):
             new_origin = Vector(geom_point.X(), geom_point.Y(), geom_point.Z())
             if not self.contains(new_origin):
                 raise ValueError(f"{locator} is not located within plane")
+        elif isinstance(locator, tuple) and len(locator) == 2:
+            new_origin = self.from_local_coords(locator)
         elif isinstance(locator, (tuple, Vector)):
             new_origin = Vector(locator)
             if not self.contains(locator):

--- a/tests/test_direct_api/test_plane.py
+++ b/tests/test_direct_api/test_plane.py
@@ -519,6 +519,36 @@ class TestPlane(unittest.TestCase):
             extrude(amount=-1, mode=Mode.SUBTRACT)
         self.assertAlmostEqual(p.part.volume, b.volume - 2**2 * 1, 5)
 
+    def test_shift_origin_local_tuple(self):
+        plane = Plane((10, 20, 30), x_dir=(0, 1, 0), z_dir=(1, 0, 0))
+        for point, expected in (
+            ((0, 0), (10, 20, 30)),
+            ((1, 2), (10, 21, 32)),
+            ((-2, 3), (10, 18, 33)),
+        ):
+            with self.subTest(point=point):
+                shifted = plane.shift_origin(point)
+                self.assertEqual(shifted.origin, Vector(expected))
+                self.assertEqual(shifted.x_dir, plane.x_dir)
+                self.assertEqual(shifted.z_dir, plane.z_dir)
+        self.assertEqual(plane.origin, Vector(10, 20, 30))
+
+    def test_shift_origin_local_tuple_isometric(self):
+        plane = Plane.isometric.offset(10)
+        shifted = plane.shift_origin((1, 2))
+        self.assertEqual(shifted.origin, plane.origin + plane.x_dir + 2 * plane.y_dir)
+        self.assertEqual(shifted.x_dir, plane.x_dir)
+        self.assertEqual(shifted.z_dir, plane.z_dir)
+
+    def test_shift_origin_global_points(self):
+        plane = Plane((10, 20, 30), x_dir=(0, 1, 0), z_dir=(1, 0, 0))
+        for point in ((10, 1, 2), Vector(10, 1, 2)):
+            with self.subTest(point=point):
+                self.assertEqual(plane.shift_origin(point).origin, Vector(10, 1, 2))
+        for point in ((1, 2, 0), Vector(1, 2)):
+            with self.subTest(point=point), self.assertRaises(ValueError):
+                plane.shift_origin(point)
+
     def test_shift_origin_error(self):
         with self.assertRaises(ValueError):
             Plane.XY.shift_origin(Vertex(1, 1, 1))


### PR DESCRIPTION
`Plane.isometric.offset(10).shift_origin((1, 2))` now places the new origin one unit along the plane's local x direction and two along local y. Previously, the tuple was interpreted as a global XY point and rejected as outside the plane.

The implementation adds one branch using the existing `from_local_coords()` conversion. Three-tuples, `Vector`, and `Vertex` remain global points; `Axis` still supplies the plane intersection. Plane orientation and existing off-plane validation are preserved. The API documentation now states the coordinate convention explicitly.

Risk is medium-low: two-tuples intentionally change from global to local coordinates, as requested in #1049. Callers requiring global coordinates can continue to use a three-tuple or `Vector`. There are no tolerance, dependency, or general geometry changes.

Validation on upstream `dev` at `5b1b4b5da481a7b0140cb71d32b7fa93fe8032ce`, using Python 3.11 and OCP 7.9.3.1.1:

- New local-coordinate regressions fail before the implementation with `ValueError`, including the reported isometric example and zero/negative coordinates on a translated, rotated plane.
- `pytest tests/test_direct_api/test_plane.py -q --benchmark-disable`: 48 passed, 9 subtests passed. Includes global-coordinate compatibility and existing Axis/Vertex/error cases.
- `pytest --benchmark-disable --cov --cov-report=xml -q`: 2,466 passed, 2 skipped, 117 subtests passed; 97.47% total coverage.
- `diff-cover coverage.xml --config-file pyproject.toml --compare-branch=origin/dev`: 100% patch coverage.
- `pytest -n auto --dist loadscope --benchmark-disable -q`: 2,466 passed, 2 skipped, 117 subtests passed. Class-based scheduling keeps existing file-based test fixtures together.
- Repository mypy check: 43 source files passed. Pylint: 10.00/10. Black and `git diff --check`: passed.
- Sphinx HTML documentation build: passed with existing docstring-formatting and unavailable Graphviz warnings.

Cross-platform CI and maintainer review remain pending.

Fixes #1049.
