### PR TITLE
Expose resolved label text on dimension annotations

### DIFF
--- a/src/build123d/drafting.py
+++ b/src/build123d/drafting.py
@@ -340,6 +340,10 @@ class DimensionLine(BaseSketchObject):
     Type 2) The text fit within the path and the arrows go outside
     Type 3) Neither the text nor the arrows fit within the path
 
+    Attributes:
+        label_str (str): Resolved text used to create the label. Changing this
+            attribute does not rebuild the geometry.
+
     Args:
         path (PathDescriptor): a very general type of input used to describe the path the
             dimension line will follow.
@@ -392,6 +396,7 @@ class DimensionLine(BaseSketchObject):
 
         # Generate the label
         label_str = draft._label_to_str(label, path_obj, label_angle, tolerance)
+        self.label_str: str = label_str
         label_shape = Text(
             txt=label_str,
             font_size=draft.font_size,
@@ -501,6 +506,10 @@ class ExtensionLine(BaseSketchObject):
     Create a dimension line with two lines extending outward from the part to dimension.
     Typically used for (but not restricted to) outside dimensions, with a pair of lines
     extending from the edge of a part to a dimension line.
+
+    Attributes:
+        label_str (str): Resolved text used to create the label. Changing this
+            attribute does not rebuild the geometry.
 
     Args:
         border (PathDescriptor): a very general type of input defining the object to
@@ -690,6 +699,7 @@ class ExtensionLine(BaseSketchObject):
             mode=Mode.PRIVATE,
         )
         self.dimension = d_line.dimension  #: length of the dimension
+        self.label_str: str = d_line.label_str
 
         e_line_sketch = Sketch(children=e_lines + d_line.faces())
 

--- a/tests/test_drafting.py
+++ b/tests/test_drafting.py
@@ -194,6 +194,7 @@ class DimensionLineTestCase(unittest.TestCase):
         bbox = d_line.bounding_box()
         self.assertAlmostEqual(bbox.max.X, 100, 5)
         self.assertAlmostEqual(d_line.dimension, 100, 5)
+        self.assertEqual(d_line.label_str, "100.00mm")
         self.assertEqual(len(d_line.faces()), 10)
 
     def test_three_points(self):
@@ -216,9 +217,15 @@ class DimensionLineTestCase(unittest.TestCase):
 
     def test_label(self):
         d_line = DimensionLine([(0, 0, 0), (100, 0, 0)], label="Test", draft=metric)
+        self.assertEqual(d_line.label_str, "Test")
         bbox = d_line.bounding_box()
         self.assertAlmostEqual(bbox.max.X, 100, 5)
         self.assertEqual(len(d_line.faces()), 6)
+
+    def test_label_with_tolerance(self):
+        d_line = DimensionLine([(0, 0), (30, 0)], draft=metric, tolerance=(0.1, 0.2))
+        self.assertEqual(d_line.label_str, "30.00 +0.10 -0.20mm")
+        self.assertAlmostEqual(d_line.dimension, 30)
 
     def test_face(self):
         with self.assertRaises(ValueError):
@@ -313,6 +320,17 @@ class DimensionLineTestCase(unittest.TestCase):
 
 
 class ExtensionLineTestCase(unittest.TestCase):
+    def test_custom_numeric_label(self):
+        e_line = ExtensionLine([(0, 0), (30, 0)], offset=10, draft=metric, label="99")
+        self.assertEqual(e_line.label_str, "99")
+        self.assertAlmostEqual(e_line.dimension, 30)
+
+    def test_curved_label_uses_border_length(self):
+        border = Edge.make_circle(100, start_angle=0, end_angle=90)
+        e_line = ExtensionLine(border, offset=10, draft=metric)
+        self.assertEqual(e_line.label_str, "157.08mm")
+        self.assertNotAlmostEqual(e_line.dimension, border.length)
+
     def test_min_x(self):
         shape, outer, inner = create_test_sketch()
         e_line = ExtensionLine(
@@ -369,6 +387,7 @@ class ExtensionLineTestCase(unittest.TestCase):
             ext.center(CenterOf.BOUNDING_BOX).Y,
         )
         self.assertEqual(ext.dimension, 100)
+        self.assertEqual(ext.label_str, "100.00mm")
 
     def test_vertical_projection_with_dim_inside_shape(self):
         diagonal_line = Edge.make_line((100, 100), (200, 200))


### PR DESCRIPTION
`DimensionLine` and `ExtensionLine` now expose `label_str`, the resolved text used to create their label. Downstream tools can inspect custom text, units, and tolerances directly, including a 30 mm dimension deliberately labeled `"99"`.

Each class stores one explicitly typed attribute. `DimensionLine` retains the string passed to `Text`; `ExtensionLine` retains its nested dimension line's resolved string. This also preserves the original border measurement for curved extension lines, where the offset dimension path can have a different length. Class documentation explains that assigning to this attribute does not rebuild the geometry.

Risk is low: the change adds two fields to the existing annotation classes and preserves label formatting, measurements, and geometry. Regression coverage includes custom numeric labels, tolerances, projected dimensions, and curved borders.

Validation on upstream `dev` at `5b1b4b5da481a7b0140cb71d32b7fa93fe8032ce`, using Python 3.11 and OCP 7.9.3.1.1:

- Before implementation, six regression cases fail with `AttributeError` for the missing `label_str` attribute.
- `pytest tests/test_drafting.py -q --benchmark-disable`: 45 passed.
- `pytest --benchmark-disable --cov --cov-report=xml -q`: 2,466 passed, 2 skipped, 110 subtests passed; 97.48% total coverage.
- `diff-cover coverage.xml --config-file pyproject.toml --compare-branch=origin/dev`: 100% patch coverage.
- `pytest -n auto --dist loadscope --benchmark-disable -q`: 2,466 passed, 2 skipped, 110 subtests passed. Class-based scheduling keeps existing file-based test fixtures together.
- Repository mypy check: 43 source files passed. Pylint: 10.00/10. `git diff --check`: passed.
- Black: full test file and changed source ranges passed. An unrelated existing line-wrapping difference in `drafting.py` was reproduced on unmodified upstream and left outside this patch.
- Sphinx HTML documentation build: passed with existing docstring-formatting and unavailable Graphviz warnings; both new attribute descriptions appear in the generated API documentation.

Cross-platform CI and maintainer review remain pending.

Fixes #1315.
